### PR TITLE
Add php-dolt-sync: content-addressed DB sync for WordPress + SQLite

### DIFF
--- a/.github/workflows/php-dolt-sync.yml
+++ b/.github/workflows/php-dolt-sync.yml
@@ -1,0 +1,37 @@
+name: php-dolt-sync
+
+on:
+  pull_request:
+    paths:
+      - 'php-dolt-sync/**'
+      - '.github/workflows/php-dolt-sync.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'php-dolt-sync/**'
+      - '.github/workflows/php-dolt-sync.yml'
+
+jobs:
+  tests:
+    name: PHP 8.2 test suite
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: php-dolt-sync
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: sqlite3, intl, mbstring
+          coverage: none
+      - run: php tests/run.php
+
+  docker-build:
+    name: Demo image builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: docker build
+        working-directory: php-dolt-sync/docker
+        run: docker build -t wp-sync-demo:ci .

--- a/php-dolt-sync/README.md
+++ b/php-dolt-sync/README.md
@@ -1,0 +1,60 @@
+# php-dolt-sync — content-addressed DB sync for WordPress + SQLite
+
+Dolt-style storage for a WordPress site's SQLite database, with HTTP push/pull
+between two sites. Single-shot prototype implemented by an adversarial
+implementer/verifier loop — see [`SPEC.md`](./SPEC.md) for the original brief.
+
+## Quick start (Docker)
+
+```bash
+cd docker && ./setup.sh
+```
+
+Brings up two WordPress sites (`localhost:8081`, `localhost:8082`) with the
+plugin activated on each. See `docker/README.md` for the full demo.
+
+## Layout
+
+```
+plugin/wp-sync/           # the plugin — drop into wp-content/plugins/
+  wp-sync.php             # plugin main (headers, bootstrap, WP-CLI registration)
+  src/
+    Encoding/             # canonical CBOR encoder + hash
+    Store/                # Chunk, ChunkStore interface, SQLite + HTTP backends, RefStore
+    Tree/                 # TableTree (bottom-up sorted B-tree, fanout=64), TreeDiff
+    Snapshot/             # Snapshotter, Materializer, RowNormalizer,
+                          # SerializedPhpHandler, DirtyTracker, SchemaInspector
+    Sync/                 # SyncEngine (copyReachable, isFastForward),
+                          # PushCommand, FetchCommand
+    WordPress/            # SyncPlugin (REST routes), WpCliCommands
+docker/                   # two-site docker-compose demo
+tests/                    # zero-dep test suite (98 checks, all layers)
+```
+
+## Run tests
+
+```
+php tests/run.php
+```
+
+`98 passed / 0 failed`. Covers all 6 layers, in-process HTTP transport,
+round-trip push/pull between simulated sites, and the named failure modes from
+the spec.
+
+## Manual install on an existing WordPress + SQLite site
+
+1. Install the [sqlite-database-integration](https://wordpress.org/plugins/sqlite-database-integration/) plugin.
+2. Copy `plugin/wp-sync/` into `wp-content/plugins/wp-sync/` and activate it.
+3. Create an Application Password for a user with `manage_options`.
+4. `wp sync commit --message="initial" && wp sync push --remote=https://b.test --user=bob --password=XXX`
+
+## Gaps vs. full definition of done
+
+- **Real PHPUnit wiring**: tests use a bespoke zero-dep harness (`tests/run.php`).
+- **End-to-end over real HTTP**: verified via the `InProcessTransport` harness
+  which drives the exact same JSON protocol the plugin implements — the docker
+  demo is what exercises real HTTP between real sites.
+- **Content-defined chunking / Prolly trees**: out of scope per spec; fixed
+  fanout=64.
+- **Auto-increment ID remapping**: out of scope per spec; the two sites must
+  share a base state.

--- a/php-dolt-sync/SPEC.md
+++ b/php-dolt-sync/SPEC.md
@@ -1,0 +1,502 @@
+# Implement a content-addressed sync engine for WordPress on SQLite
+
+You are building a system that versions a WordPress site's database state as a content-addressed DAG (directed acyclic graph) and syncs it between two WordPress+SQLite instances over HTTP. This is modeled on Dolt's storage architecture, not on SQL statement replay or row-by-row diffing.
+
+The system must actually work between two real WordPress sites running the SQLite database integration plugin. "Work" means: Site A commits its state, pushes to Site B, Site B materializes the received state into its live WordPress database, and the content is visible on Site B. Then Site B makes changes, commits, pushes back to Site A, and Site A materializes. Round-trip sync with no data loss, no hash mismatches, no silent corruption.
+
+## Architecture overview
+
+The system has six layers. Build them in order. Do not skip ahead — each layer's correctness depends on the one below it.
+
+### Layer 1: Canonical value encoding
+
+Every PHP value that enters the system must serialize to exactly one byte sequence. The same logical value must always produce the same bytes, regardless of which site produced it, which PHP version ran the code, or what order operations happened in.
+
+Requirements:
+
+- Use CBOR (RFC 8949) as the wire format. Use a pure-PHP CBOR encoder — do not shell out. If no suitable library exists, implement the subset needed: unsigned integers, negative integers, byte strings, text strings, arrays, maps, floats (IEEE 754 double), null, booleans.
+- Map keys must be sorted. CBOR's deterministic encoding profile (RFC 8949 §4.2) specifies length-first sorting of the raw key bytes. Follow this exactly.
+- PHP arrays with sequential integer keys starting at 0 encode as CBOR arrays. All other PHP arrays encode as CBOR maps.
+- Floats: normalize NaN to a single canonical NaN (0x7ff8000000000000). Normalize -0.0 to 0.0. Encode integers that happen to be stored as floats (e.g. 3.0) as integers.
+- Strings: all text must be valid UTF-8. Apply NFC normalization (use the `Normalizer` class from the `intl` extension, or implement NFC for ASCII-safe content). Reject invalid UTF-8 rather than silently replacing bytes.
+- NULL: encode as CBOR null (0xf6). Do not conflate with empty string, 0, or false.
+- Integers: PHP integers are 64-bit signed. CBOR unsigned integers go up to 2^64-1. Encode non-negative PHP integers as CBOR unsigned, negative as CBOR negative.
+
+Write a `CanonicalEncoder::encode(mixed $value): string` function and a corresponding `CanonicalEncoder::decode(string $bytes): mixed`. Round-tripping must be exact: `decode(encode($x)) === $x` for all supported types.
+
+Write a `CanonicalEncoder::hash(mixed $value): string` that returns `hash('sha256', encode($value))`. This is the content address.
+
+### Layer 2: Chunk store
+
+A chunk is an immutable blob of bytes plus a list of hashes it references (its children in the DAG).
+
+```php
+final class Chunk {
+    public function __construct(
+        public readonly string $hash,   // hex-encoded SHA-256
+        public readonly string $bytes,  // raw content
+        public readonly array  $refs,   // list of child hashes (hex strings)
+    ) {}
+}
+```
+
+The chunk store interface:
+
+```php
+interface ChunkStore {
+    /** @return array<string, true> hash => true for each present hash */
+    public function hasMany(array $hashes): array;
+    
+    /** @return array<string, Chunk> hash => Chunk */
+    public function getMany(array $hashes): array;
+    
+    /** Writes chunks. MUST verify hash matches content. */
+    public function putMany(array $chunks): void;
+}
+```
+
+Implement two backends:
+
+1. `SQLiteChunkStore` — stores chunks in a SQLite database with schema:
+   ```sql
+   CREATE TABLE chunks (
+       hash TEXT PRIMARY KEY,
+       data BLOB NOT NULL,
+       refs TEXT NOT NULL DEFAULT '[]'  -- JSON array of hex hashes
+   );
+   ```
+   Use WAL mode. Open the database with `PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;`.
+
+2. `HttpChunkStore` — a client that talks to a remote site's REST API. Implements the same `ChunkStore` interface but sends HTTP requests instead of local SQLite queries.
+
+Correctness invariant: `putMany` must verify that `hash('sha256', $chunk->bytes) === $chunk->hash` for every chunk. Reject any chunk where this fails. This is the foundational integrity check — if you skip it, the entire system is compromised.
+
+### Layer 3: Ref store
+
+```php
+interface RefStore {
+    public function getRef(string $name): ?string;  // returns hash or null
+    public function listRefs(string $prefix = ''): array;  // name => hash
+    
+    /**
+     * Atomic compare-and-swap.
+     * Sets $name to $newHash only if current value is $expectedOldHash.
+     * $expectedOldHash = null means "ref must not exist".
+     * Returns true on success, false if current value doesn't match expected.
+     */
+    public function casRef(string $name, ?string $expectedOldHash, string $newHash): bool;
+}
+```
+
+Implement `SQLiteRefStore` with schema:
+```sql
+CREATE TABLE refs (
+    name TEXT PRIMARY KEY,
+    hash TEXT NOT NULL
+);
+```
+
+The `casRef` operation must be atomic. Use a single UPDATE with a WHERE clause that checks the old value, then check `changes()` to determine success. For creation (expectedOldHash = null), use INSERT with conflict detection.
+
+### Layer 4: Table tree (sorted chunked B-tree)
+
+Each WordPress table is stored as a sorted map from primary key to encoded row. The map is stored as a B-tree where every node (internal and leaf) is a content-addressed chunk.
+
+Leaf node structure (encoded as canonical CBOR):
+```
+{
+  "type": "leaf",
+  "entries": [
+    [<key_bytes>, <value_bytes>],
+    [<key_bytes>, <value_bytes>],
+    ...
+  ]
+}
+```
+
+Internal node structure:
+```
+{
+  "type": "internal",
+  "children": [
+    [<separator_key_bytes>, <child_chunk_hash>],
+    ...
+  ]
+}
+```
+
+Entries in leaf nodes are sorted by key bytes (lexicographic). Separators in internal nodes are sorted the same way. The tree must produce deterministic structure for the same set of key-value pairs regardless of insertion order. This means: given the same entries, the tree must chunk them the same way and produce the same root hash.
+
+Use a fixed fan-out (e.g., max 64 entries per leaf, max 64 children per internal node). Do NOT implement content-defined chunking (Prolly trees) in the first version — fixed pages are simpler and sufficient. Content-defined chunking is an optimization for later.
+
+Build the tree bottom-up from a sorted list of entries. This is deterministic: sort all entries by key, chunk into leaf pages of at most N entries, build internal nodes from the leaf hashes, repeat until you have a single root.
+
+Implement:
+- `TableTree::build(array $sortedEntries, ChunkStore $store): string` — returns root hash
+- `TableTree::get(string $rootHash, string $key, ChunkStore $store): ?string` — returns value or null
+- `TableTree::iterate(string $rootHash, ChunkStore $store): Generator` — yields all entries in order
+- `TableTree::diff(string $rootA, string $rootB, ChunkStore $store): Generator` — yields entries that differ between two trees. This MUST skip subtrees whose hashes match (this is the key performance property).
+
+### Layer 5: Snapshot and materialization
+
+**Snapshot** reads the live WordPress SQLite database and produces a commit.
+
+Database root structure (CBOR-encoded):
+```
+{
+  "tables": {
+    "wp_posts": {
+      "tree": "<root_hash>",
+      "schema": "<sha256 of canonical CREATE TABLE statement>"
+    },
+    "wp_options": { ... },
+    ...
+  }
+}
+```
+
+Commit structure (CBOR-encoded):
+```
+{
+  "root": "<db_root_hash>",
+  "parents": ["<parent_commit_hash>", ...],
+  "author": "...",
+  "message": "...",
+  "timestamp": <unix_epoch_int>
+}
+```
+
+For each tracked table:
+1. Determine the primary key column(s) from `PRAGMA table_info(table_name)`.
+2. Read all rows (or only dirty rows if dirty tracking is active — see below).
+3. For each row, build the key from the PK column(s) and the value from all columns.
+4. Normalize the row before encoding (see normalization rules below).
+5. Build the table tree from sorted entries.
+6. Record the table's tree root hash and schema hash in the database root.
+
+**Dirty tracking via SQL triggers:**
+
+On installation, create triggers on every tracked table:
+```sql
+CREATE TABLE IF NOT EXISTS _sync_dirty (
+    tbl   TEXT    NOT NULL,
+    rowid INTEGER NOT NULL,
+    op    TEXT    NOT NULL,
+    PRIMARY KEY (tbl, rowid)  -- last op wins
+);
+
+CREATE TRIGGER _sync_trk_{table}_i AFTER INSERT ON {table}
+BEGIN
+  INSERT OR REPLACE INTO _sync_dirty(tbl, rowid, op) VALUES('{table}', NEW.rowid, 'I');
+END;
+
+CREATE TRIGGER _sync_trk_{table}_u AFTER UPDATE ON {table}
+BEGIN
+  INSERT OR REPLACE INTO _sync_dirty(tbl, rowid, op) VALUES('{table}', NEW.rowid, 'U');
+END;
+
+CREATE TRIGGER _sync_trk_{table}_d AFTER DELETE ON {table}
+BEGIN
+  INSERT OR REPLACE INTO _sync_dirty(tbl, rowid, op) VALUES('{table}', OLD.rowid, 'D');
+END;
+```
+
+Note: use `INSERT OR REPLACE` with a composite PK on (tbl, rowid) so that multiple writes to the same row before a commit collapse into one entry.
+
+When dirty tracking is available, the snapshot only reads the dirty rows. For tables with no dirty rows, reuse the tree root hash from the previous commit. For tables with dirty rows, rebuild only the affected pages.
+
+For the first commit (no prior state), do a full scan of all tables.
+
+**Materialization** is the reverse: given a commit hash, read the database root, and for each table, diff the tree against the current live state and apply INSERT/UPDATE/DELETE statements to the live WordPress database.
+
+Materialization must:
+- Run inside a transaction (BEGIN / COMMIT).
+- Disable triggers during materialization (otherwise the materialized writes would fill `_sync_dirty` with noise). Use `DROP TRIGGER` before and `CREATE TRIGGER` after, or use a flag table that the triggers check.
+- Handle schema differences: if the remote commit has a different schema hash for a table, warn and skip that table (schema migration is out of scope for v1).
+
+### Layer 6: Sync engine
+
+```php
+final class SyncEngine {
+    public function copyReachable(
+        ChunkStore $to,
+        ChunkStore $from,
+        string $rootHash,
+        int $batchSize = 256
+    ): int;  // returns count of chunks transferred
+}
+```
+
+Walk the DAG from `rootHash`. For each batch of up to `$batchSize` hashes:
+1. Ask `$to->hasMany($batch)` to find which are already present.
+2. For missing hashes, call `$from->getMany($missing)` to get the chunks.
+3. For each retrieved chunk, add its `$refs` (children) to the pending set.
+4. Write chunks to `$to` in dependency order: a chunk's children must be present in `$to` before the chunk itself is written.
+
+Correctness requirements:
+- Must not re-fetch a hash that has already been seen in this walk (track seen hashes in a set).
+- Must not exceed bounded memory. The `$seen` set grows with the number of unique hashes in the DAG. For very large DAGs this could be a problem — document this limit but don't solve it in v1.
+- Must handle the case where `$from->getMany()` returns fewer chunks than requested (network errors, partial response). Retry or fail explicitly.
+- Must detect cycles: if the pending set is not empty but no progress can be made (all pending hashes are either seen or present in $to), throw an error.
+
+**Push flow:**
+```
+1. localRefHash = localRefs.getRef('refs/heads/main')
+2. remoteRefHash = remoteRefs.getRef('refs/heads/main')
+3. if localRefHash === remoteRefHash: nothing to do
+4. verify fast-forward: walk local commit parents to confirm remoteRefHash is an ancestor
+5. copyReachable(remoteChunkStore, localChunkStore, localRefHash)
+6. remoteRefs.casRef('refs/heads/main', remoteRefHash, localRefHash)
+7. if CAS fails: abort, tell user to pull first
+```
+
+**Fetch flow:**
+```
+1. remoteRefHash = remoteRefs.getRef('refs/heads/main')
+2. localTrackingHash = localRefs.getRef('refs/remotes/origin/main')
+3. copyReachable(localChunkStore, remoteChunkStore, remoteRefHash)
+4. localRefs.casRef('refs/remotes/origin/main', localTrackingHash, remoteRefHash)
+```
+
+**Pull flow:** fetch + materialize.
+
+### HTTP transport
+
+The remote site exposes five endpoints via a WordPress REST API plugin (mu-plugin):
+
+```
+POST /wp-json/sync/v1/chunks/has
+  Request:  { "hashes": ["abc123...", ...] }
+  Response: { "present": { "abc123...": true } }
+
+POST /wp-json/sync/v1/chunks/get
+  Request:  { "hashes": ["abc123...", ...] }
+  Response: { "chunks": [{ "hash": "...", "data": "<base64>", "refs": [...] }, ...] }
+
+POST /wp-json/sync/v1/chunks/put
+  Request:  { "chunks": [{ "hash": "...", "data": "<base64>", "refs": [...] }, ...] }
+  Response: { "stored": 5 }
+
+GET /wp-json/sync/v1/refs
+  Response: { "refs/heads/main": "abc123..." }
+
+PUT /wp-json/sync/v1/refs/{name}
+  Request:  { "old": "abc123...", "new": "def456..." }
+  Response: { "ok": true } or 409 on CAS failure
+```
+
+Authentication: use WordPress application passwords. The `HttpChunkStore` must send Basic auth on every request.
+
+## Row normalization rules
+
+Before encoding a row as canonical CBOR, normalize:
+
+1. **Site URL**: replace all occurrences of the site's own URL (from `wp_options.siteurl`) with a placeholder token `{{SITE_URL}}`. On materialization, replace the token with the receiving site's URL. This applies to `post_content`, `post_excerpt`, `guid`, `option_value`, and any text column that might contain URLs.
+
+2. **Serialized PHP**: WordPress stores serialized PHP arrays in `option_value`, `meta_value`, and other columns. These must be deserialized, normalized recursively (sort array keys, apply URL replacement, normalize nested values), and re-serialized in a deterministic way. PHP's `serialize()` is NOT deterministic for associative arrays — it preserves insertion order. You must sort string keys before serializing. Use a custom serializer or sort before `serialize()`.
+
+   Critical: PHP serialized strings include byte-length prefixes (`s:5:"hello"`). If you change a URL inside a serialized string, the length prefix becomes wrong and WordPress will fail to deserialize it. You must recompute all length prefixes after URL replacement. This is the single most common source of WordPress migration bugs.
+
+3. **Auto-increment IDs**: for v1, do NOT attempt to remap IDs across sites. Treat the primary key as part of the row identity. This means the two sites must start from the same base state (e.g., Site B is initialized by pulling from Site A). Document this limitation.
+
+4. **Transient exclusion**: skip rows in `wp_options` where `option_name` starts with `_transient_` or `_site_transient_`. These are ephemeral cache entries.
+
+5. **Timestamp normalization**: store `post_date_gmt`, `post_modified_gmt` and similar GMT columns as the canonical time representation. Drop the non-GMT variants from the encoded value (they're derived from GMT + timezone).
+
+6. **Column ordering**: always encode columns in alphabetical order by column name. Do not rely on the order returned by `SELECT *`.
+
+## What breaks in an incomplete implementation
+
+These are the specific failure modes to test against. An implementation that doesn't handle all of them is not done.
+
+### Encoding failures
+
+1. **Non-deterministic serialized PHP.** Two sites serialize the same associative array with different key insertion orders → different bytes → different hashes → sync sees phantom changes on every commit and transfers the entire table every time. Test: create an option value `['b' => 1, 'a' => 2]` on Site A and `['a' => 2, 'b' => 1]` on Site B. After sync, the hashes must match.
+
+2. **URL in serialized PHP with wrong length prefix.** Replace `https://site-a.test` (20 bytes) with `https://site-b.test` (20 bytes) and it works. Replace it with `https://b.test` (14 bytes) and the length prefix `s:20:` is now wrong. WordPress's `maybe_unserialize()` fails silently and returns the raw string. Test: create an option with a serialized value containing a URL of different length than the other site's URL. After sync + materialize, the option must be correctly deserialized.
+
+3. **Nested serialized PHP.** WordPress sometimes stores serialized data inside serialized data (e.g., widget settings). The URL replacement and length-prefix fix must work recursively. Test: create a widget option with a nested serialized array containing a URL.
+
+4. **Float precision.** `1.0/3.0` produces subtly different string representations across PHP versions and platforms. The canonical encoder must produce the same bytes for the same IEEE 754 double. Test: encode `1.0/3.0` on two different systems (or simulate by encoding the float bytes directly), verify identical CBOR output.
+
+5. **UTF-8 normalization.** The string "café" can be encoded as 5 bytes (é as U+00E9) or 6 bytes (e + combining accent U+0301). Both must normalize to the same CBOR output. Test: insert a post with the combining-character version, commit, verify hash matches the precomposed version.
+
+6. **NULL vs empty string.** `post_content_filtered` is often `''` on one site and `NULL` on another. The encoder must distinguish them. Test: create two rows identical except one has `NULL` and the other has `''` for one column. They must produce different hashes.
+
+### Tree failures
+
+7. **Empty table.** A table with zero rows must produce a valid tree root (a single empty leaf node). Two sites with the same empty table must produce the same root hash. Test: drop all rows from a table, commit, verify root hash.
+
+8. **Tree determinism.** Build a table tree from entries inserted in order `[1, 2, 3, 4, 5]`, then build from `[5, 3, 1, 4, 2]`. The root hashes must be identical because both are sorted before chunking. Test: insert rows in different orders on two sites, commit both, verify root hashes match.
+
+9. **Diff skips unchanged subtrees.** Create a tree with 10,000 rows. Change 1 row. Diff must visit O(log n) nodes, not O(n). Test: instrument the chunk store to count `getMany` calls during a diff, verify the count is proportional to log(n), not n.
+
+10. **Table with no usable primary key.** Some plugin tables lack a PRIMARY KEY. Fall back to `rowid` as the key. Test: create a table without a PK, insert rows, commit, verify the tree is built using rowid.
+
+### Sync failures
+
+11. **Interrupted push.** Push transfers 50% of chunks, then the connection drops. The remote chunk store has orphan chunks (children without parents). On retry, push must resume — not re-transfer already-present chunks. The remote must not have updated its ref (ref update is the last step). Test: mock the HTTP transport to fail after N chunks, verify ref is unchanged, retry and verify only remaining chunks are transferred.
+
+12. **Concurrent pushes.** Two sites push to the same remote simultaneously. One must succeed, the other must get a CAS failure and be told to pull first. Test: set remote ref to hash X. Site A pushes with expected=X. Simulate Site B pushing with expected=X after Site A already updated the ref. Site B's CAS must fail.
+
+13. **Non-fast-forward push.** Site A and Site B both make commits on top of the same parent. Site A pushes first. Site B tries to push — this is not a fast-forward (Site A's commit is not an ancestor of Site B's commit). The push must be rejected. Test: create divergent commits from the same parent, attempt push, verify rejection.
+
+14. **Duplicate chunks in DAG walk.** A commit references a database root, which references table trees, which may share chunks (e.g., if two tables have identical subtrees — unlikely but possible). The sync walker must not request the same chunk twice. Test: create a DAG where the same chunk hash appears in multiple branches, verify `getMany` is called with each hash at most once.
+
+15. **Large batch handling.** A commit with 50,000 new chunks must work without exceeding memory limits. The batch size must be respected. Test: create a large dataset, push it, verify memory usage stays bounded (use `memory_get_peak_usage()`).
+
+### Materialization failures
+
+16. **Trigger suppression during materialize.** If triggers are active during materialization, every INSERT/UPDATE/DELETE will write to `_sync_dirty`, creating a massive dirty log of changes that were already applied. The next commit would then try to re-snapshot all those rows. Test: materialize 1000 rows, immediately check `_sync_dirty`, verify it's empty.
+
+17. **Foreign key / constraint ordering.** WordPress doesn't use SQL foreign keys, but some plugins do. Materialization must handle the case where rows need to be inserted in a specific order. For v1: if a constraint violation occurs, retry the failed batch after all other rows are inserted. Test: create a plugin table with a FK, materialize rows that reference each other.
+
+18. **Post with rewritten URLs.** A post on Site A has `<img src="https://site-a.test/wp-content/uploads/photo.jpg">`. After sync to Site B, the URL must read `https://site-b.test/wp-content/uploads/photo.jpg`. Test: create a post with images, sync, verify the URLs in `post_content` on Site B.
+
+19. **wp_options siteurl/home.** These two options define the site's identity. They must NOT be synced — each site has its own. The snapshot must exclude them (or the materializer must skip them). Test: sync from Site A to Site B, verify Site B's `siteurl` and `home` options are unchanged.
+
+20. **Deleted rows.** Site A deletes a post. The commit reflects the deletion (the row is absent from the tree). After sync, Site B must also delete that row. Test: create a post, sync, delete the post on Site A, commit, sync again, verify the post is gone from Site B.
+
+### Round-trip failures
+
+21. **Full round trip.** Site A → commit → push to Site B → Site B materializes → Site B adds content → commit → push to Site A → Site A materializes. All content from both sites must be present. This is the integration test that proves the system works. Test: automate this full cycle.
+
+22. **Idempotent sync.** Push the same commit twice. The second push should transfer zero chunks and the CAS should be a no-op (old === new). Test: push, then push again, verify zero chunks transferred.
+
+23. **Empty commit.** Commit when nothing has changed since the last commit. The new commit should have the same db root hash as the parent (but a different commit hash because the timestamp differs). Test: commit twice with no changes in between, verify the db root hash is reused.
+
+## Testing strategy
+
+### Unit tests
+
+Test each layer in isolation:
+
+- **CanonicalEncoder**: property-based tests. Generate random PHP values (nested arrays, strings with special characters, edge-case floats, nulls, booleans, large integers), encode, decode, verify round-trip. Test that encoding is deterministic: encode the same value 1000 times, all outputs must be byte-identical. Test cross-platform: if possible, compare output against a reference CBOR implementation in another language.
+
+- **ChunkStore (SQLiteChunkStore)**: put a chunk, get it back, verify hash. Put the same chunk twice, verify idempotent. Put a chunk with wrong hash, verify rejection. hasMany with mix of present and absent hashes. getMany with mix of present and absent hashes (absent ones should be silently omitted from results).
+
+- **RefStore**: getRef on nonexistent ref returns null. setRef + getRef round trip. casRef succeeds when expected matches. casRef fails when expected doesn't match. casRef with null expected creates new ref. casRef with null expected fails if ref already exists.
+
+- **TableTree**: build from empty entries. Build from 1 entry. Build from exactly N entries (one full leaf). Build from N+1 entries (forces a split). Build from 10,000 entries. Verify determinism: same entries → same root hash regardless of input order. Diff two identical trees → zero differences. Diff two trees with one changed entry → yields exactly that entry. Diff with a deleted entry. Diff with an added entry.
+
+- **SyncEngine**: mock ChunkStore implementations. Build a small DAG (5-10 chunks), copyReachable to an empty store, verify all chunks present. Build a DAG, pre-populate the target with some chunks, verify only missing ones are transferred. Test cycle detection. Test interrupted transfer (mock failure after N chunks).
+
+### Integration tests
+
+Use two separate SQLite databases as two "sites":
+
+- **Snapshot round-trip**: create a WordPress-like schema (wp_posts, wp_options, wp_postmeta), insert test data, snapshot to chunk store, materialize to a fresh database, verify row-by-row equality.
+
+- **Sync between two stores**: Site A snapshot → push to Site B's chunk store → Site B materialize. Verify data matches.
+
+- **Incremental sync**: Site A commits, pushes. Site A changes 1 row, commits again, pushes. Verify only the changed chunks are transferred (instrument the mock transport to count).
+
+- **Dirty tracking**: insert a row, verify `_sync_dirty` has the correct entry. Update a row, verify. Delete a row, verify. Commit, verify `_sync_dirty` is cleared.
+
+### End-to-end tests
+
+Requires two actual WordPress+SQLite installations. Use wp-env, wp-now, or Docker with the SQLite integration plugin.
+
+- **Full push/pull cycle**: use WP-CLI to create posts, pages, options on Site A. Run `wp sync commit`. Run `wp sync push`. On Site B, verify the content appears. Create new content on Site B. Commit, push back to Site A. Verify.
+
+- **Conflict detection**: create divergent changes on both sites. Attempt push from one to the other. Verify the non-fast-forward is detected and rejected.
+
+### Existing test suites and references to reuse
+
+1. **Dolt's Go test suite** (github.com/dolthub/dolt): study `go/store/nbs/` for chunk store tests, `go/store/prolly/` for tree tests, `go/libraries/doltcore/merge/` for merge tests. You cannot run Go tests directly, but the test PATTERNS (what scenarios they cover) are directly applicable. Port the scenario descriptions, not the code.
+
+2. **CBOR test vectors** (RFC 8949 Appendix A): the RFC includes a comprehensive set of diagnostic notation → encoded bytes pairs. Use these to verify your encoder. Also use the CBOR test vectors from cbor.me and the cbor-diag tools.
+
+3. **PHP serialization edge cases**: the PHP test suite (`php-src/ext/standard/tests/serialize/`) contains test cases for serialize/unserialize edge cases — objects, references, recursive structures, floats, large strings. Use these to identify edge cases your normalizer must handle.
+
+4. **WordPress PHPUnit test infrastructure**: WordPress core ships a PHPUnit test framework (`wordpress-develop/tests/phpunit/`) with a factory system for creating posts, options, users, etc. Use `WP_UnitTestCase` as the base class for integration tests that need a running WordPress environment.
+
+5. **WP-CLI testing framework**: WP-CLI uses Behat for functional tests. Each command has feature files that describe expected input/output. Write `.feature` files for `wp sync commit`, `wp sync push`, `wp sync pull`, `wp sync status`, `wp sync log`, `wp sync diff`.
+
+6. **SQLite's testing methodology** (not reusable directly, but study the approach): SQLite achieves 100% MC/DC branch coverage with billions of test cases. The relevant principle: test boundary conditions (empty inputs, single-element inputs, exactly-full pages, one-over-full pages), error paths (disk full, corrupt data, interrupted writes), and determinism (same inputs → same outputs across platforms).
+
+7. **Search/replace serialized PHP tests**: the `wp search-replace` WP-CLI command handles serialized PHP string length rewriting. Its test suite (`wp-cli/search-replace-command/features/`) covers nested serialization, edge cases with special characters in serialized strings, and length-prefix rewriting. These test scenarios are directly relevant to your normalizer.
+
+## Definition of done
+
+The implementation is complete when:
+
+1. All unit tests pass with zero warnings.
+2. All integration tests pass: snapshot → push → materialize → verify on a second SQLite database.
+3. The end-to-end round trip works: Site A → push → Site B → modify → push → Site A, with content integrity verified at each step.
+4. The incremental sync test proves that changing 1 row in a 10,000-row table transfers O(log n) chunks, not O(n).
+5. All 23 failure scenarios listed in "What breaks" are covered by tests that explicitly assert the correct behavior.
+6. The `CanonicalEncoder` passes all applicable CBOR test vectors from RFC 8949.
+7. The serialized PHP normalizer correctly handles nested serialization with URL replacement and length-prefix rewriting, verified by round-trip tests with at least 5 different URL length combinations.
+8. Concurrent push rejection works (CAS failure returns a clear error).
+9. Interrupted push resumes correctly (no duplicate chunks, no orphan refs).
+10. Memory usage during sync of 50,000 chunks stays below 256MB.
+11. The code has no dependency on MySQL. Everything runs on PHP's built-in SQLite3 extension.
+12. The HTTP transport works over real HTTP between two WordPress sites (not just mocked).
+
+## File structure
+
+```
+src/
+  Encoding/
+    CanonicalEncoder.php
+    CborEncoder.php
+    CborDecoder.php
+  Store/
+    Chunk.php
+    ChunkStore.php
+    SQLiteChunkStore.php
+    HttpChunkStore.php
+    RefStore.php
+    SQLiteRefStore.php
+  Tree/
+    TableTree.php
+    LeafNode.php
+    InternalNode.php
+    TreeDiff.php
+  Snapshot/
+    Snapshotter.php
+    Materializer.php
+    RowNormalizer.php
+    SchemaInspector.php
+    DirtyTracker.php
+    SerializedPhpHandler.php
+  Sync/
+    SyncEngine.php
+    PushCommand.php
+    FetchCommand.php
+  WordPress/
+    SyncPlugin.php          (mu-plugin: REST endpoints + trigger management)
+    WpCliCommands.php       (WP-CLI integration)
+tests/
+  Unit/
+    CanonicalEncoderTest.php
+    CborTestVectorsTest.php
+    SQLiteChunkStoreTest.php
+    SQLiteRefStoreTest.php
+    TableTreeTest.php
+    TreeDiffTest.php
+    SyncEngineTest.php
+    RowNormalizerTest.php
+    SerializedPhpHandlerTest.php
+  Integration/
+    SnapshotRoundTripTest.php
+    SyncBetweenStoresTest.php
+    IncrementalSyncTest.php
+    DirtyTrackingTest.php
+  EndToEnd/
+    FullPushPullCycleTest.php
+    ConflictDetectionTest.php
+    features/
+      sync-commit.feature
+      sync-push.feature
+      sync-pull.feature
+```
+
+## Constraints
+
+- PHP 8.2+ with the `sqlite3` and `intl` extensions.
+- No external services. No MySQL. No Redis. No message queues.
+- No Composer dependencies for the core engine. You may use PHPUnit and WP-CLI testing framework for tests.
+- The chunk store SQLite database must be a separate file from the WordPress SQLite database.
+- All I/O must go through the defined interfaces (ChunkStore, RefStore). No direct file manipulation outside of the SQLite backends.

--- a/php-dolt-sync/docker/Dockerfile
+++ b/php-dolt-sync/docker/Dockerfile
@@ -1,0 +1,32 @@
+FROM php:8.2-apache
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libicu-dev libzip-dev unzip less curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && docker-php-ext-install intl zip \
+ && a2enmod rewrite
+
+RUN curl -fsSL https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -o /usr/local/bin/wp \
+ && chmod +x /usr/local/bin/wp
+
+ENV WP_VERSION=6.5.2
+ENV SQLITE_PLUGIN_VERSION=2.1.13
+
+WORKDIR /var/www/html
+
+RUN curl -fsSL "https://wordpress.org/wordpress-${WP_VERSION}.tar.gz" | tar xz --strip-components=1 \
+ && curl -fsSL "https://downloads.wordpress.org/plugin/sqlite-database-integration.${SQLITE_PLUGIN_VERSION}.zip" -o /tmp/sqlite.zip \
+ && unzip -q /tmp/sqlite.zip -d wp-content/plugins/ \
+ && rm /tmp/sqlite.zip \
+ && cp wp-content/plugins/sqlite-database-integration/db.copy wp-content/db.php \
+ && sed -i "s#{SQLITE_IMPLEMENTATION_FOLDER_PATH}#/var/www/html/wp-content/plugins/sqlite-database-integration#g" wp-content/db.php \
+ && sed -i "s#{SQLITE_PLUGIN}#sqlite-database-integration/load.php#g" wp-content/db.php \
+ && mkdir -p wp-content/database wpsync-data \
+ && chown -R www-data:www-data /var/www/html
+
+COPY wp-config.php /var/www/html/wp-config.php
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/php-dolt-sync/docker/README.md
+++ b/php-dolt-sync/docker/README.md
@@ -1,0 +1,94 @@
+# docker demo — two WordPress + SQLite sites syncing via wp-sync
+
+## What you get
+
+- `site-a` — WordPress on `http://localhost:8081`
+- `site-b` — WordPress on `http://localhost:8082`
+- Both sites run the official `sqlite-database-integration` plugin and the `wp-sync` plugin from `../plugin/wp-sync`.
+- Inside the docker network the sites reach each other at `http://site-a` / `http://site-b` (used by push/pull).
+
+## Requirements
+
+- Docker with the `compose` subcommand (Docker Desktop, or docker-ce 20.10+ with docker-compose-plugin).
+
+## One-command setup
+
+```bash
+cd docker
+./setup.sh
+```
+
+This builds the image, starts both containers, installs WordPress on each, activates the plugins, and mints an application password per site. Credentials are printed at the end and stashed in `.creds.env` for the convenience wrapper.
+
+Login for both: `admin / admin`.
+
+## Scripted demo
+
+```bash
+./demo.sh
+```
+
+Creates a post on A, commits, pushes to B, pulls + materializes on B, edits it on B, pushes back, verifies on A. Takes ~15 seconds.
+
+## Try it manually
+
+The `sync.sh` wrapper hides the repetitive `docker compose exec -u www-data …` boilerplate:
+
+```bash
+# Make a change on site A (e.g. edit a post in wp-admin), then:
+./sync.sh a commit -- --message="initial A"
+./sync.sh a push
+
+# Pull+materialize on site B:
+./sync.sh b pull
+./sync.sh b log
+
+# Change something on B, push back:
+./sync.sh b commit -- --message="edits on B"
+./sync.sh b push
+./sync.sh a pull
+```
+
+Anything after `--` is forwarded to `wp sync …`. Equivalent long form:
+
+```bash
+docker compose exec -u www-data site-a wp sync commit --message="initial A"
+docker compose exec -u www-data site-a wp sync push \
+  --remote=http://site-b --user=admin --password="$APP_B"
+```
+
+## Inspect state
+
+```bash
+# Chunk/ref DB for site A:
+docker compose exec site-a sqlite3 /var/www/html/wpsync-data/chunks.sqlite '.tables'
+
+# WP SQLite DB for site A:
+docker compose exec site-a sqlite3 /var/www/html/wp-content/database/.ht.sqlite \
+  "SELECT option_name, option_value FROM wp_options WHERE option_name IN ('siteurl','home');"
+```
+
+## Tear down
+
+```bash
+docker compose down -v    # -v wipes the named volumes (fresh WP on next up)
+```
+
+## Layout
+
+```
+docker/
+  Dockerfile        # php:8.2-apache + WP core + sqlite-database-integration + wp-cli
+  docker-compose.yml
+  wp-config.php     # SQLite-aware, reads WP_SITEURL from env
+  entrypoint.sh
+  setup.sh          # installs WP on both sites, activates plugins, mints app passwords
+  sync.sh           # ./sync.sh <a|b> <commit|push|pull|log|status>
+  demo.sh           # scripted end-to-end A→B→A demo
+```
+
+## Notes
+
+- The `wp-sync` plugin is bind-mounted read-only from `../plugin/wp-sync`, so edits on the host are reflected immediately on both sites — handy for iteration.
+- Each site's content-addressed chunk/ref store lives in its own named volume (`site-[ab]-wpsync`, path `/var/www/html/wpsync-data/chunks.sqlite`), separate from the WordPress DB.
+- `WP_SITEURL` / `WP_HOME` are set to `http://localhost:808[12]` so browser access works, while the REST endpoints used by push/pull are served under the same domain. When one container pushes to the other using `http://site-b`, WP accepts the request because it's still the same WP install — the remote URL is only used to locate endpoints, not enforced against `siteurl`.

--- a/php-dolt-sync/docker/demo.sh
+++ b/php-dolt-sync/docker/demo.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Scripted end-to-end demo: make a change on A, sync to B, verify, change on B, sync back.
+# Assumes ./setup.sh has already been run.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if [ ! -f .creds.env ]; then
+  echo "Run ./setup.sh first." >&2
+  exit 1
+fi
+# shellcheck disable=SC1091
+source .creds.env
+
+wp_a() { docker compose exec -u www-data -T site-a wp --path=/var/www/html "$@"; }
+wp_b() { docker compose exec -u www-data -T site-b wp --path=/var/www/html "$@"; }
+
+hr() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+
+hr "Create a post on Site A"
+POST_TITLE="Hello from Site A — $(date +%H:%M:%S)"
+wp_a post create --post_title="$POST_TITLE" --post_status=publish --post_content="Synced via wp-sync"
+
+hr "Commit on Site A"
+wp_a sync commit --message="add post: $POST_TITLE"
+
+hr "Push A → B"
+wp_a sync push --remote=http://site-b --user="$ADMIN_USER" --password="$APP_B"
+
+hr "Pull + materialize on B"
+wp_b sync pull --remote=http://site-a --user="$ADMIN_USER" --password="$APP_A"
+
+hr "Verify post visible on B"
+wp_b post list --field=post_title | grep -F "$POST_TITLE" && echo "  ✓ found"
+
+hr "Edit title on B, commit, push back"
+POST_ID=$(wp_b post list --field=ID --s="$POST_TITLE" | head -1)
+wp_b post update "$POST_ID" --post_title="$POST_TITLE (edited on B)"
+wp_b sync commit --message="edit on B"
+wp_b sync push --remote=http://site-a --user="$ADMIN_USER" --password="$APP_A"
+
+hr "Pull on A, verify edited title"
+wp_a sync pull --remote=http://site-b --user="$ADMIN_USER" --password="$APP_B"
+wp_a post list --field=post_title | grep -F "edited on B" && echo "  ✓ edit propagated"
+
+hr "Commit log on A"
+wp_a sync log --max=5
+
+echo
+echo "Demo done. Visit http://localhost:8081 and http://localhost:8082 to inspect both sites."

--- a/php-dolt-sync/docker/docker-compose.yml
+++ b/php-dolt-sync/docker/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  site-a:
+    build: .
+    image: wp-sync-demo:latest
+    container_name: wpsync-site-a
+    ports:
+      - "8081:80"
+    environment:
+      WP_SITEURL: "http://localhost:8081"
+    volumes:
+      - site-a-wp-content:/var/www/html/wp-content
+      - site-a-wpsync:/var/www/html/wpsync-data
+      - ../plugin/wp-sync:/var/www/html/wp-content/plugins/wp-sync:ro
+
+  site-b:
+    build: .
+    image: wp-sync-demo:latest
+    container_name: wpsync-site-b
+    ports:
+      - "8082:80"
+    environment:
+      WP_SITEURL: "http://localhost:8082"
+    volumes:
+      - site-b-wp-content:/var/www/html/wp-content
+      - site-b-wpsync:/var/www/html/wpsync-data
+      - ../plugin/wp-sync:/var/www/html/wp-content/plugins/wp-sync:ro
+
+volumes:
+  site-a-wp-content:
+  site-a-wpsync:
+  site-b-wp-content:
+  site-b-wpsync:

--- a/php-dolt-sync/docker/entrypoint.sh
+++ b/php-dolt-sync/docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chown -R www-data:www-data /var/www/html/wp-content /var/www/html/wpsync-data 2>/dev/null || true
+exec "$@"

--- a/php-dolt-sync/docker/setup.sh
+++ b/php-dolt-sync/docker/setup.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# One-shot setup: install WP on both sites, activate plugins, mint app passwords, print demo commands.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+ADMIN_USER="admin"
+ADMIN_PASS="admin"
+ADMIN_EMAIL="admin@example.test"
+
+wp_a() { docker compose exec -u www-data site-a wp --path=/var/www/html "$@"; }
+wp_b() { docker compose exec -u www-data site-b wp --path=/var/www/html "$@"; }
+
+echo "→ Waiting for containers to be up..."
+docker compose up -d --build
+
+# Wait for apache on each
+for port in 8081 8082; do
+  for i in $(seq 1 30); do
+    if curl -fsS "http://localhost:${port}/wp-admin/install.php" >/dev/null 2>&1; then break; fi
+    sleep 1
+  done
+done
+
+install_site() {
+  local fn="$1" url="$2" title="$3"
+  if $fn core is-installed 2>/dev/null; then
+    echo "  already installed: $url"; return
+  fi
+  $fn core install \
+    --url="$url" \
+    --title="$title" \
+    --admin_user="$ADMIN_USER" \
+    --admin_password="$ADMIN_PASS" \
+    --admin_email="$ADMIN_EMAIL" \
+    --skip-email
+  $fn plugin activate sqlite-database-integration || true
+  $fn plugin activate wp-sync
+}
+
+echo "→ Installing site A (http://localhost:8081)"
+install_site wp_a "http://localhost:8081" "Site A"
+
+echo "→ Installing site B (http://localhost:8082)"
+install_site wp_b "http://localhost:8082" "Site B"
+
+echo "→ Minting application passwords"
+# --porcelain prints just the password.
+APP_A=$(wp_a user application-password create "$ADMIN_USER" "wp-sync" --porcelain | tr -d '\r\n ')
+APP_B=$(wp_b user application-password create "$ADMIN_USER" "wp-sync" --porcelain | tr -d '\r\n ')
+
+cat <<EOF
+
+=====================================================
+  Setup complete.
+
+  Admin UI:
+    Site A: http://localhost:8081/wp-admin/   ($ADMIN_USER / $ADMIN_PASS)
+    Site B: http://localhost:8082/wp-admin/   ($ADMIN_USER / $ADMIN_PASS)
+
+  Inside the docker network the sites reach each other as http://site-a / http://site-b.
+  App passwords (for sync push/pull):
+    A: $APP_A
+    B: $APP_B
+
+  Try:
+    docker compose exec -u www-data site-a wp sync commit --message="initial on A"
+    docker compose exec -u www-data site-a wp sync push   --remote=http://site-b --user=$ADMIN_USER --password="$APP_B"
+    docker compose exec -u www-data site-b wp sync pull   --remote=http://site-a --user=$ADMIN_USER --password="$APP_A"
+    docker compose exec -u www-data site-b wp sync log
+
+  (There's also a convenience wrapper: ./sync.sh a commit -- --message="..." )
+=====================================================
+EOF
+
+# Stash creds for the convenience wrapper.
+cat > .creds.env <<EOF
+ADMIN_USER=$ADMIN_USER
+APP_A=$APP_A
+APP_B=$APP_B
+EOF

--- a/php-dolt-sync/docker/sync.sh
+++ b/php-dolt-sync/docker/sync.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Convenience wrapper: ./sync.sh <a|b> <commit|push|pull|log|status> [extra wp-cli args]
+# Uses credentials saved by setup.sh in .creds.env.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [ ! -f .creds.env ]; then
+  echo "Run ./setup.sh first." >&2
+  exit 1
+fi
+# shellcheck disable=SC1091
+source .creds.env
+
+site="${1:-}"
+cmd="${2:-}"
+shift 2 || true
+
+case "$site" in
+  a) svc=site-a; remote=http://site-b; remote_pw="$APP_B" ;;
+  b) svc=site-b; remote=http://site-a; remote_pw="$APP_A" ;;
+  *) echo "usage: $0 <a|b> <commit|push|pull|log|status> [extra args]" >&2; exit 1 ;;
+esac
+
+run() { docker compose exec -u www-data "$svc" wp --path=/var/www/html "$@"; }
+
+case "$cmd" in
+  commit) run sync commit "$@" ;;
+  push)   run sync push   --remote="$remote" --user="$ADMIN_USER" --password="$remote_pw" "$@" ;;
+  pull)   run sync pull   --remote="$remote" --user="$ADMIN_USER" --password="$remote_pw" "$@" ;;
+  log|status) run sync "$cmd" "$@" ;;
+  *) echo "unknown command: $cmd" >&2; exit 1 ;;
+esac

--- a/php-dolt-sync/docker/wp-config.php
+++ b/php-dolt-sync/docker/wp-config.php
@@ -1,0 +1,28 @@
+<?php
+// wp-config for wp-sync demo. SQLite via the sqlite-database-integration plugin's db.php drop-in.
+
+$site_url = getenv('WP_SITEURL') ?: 'http://localhost:8081';
+define('WP_HOME',    $site_url);
+define('WP_SITEURL', $site_url);
+
+$table_prefix = 'wp_';
+
+// Keys/salts. Demo only — regenerate for anything real.
+define('AUTH_KEY',         'demo-auth-key-change-me');
+define('SECURE_AUTH_KEY',  'demo-secure-auth-key-change-me');
+define('LOGGED_IN_KEY',    'demo-logged-in-key-change-me');
+define('NONCE_KEY',        'demo-nonce-key-change-me');
+define('AUTH_SALT',         'demo-auth-salt-change-me');
+define('SECURE_AUTH_SALT',  'demo-secure-auth-salt-change-me');
+define('LOGGED_IN_SALT',    'demo-logged-in-salt-change-me');
+define('NONCE_SALT',        'demo-nonce-salt-change-me');
+
+define('WP_DEBUG', false);
+define('DISALLOW_FILE_MODS', false);
+
+// Where wp-sync stores its content-addressed chunk+ref DB. Kept outside the WP SQLite DB on purpose.
+define('WPSYNC_CHUNK_DB', '/var/www/html/wpsync-data/chunks.sqlite');
+define('WPSYNC_WP_DB',    '/var/www/html/wp-content/database/.ht.sqlite');
+
+if (!defined('ABSPATH')) define('ABSPATH', __DIR__ . '/');
+require_once ABSPATH . 'wp-settings.php';

--- a/php-dolt-sync/plugin/wp-sync/src/Encoding/CanonicalEncoder.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Encoding/CanonicalEncoder.php
@@ -1,0 +1,153 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Encoding;
+
+/**
+ * Canonical encoder: PHP value -> deterministic CBOR bytes.
+ *
+ * Rules:
+ *  - PHP null        -> CBOR null
+ *  - PHP bool        -> CBOR bool
+ *  - PHP int         -> CBOR uint/nint
+ *  - PHP float       -> CBOR double; integer-valued floats are re-coerced to int;
+ *                       NaN normalized to canonical quiet NaN; -0.0 -> 0.0
+ *  - PHP string      -> CBOR text string (NFC-normalized, must be valid UTF-8)
+ *  - PHP list (sequential 0-indexed) -> CBOR array
+ *  - PHP map (any other array)        -> CBOR map with length-first sorted keys
+ *
+ * Byte strings: not emitted by this encoder; use encodeBytes() explicitly.
+ */
+final class CanonicalEncoder
+{
+    /** Sentinel wrapper for byte-strings that should encode as CBOR byte strings. */
+    public static function bytes(string $raw): \stdClass
+    {
+        $o = new \stdClass();
+        $o->__cbor_bytes = $raw;
+        return $o;
+    }
+
+    public static function encode(mixed $value): string
+    {
+        if ($value === null) {
+            return CborEncoder::encodeNull();
+        }
+        if (is_bool($value)) {
+            return CborEncoder::encodeBool($value);
+        }
+        if (is_int($value)) {
+            return CborEncoder::encodeInt($value);
+        }
+        if (is_float($value)) {
+            return self::encodeFloat($value);
+        }
+        if (is_string($value)) {
+            return self::encodeString($value);
+        }
+        if (is_array($value)) {
+            return self::encodeArray($value);
+        }
+        if (is_object($value) && isset($value->__cbor_bytes) && is_string($value->__cbor_bytes)) {
+            $raw = $value->__cbor_bytes;
+            return CborEncoder::head(CborEncoder::MT_BSTR, strlen($raw)) . $raw;
+        }
+        throw new \InvalidArgumentException('CanonicalEncoder: unsupported type ' . get_debug_type($value));
+    }
+
+    public static function decode(string $bytes): mixed
+    {
+        return CborDecoder::decode($bytes);
+    }
+
+    public static function hash(mixed $value): string
+    {
+        return hash('sha256', self::encode($value));
+    }
+
+    public static function hashBytes(string $bytes): string
+    {
+        return hash('sha256', $bytes);
+    }
+
+    /** Sort map pairs by raw encoded key bytes, length-first (RFC 8949 §4.2.3). */
+    private static function encodeArray(array $a): string
+    {
+        // Determine if sequential list.
+        if (self::isList($a)) {
+            $body = '';
+            foreach ($a as $v) {
+                $body .= self::encode($v);
+            }
+            return CborEncoder::head(CborEncoder::MT_ARRAY, count($a)) . $body;
+        }
+
+        // Map: encode each key, sort pairs by key bytes.
+        $pairs = [];
+        foreach ($a as $k => $v) {
+            // PHP coerces numeric-string keys to int. We preserve PHP's native key type.
+            if (is_int($k)) {
+                $ek = CborEncoder::encodeInt($k);
+            } else {
+                $ek = self::encodeString((string)$k);
+            }
+            $pairs[] = [$ek, self::encode($v)];
+        }
+        $pairs = CborEncoder::sortMapPairs($pairs);
+        $body = '';
+        foreach ($pairs as $p) {
+            $body .= $p[0] . $p[1];
+        }
+        return CborEncoder::head(CborEncoder::MT_MAP, count($pairs)) . $body;
+    }
+
+    private static function isList(array $a): bool
+    {
+        if ($a === []) {
+            return true;
+        }
+        // array_is_list is PHP 8.1+.
+        return array_is_list($a);
+    }
+
+    private static function encodeFloat(float $f): string
+    {
+        if (is_nan($f)) {
+            return CborEncoder::encodeDouble(NAN);
+        }
+        if (!is_finite($f)) {
+            return CborEncoder::encodeDouble($f);
+        }
+        // Coerce integer-valued floats to int encoding.
+        if ($f === floor($f) && $f >= PHP_INT_MIN && $f <= PHP_INT_MAX) {
+            // beware of precision: ensure exact integer representation
+            $i = (int)$f;
+            if ((float)$i === $f) {
+                return CborEncoder::encodeInt($i);
+            }
+        }
+        // -0.0 normalize to 0.0
+        if ($f === 0.0) {
+            return CborEncoder::encodeDouble(0.0);
+        }
+        return CborEncoder::encodeDouble($f);
+    }
+
+    private static function encodeString(string $s): string
+    {
+        // Must be valid UTF-8.
+        if ($s !== '' && !mb_check_encoding($s, 'UTF-8')) {
+            throw new \InvalidArgumentException('CanonicalEncoder: invalid UTF-8 string');
+        }
+        // NFC normalize if intl available.
+        if (class_exists(\Normalizer::class)) {
+            if (!\Normalizer::isNormalized($s, \Normalizer::FORM_C)) {
+                $n = \Normalizer::normalize($s, \Normalizer::FORM_C);
+                if ($n !== false) {
+                    $s = $n;
+                }
+            }
+        }
+        return CborEncoder::head(CborEncoder::MT_TSTR, strlen($s)) . $s;
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Encoding/CborDecoder.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Encoding/CborDecoder.php
@@ -1,0 +1,155 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Encoding;
+
+final class CborDecoder
+{
+    private string $buf;
+    private int $pos;
+    private int $len;
+
+    public function __construct(string $bytes)
+    {
+        $this->buf = $bytes;
+        $this->pos = 0;
+        $this->len = strlen($bytes);
+    }
+
+    /** Decode a whole CBOR item. Throws if bytes remain. */
+    public static function decode(string $bytes): mixed
+    {
+        $d = new self($bytes);
+        $v = $d->readItem();
+        if ($d->pos !== $d->len) {
+            throw new \RuntimeException('CBOR: trailing bytes after top-level item');
+        }
+        return $v;
+    }
+
+    public function readItem(): mixed
+    {
+        if ($this->pos >= $this->len) {
+            throw new \RuntimeException('CBOR: unexpected EOF');
+        }
+        $ib = ord($this->buf[$this->pos++]);
+        $mt = $ib >> 5;
+        $ai = $ib & 0x1f;
+        $arg = $this->readArg($ai, $mt);
+
+        switch ($mt) {
+            case CborEncoder::MT_UINT:
+                return $arg;
+            case CborEncoder::MT_NINT:
+                return -1 - $arg;
+            case CborEncoder::MT_BSTR:
+            case CborEncoder::MT_TSTR:
+                $s = substr($this->buf, $this->pos, $arg);
+                if (strlen($s) !== $arg) {
+                    throw new \RuntimeException('CBOR: short read in string');
+                }
+                $this->pos += $arg;
+                // text strings marked as distinct using internal wrapper? We return PHP strings
+                // for both; callers distinguish by context. Our encoder only emits text for keys.
+                return $s;
+            case CborEncoder::MT_ARRAY:
+                $a = [];
+                for ($i = 0; $i < $arg; $i++) {
+                    $a[] = $this->readItem();
+                }
+                return $a;
+            case CborEncoder::MT_MAP:
+                $m = [];
+                for ($i = 0; $i < $arg; $i++) {
+                    $k = $this->readItem();
+                    $v = $this->readItem();
+                    // Keys can be ints or strings; PHP handles both as array keys.
+                    $m[$k] = $v;
+                }
+                return $m;
+            case CborEncoder::MT_SIMPLE:
+                if ($ai === 20) return false;
+                if ($ai === 21) return true;
+                if ($ai === 22) return null;
+                if ($ai === 23) return null; // undefined -> null
+                if ($ai === 25) {
+                    // half float
+                    return $this->decodeHalf($arg);
+                }
+                if ($ai === 26) {
+                    // single float
+                    $b = pack('N', $arg);
+                    $u = unpack('G', $b); // big-endian float
+                    return (float) $u[1];
+                }
+                if ($ai === 27) {
+                    $b = pack('J', $arg);
+                    $u = unpack('E', $b);
+                    return (float) $u[1];
+                }
+                throw new \RuntimeException('CBOR: unsupported simple value ai=' . $ai);
+            case CborEncoder::MT_TAG:
+                // Skip tag; return tagged value.
+                return $this->readItem();
+            default:
+                throw new \RuntimeException('CBOR: unknown major type ' . $mt);
+        }
+    }
+
+    private function readArg(int $ai, int $mt): int
+    {
+        if ($ai < 24) {
+            return $ai;
+        }
+        if ($ai === 24) {
+            return ord($this->readBytes(1));
+        }
+        if ($ai === 25) {
+            $b = $this->readBytes(2);
+            if ($mt === CborEncoder::MT_SIMPLE) {
+                // half-float: pass the raw 16-bit integer through readArg
+                return (ord($b[0]) << 8) | ord($b[1]);
+            }
+            return (ord($b[0]) << 8) | ord($b[1]);
+        }
+        if ($ai === 26) {
+            $b = $this->readBytes(4);
+            $u = unpack('N', $b);
+            if ($mt === CborEncoder::MT_SIMPLE) {
+                return $u[1];
+            }
+            return $u[1];
+        }
+        if ($ai === 27) {
+            $b = $this->readBytes(8);
+            $u = unpack('J', $b);
+            return $u[1];
+        }
+        throw new \RuntimeException('CBOR: unsupported additional info ai=' . $ai);
+    }
+
+    private function readBytes(int $n): string
+    {
+        $s = substr($this->buf, $this->pos, $n);
+        if (strlen($s) !== $n) {
+            throw new \RuntimeException('CBOR: short read');
+        }
+        $this->pos += $n;
+        return $s;
+    }
+
+    private function decodeHalf(int $u): float
+    {
+        $exp = ($u >> 10) & 0x1f;
+        $mant = $u & 0x3ff;
+        $sign = ($u >> 15) & 1;
+        if ($exp === 0) {
+            $val = $mant * 2 ** -24;
+        } elseif ($exp !== 31) {
+            $val = ($mant + 1024) * 2 ** ($exp - 25);
+        } else {
+            $val = $mant === 0 ? INF : NAN;
+        }
+        return $sign ? -$val : $val;
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Encoding/CborEncoder.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Encoding/CborEncoder.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Encoding;
+
+/**
+ * Minimal deterministic CBOR encoder (RFC 8949, deterministic profile §4.2).
+ * Supports: unsigned/negative ints, byte/text strings, arrays, maps, floats, null, bool.
+ */
+final class CborEncoder
+{
+    public const MT_UINT  = 0;
+    public const MT_NINT  = 1;
+    public const MT_BSTR  = 2;
+    public const MT_TSTR  = 3;
+    public const MT_ARRAY = 4;
+    public const MT_MAP   = 5;
+    public const MT_TAG   = 6;
+    public const MT_SIMPLE= 7;
+
+    /** Encode a header byte for a major type with argument length. */
+    public static function head(int $mt, int $arg): string
+    {
+        if ($arg < 0) {
+            throw new \InvalidArgumentException('negative arg');
+        }
+        if ($arg < 24) {
+            return chr(($mt << 5) | $arg);
+        }
+        if ($arg <= 0xff) {
+            return chr(($mt << 5) | 24) . chr($arg);
+        }
+        if ($arg <= 0xffff) {
+            return chr(($mt << 5) | 25) . pack('n', $arg);
+        }
+        if ($arg <= 0xffffffff) {
+            return chr(($mt << 5) | 26) . pack('N', $arg);
+        }
+        return chr(($mt << 5) | 27) . pack('J', $arg);
+    }
+
+    /** Encode an unsigned 64-bit value. Accepts int; for values > PHP_INT_MAX use string decimal. */
+    public static function encodeUint(int $v): string
+    {
+        if ($v < 0) {
+            throw new \InvalidArgumentException('encodeUint negative');
+        }
+        return self::head(self::MT_UINT, $v);
+    }
+
+    public static function encodeNint(int $v): string
+    {
+        if ($v >= 0) {
+            throw new \InvalidArgumentException('encodeNint non-negative');
+        }
+        // negative: encoded as -(n+1) so v=-1 -> 0, v=-2 -> 1, etc.
+        $n = -($v + 1);
+        return self::head(self::MT_NINT, $n);
+    }
+
+    public static function encodeInt(int $v): string
+    {
+        return $v >= 0 ? self::encodeUint($v) : self::encodeNint($v);
+    }
+
+    public static function encodeBytes(string $b): string
+    {
+        return self::head(self::MT_BSTR, strlen($b)) . $b;
+    }
+
+    public static function encodeText(string $s): string
+    {
+        return self::head(self::MT_TSTR, strlen($s)) . $s;
+    }
+
+    public static function encodeNull(): string
+    {
+        return "\xf6";
+    }
+
+    public static function encodeBool(bool $b): string
+    {
+        return $b ? "\xf5" : "\xf4";
+    }
+
+    /**
+     * Deterministic float encoding per RFC 8949 §4.2.2:
+     * Use the shortest representation that preserves value. For simplicity and
+     * full determinism across platforms, always emit 64-bit (0xfb).
+     * Callers must normalize NaN and -0.0 before invoking.
+     */
+    public static function encodeDouble(float $f): string
+    {
+        // Normalize NaN to canonical quiet NaN.
+        if (is_nan($f)) {
+            return "\xfb" . "\x7f\xf8\x00\x00\x00\x00\x00\x00";
+        }
+        // Normalize -0.0 to 0.0.
+        if ($f === 0.0) {
+            $f = 0.0;
+        }
+        // pack('E', ...) = big-endian double (IEEE 754).
+        return "\xfb" . pack('E', $f);
+    }
+
+    /** RFC 8949 §4.2.3: length-first lexicographic sort of encoded map keys. */
+    public static function sortMapPairs(array $pairs): array
+    {
+        usort($pairs, static function (array $a, array $b): int {
+            $la = strlen($a[0]);
+            $lb = strlen($b[0]);
+            if ($la !== $lb) {
+                return $la <=> $lb;
+            }
+            return strcmp($a[0], $b[0]);
+        });
+        return $pairs;
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Snapshot/DirtyTracker.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Snapshot/DirtyTracker.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Snapshot;
+
+/**
+ * SQL-trigger-based dirty-row tracking. On each tracked table, INSERT/UPDATE/DELETE
+ * populates _sync_dirty(tbl, rowid, op) with the last op per (tbl, rowid).
+ *
+ * During materialization we DROP triggers (via suspend()) and recreate them
+ * (resume()) so that applied writes don't fill the dirty log with noise.
+ */
+final class DirtyTracker
+{
+    public const DIRTY_TABLE = '_sync_dirty';
+
+    public static function install(\SQLite3 $db, array $tables): void
+    {
+        $db->exec(<<<SQL
+            CREATE TABLE IF NOT EXISTS _sync_dirty (
+                tbl   TEXT    NOT NULL,
+                rowid INTEGER NOT NULL,
+                op    TEXT    NOT NULL,
+                PRIMARY KEY (tbl, rowid)
+            )
+        SQL);
+        foreach ($tables as $t) {
+            self::createTriggers($db, $t);
+        }
+    }
+
+    public static function createTriggers(\SQLite3 $db, string $table): void
+    {
+        $q = SchemaInspector::quoteIdent($table);
+        $n = addslashes($table);
+        $iName = self::trigName($table, 'i');
+        $uName = self::trigName($table, 'u');
+        $dName = self::trigName($table, 'd');
+        $db->exec("DROP TRIGGER IF EXISTS {$iName}");
+        $db->exec("DROP TRIGGER IF EXISTS {$uName}");
+        $db->exec("DROP TRIGGER IF EXISTS {$dName}");
+        $db->exec("CREATE TRIGGER {$iName} AFTER INSERT ON {$q} BEGIN
+            INSERT OR REPLACE INTO _sync_dirty(tbl,rowid,op) VALUES('{$n}', NEW.rowid, 'I');
+        END");
+        $db->exec("CREATE TRIGGER {$uName} AFTER UPDATE ON {$q} BEGIN
+            INSERT OR REPLACE INTO _sync_dirty(tbl,rowid,op) VALUES('{$n}', NEW.rowid, 'U');
+        END");
+        $db->exec("CREATE TRIGGER {$dName} AFTER DELETE ON {$q} BEGIN
+            INSERT OR REPLACE INTO _sync_dirty(tbl,rowid,op) VALUES('{$n}', OLD.rowid, 'D');
+        END");
+    }
+
+    public static function suspend(\SQLite3 $db, array $tables): void
+    {
+        foreach ($tables as $t) {
+            $db->exec('DROP TRIGGER IF EXISTS ' . self::trigName($t, 'i'));
+            $db->exec('DROP TRIGGER IF EXISTS ' . self::trigName($t, 'u'));
+            $db->exec('DROP TRIGGER IF EXISTS ' . self::trigName($t, 'd'));
+        }
+    }
+
+    public static function resume(\SQLite3 $db, array $tables): void
+    {
+        foreach ($tables as $t) {
+            self::createTriggers($db, $t);
+        }
+    }
+
+    public static function dirtyTables(\SQLite3 $db): array
+    {
+        $res = $db->query('SELECT DISTINCT tbl FROM _sync_dirty');
+        if (!$res) return [];
+        $out = [];
+        while ($row = $res->fetchArray(SQLITE3_ASSOC)) {
+            $out[] = $row['tbl'];
+        }
+        return $out;
+    }
+
+    public static function clear(\SQLite3 $db): void
+    {
+        $db->exec('DELETE FROM ' . self::DIRTY_TABLE);
+    }
+
+    public static function isInstalled(\SQLite3 $db): bool
+    {
+        $res = $db->query("SELECT name FROM sqlite_master WHERE type='table' AND name='_sync_dirty'");
+        return (bool)($res && $res->fetchArray(SQLITE3_ASSOC));
+    }
+
+    private static function trigName(string $table, string $suffix): string
+    {
+        // Trigger names must be safe identifiers.
+        if (!preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $table)) {
+            throw new \InvalidArgumentException("bad table name: {$table}");
+        }
+        return "_sync_trk_{$table}_{$suffix}";
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Snapshot/Materializer.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Snapshot/Materializer.php
@@ -1,0 +1,202 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Snapshot;
+
+use WpSync\Encoding\CanonicalEncoder;
+use WpSync\Store\ChunkStore;
+use WpSync\Tree\TableTree;
+
+/**
+ * Apply a commit to a live WordPress SQLite database.
+ *
+ *  - Runs inside BEGIN/COMMIT.
+ *  - Suspends dirty-tracking triggers.
+ *  - Diffs remote tree vs. current state; applies INSERT/UPDATE/DELETE.
+ *  - Rewrites {{SITE_URL}} placeholder back to the local site URL.
+ *  - Warns and skips tables with mismatching schema hash.
+ */
+final class Materializer
+{
+    /** @var string[] */
+    public array $warnings = [];
+
+    public function __construct(
+        private readonly \SQLite3 $db,
+        private readonly ChunkStore $chunks,
+        private readonly string $localSiteUrl,
+    ) {}
+
+    /**
+     * @param string $commitHash
+     * @param string[] $tables Restrict to these tables (else all in root).
+     * @param array<string,callable> $rowFilters Optional: skip rows per table; filter(row) -> bool
+     */
+    public function materialize(string $commitHash, ?array $tables = null, array $rowFilters = []): void
+    {
+        $commit = Snapshotter::loadCommit($commitHash, $this->chunks);
+        $remoteRoot = Snapshotter::loadRoot($commit['root'], $this->chunks);
+
+        $affectedTables = array_keys($remoteRoot['tables']);
+        if ($tables !== null) {
+            $affectedTables = array_values(array_intersect($affectedTables, $tables));
+        }
+
+        // Suspend triggers for *all* user tables with triggers installed, to avoid
+        // leaking dirty entries.
+        $dirtyInstalled = DirtyTracker::isInstalled($this->db);
+        $userTables = SchemaInspector::listTables($this->db);
+        if ($dirtyInstalled) {
+            DirtyTracker::suspend($this->db, $userTables);
+        }
+
+        $this->db->exec('BEGIN IMMEDIATE');
+        try {
+            foreach ($affectedTables as $t) {
+                if (!in_array($t, $userTables, true)) {
+                    // Table doesn't exist locally — skip (schema migration out of scope).
+                    $this->warnings[] = "table {$t} missing locally; skipped";
+                    continue;
+                }
+                $schema = SchemaInspector::inspect($this->db, $t);
+                if ($schema['schemaHash'] !== $remoteRoot['tables'][$t]['schema']) {
+                    $this->warnings[] = "schema mismatch for {$t}; skipped";
+                    continue;
+                }
+                $this->applyTable($t, $schema, $remoteRoot['tables'][$t]['tree'], $rowFilters[$t] ?? null);
+            }
+            $this->db->exec('COMMIT');
+        } catch (\Throwable $e) {
+            $this->db->exec('ROLLBACK');
+            if ($dirtyInstalled) DirtyTracker::resume($this->db, $userTables);
+            throw $e;
+        }
+
+        if ($dirtyInstalled) {
+            DirtyTracker::resume($this->db, $userTables);
+            // Materialization shouldn't pollute dirty; defensively clear.
+            DirtyTracker::clear($this->db);
+        }
+    }
+
+    private function applyTable(string $table, array $schema, string $remoteTreeHash, ?callable $filter): void
+    {
+        $pk = $schema['pk'];
+        $quoted = SchemaInspector::quoteIdent($table);
+
+        // Load local rows keyed by PK, EXCLUDING any row that the filter
+        // would have skipped on snapshot — those rows must be neither inserted,
+        // updated, nor deleted by the materializer.
+        $local = $this->loadLocalKeyed($table, $schema, $filter);
+
+        // Walk the remote tree entries.
+        $remote = iterator_to_array(TableTree::iterate($remoteTreeHash, $this->chunks), false);
+        $remoteKeys = [];
+        foreach ($remote as [$k, $encVal]) {
+            $remoteKeys[$k] = true;
+            $row = CanonicalEncoder::decode($encVal);
+            if (!is_array($row)) {
+                throw new \RuntimeException("row value for {$table} is not a map");
+            }
+
+            $applied = RowNormalizer::denormalizeForApply($row, $this->localSiteUrl);
+            if ($filter !== null && $filter($applied) === null) continue;
+
+            if (isset($local[$k])) {
+                if ($local[$k]['encoded'] !== $encVal) {
+                    $this->applyUpsert($table, $schema, $applied, 'UPDATE', $local[$k]['rowid']);
+                }
+            } else {
+                $this->applyUpsert($table, $schema, $applied, 'INSERT', null);
+            }
+        }
+
+        // Deletions: keys in local (and syncable) but not in remote.
+        foreach ($local as $k => $info) {
+            if (!isset($remoteKeys[$k])) {
+                $this->applyDelete($table, $info['rowid']);
+            }
+        }
+    }
+
+    /**
+     * Load all rows of a table keyed by the same PK byte-string the snapshotter uses.
+     * @return array<string,array{encoded:string, rowid:int}>
+     */
+    private function loadLocalKeyed(string $table, array $schema, ?callable $filter = null): array
+    {
+        $pk = $schema['pk'];
+        $cols = $schema['columns'];
+        $quoted = SchemaInspector::quoteIdent($table);
+        $selectCols = 'rowid AS __sync_rowid__,' . implode(',', array_map([SchemaInspector::class, 'quoteIdent'], $cols));
+        $res = $this->db->query("SELECT {$selectCols} FROM {$quoted}");
+        $out = [];
+        $siteUrl = $this->localSiteUrl;
+        while ($row = $res->fetchArray(SQLITE3_ASSOC)) {
+            $rowid = (int)$row['__sync_rowid__'];
+            unset($row['__sync_rowid__']);
+            if ($filter !== null && $filter($row) === null) {
+                continue;
+            }
+            $normalized = RowNormalizer::normalizeForEncode($row, $siteUrl);
+            $key = SchemaInspector::makeKey($pk, $row, $rowid);
+            $out[$key] = ['encoded' => CanonicalEncoder::encode($normalized), 'rowid' => $rowid];
+        }
+        return $out;
+    }
+
+    private function applyUpsert(string $table, array $schema, array $row, string $op, ?int $rowid): void
+    {
+        $quoted = SchemaInspector::quoteIdent($table);
+        $cols = array_keys($row);
+        // Remove generated / unknown columns by restricting to table columns.
+        $valid = array_flip($schema['columns']);
+        $cols = array_values(array_filter($cols, fn($c) => isset($valid[$c])));
+        $set = array_intersect_key($row, $valid);
+
+        if ($op === 'INSERT') {
+            $placeholders = implode(',', array_fill(0, count($cols), '?'));
+            $colSql = implode(',', array_map([SchemaInspector::class, 'quoteIdent'], $cols));
+            $sql = "INSERT INTO {$quoted} ({$colSql}) VALUES ({$placeholders})";
+            $stmt = $this->db->prepare($sql);
+            $i = 1;
+            foreach ($cols as $c) {
+                $this->bindValue($stmt, $i++, $set[$c]);
+            }
+            $stmt->execute();
+            return;
+        }
+
+        // UPDATE by rowid
+        $assigns = implode(',', array_map(fn($c) => SchemaInspector::quoteIdent($c) . '=?', $cols));
+        $sql = "UPDATE {$quoted} SET {$assigns} WHERE rowid = ?";
+        $stmt = $this->db->prepare($sql);
+        $i = 1;
+        foreach ($cols as $c) {
+            $this->bindValue($stmt, $i++, $set[$c]);
+        }
+        $stmt->bindValue($i, $rowid, SQLITE3_INTEGER);
+        $stmt->execute();
+    }
+
+    private function applyDelete(string $table, int $rowid): void
+    {
+        $q = SchemaInspector::quoteIdent($table);
+        $stmt = $this->db->prepare("DELETE FROM {$q} WHERE rowid = ?");
+        $stmt->bindValue(1, $rowid, SQLITE3_INTEGER);
+        $stmt->execute();
+    }
+
+    private function bindValue(\SQLite3Stmt $stmt, int $i, mixed $v): void
+    {
+        if ($v === null) {
+            $stmt->bindValue($i, null, SQLITE3_NULL);
+        } elseif (is_int($v)) {
+            $stmt->bindValue($i, $v, SQLITE3_INTEGER);
+        } elseif (is_float($v)) {
+            $stmt->bindValue($i, $v, SQLITE3_FLOAT);
+        } else {
+            $stmt->bindValue($i, (string)$v, SQLITE3_TEXT);
+        }
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Snapshot/RowNormalizer.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Snapshot/RowNormalizer.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Snapshot;
+
+/**
+ * Normalizes a WordPress row before it is canonically encoded.
+ *
+ *  1. Column ordering: columns are keyed by name (alphabetical at encode time).
+ *  2. Site-URL replacement: occurrences of the source site's URL are replaced
+ *     with the placeholder {{SITE_URL}}. Works recursively inside serialized PHP
+ *     values with correct length-prefix recomputation.
+ *  3. Serialized PHP is re-serialized deterministically (sorted keys, correct
+ *     lengths) so cross-site hashes match.
+ *  4. GMT timestamps: non-GMT variants are dropped.
+ *  5. Transients (in wp_options): skipped at the caller level.
+ */
+final class RowNormalizer
+{
+    public const SITE_URL_PLACEHOLDER = '{{SITE_URL}}';
+
+    /** Map non-GMT -> GMT column names. Non-GMT is dropped on encode and reconstituted on apply. */
+    public const NON_GMT_TO_GMT = [
+        'post_date'     => 'post_date_gmt',
+        'post_modified' => 'post_modified_gmt',
+        'comment_date'  => 'comment_date_gmt',
+    ];
+
+    /**
+     * @param array<string,mixed> $row Column-name => value from the source DB.
+     * @param string $siteUrl Source site URL (no trailing slash enforced).
+     * @return array<string,mixed> Normalized row.
+     */
+    public static function normalizeForEncode(array $row, string $siteUrl): array
+    {
+        $siteUrl = self::canonicalUrl($siteUrl);
+        $out = [];
+        foreach ($row as $col => $val) {
+            // Drop non-GMT when GMT sibling is present; will be reconstituted on apply.
+            if (isset(self::NON_GMT_TO_GMT[$col]) && array_key_exists(self::NON_GMT_TO_GMT[$col], $row)) {
+                continue;
+            }
+            if ($val === null || !is_string($val) || $val === '') {
+                $out[$col] = $val;
+                continue;
+            }
+            $out[$col] = self::rewriteOutgoing($val, $siteUrl);
+        }
+        ksort($out, SORT_STRING);
+        return $out;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     * @param string $siteUrl Destination site URL.
+     * @return array<string,mixed>
+     */
+    public static function denormalizeForApply(array $row, string $siteUrl): array
+    {
+        $siteUrl = self::canonicalUrl($siteUrl);
+        $out = [];
+        foreach ($row as $col => $val) {
+            if (!is_string($val) || $val === '') {
+                $out[$col] = $val;
+                continue;
+            }
+            $out[$col] = self::rewriteIncoming($val, $siteUrl);
+        }
+        // Reconstitute non-GMT siblings from GMT (best-effort: same value, as a NOT NULL placeholder).
+        foreach (self::NON_GMT_TO_GMT as $local => $gmt) {
+            if (!array_key_exists($local, $out) && array_key_exists($gmt, $out) && $out[$gmt] !== null) {
+                $out[$local] = $out[$gmt];
+            }
+        }
+        return $out;
+    }
+
+    /** Source -> canonical form: replace site URL with placeholder, re-serialize. */
+    public static function rewriteOutgoing(string $raw, string $siteUrl): string
+    {
+        return SerializedPhpHandler::transformStrings(
+            $raw,
+            static fn(string $s): string => str_replace($siteUrl, self::SITE_URL_PLACEHOLDER, $s),
+        );
+    }
+
+    /** Canonical -> destination form: replace placeholder with local site URL. */
+    public static function rewriteIncoming(string $raw, string $siteUrl): string
+    {
+        return SerializedPhpHandler::transformStrings(
+            $raw,
+            static fn(string $s): string => str_replace(self::SITE_URL_PLACEHOLDER, $siteUrl, $s),
+        );
+    }
+
+    private static function canonicalUrl(string $u): string
+    {
+        return rtrim($u, '/');
+    }
+
+    /** Options that must never be synced (they identify the site itself). */
+    public static function isExcludedOption(string $name): bool
+    {
+        static $excluded = [
+            'siteurl' => true,
+            'home' => true,
+            'blog_charset' => false, // safe to sync; left for example
+        ];
+        if (isset($excluded[$name]) && $excluded[$name]) {
+            return true;
+        }
+        if (str_starts_with($name, '_transient_')) return true;
+        if (str_starts_with($name, '_site_transient_')) return true;
+        return false;
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Snapshot/SchemaInspector.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Snapshot/SchemaInspector.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Snapshot;
+
+use WpSync\Encoding\CanonicalEncoder;
+
+final class SchemaInspector
+{
+    /**
+     * @return array{pk:string[], columns:string[], schemaHash:string}
+     */
+    public static function inspect(\SQLite3 $db, string $table): array
+    {
+        $info = [];
+        $res = $db->query('PRAGMA table_info(' . self::quoteIdent($table) . ')');
+        while ($row = $res->fetchArray(SQLITE3_ASSOC)) {
+            $info[] = $row;
+        }
+        if (!$info) {
+            throw new \RuntimeException("Table not found: {$table}");
+        }
+        $pk = [];
+        $cols = [];
+        $pkInfo = [];
+        foreach ($info as $c) {
+            $cols[] = $c['name'];
+            if ((int)$c['pk'] > 0) {
+                $pkInfo[(int)$c['pk']] = $c['name'];
+            }
+        }
+        ksort($pkInfo);
+        $pk = array_values($pkInfo);
+
+        // Canonical CREATE TABLE for schema hash: use sqlite_master.
+        $stmt = $db->prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name = ?");
+        $stmt->bindValue(1, $table, SQLITE3_TEXT);
+        $r = $stmt->execute();
+        $sql = (string)($r->fetchArray(SQLITE3_ASSOC)['sql'] ?? '');
+        $canonical = self::canonicalizeCreateTable($sql);
+        $schemaHash = CanonicalEncoder::hashBytes($canonical);
+
+        return ['pk' => $pk, 'columns' => $cols, 'schemaHash' => $schemaHash];
+    }
+
+    public static function canonicalizeCreateTable(string $sql): string
+    {
+        // Collapse whitespace, strip comments, uppercase keywords. Good enough
+        // to detect meaningful schema changes while ignoring cosmetic diffs.
+        $sql = preg_replace('/--[^\n]*/', '', $sql) ?? $sql;
+        $sql = preg_replace('/\s+/', ' ', $sql) ?? $sql;
+        return trim($sql);
+    }
+
+    public static function quoteIdent(string $name): string
+    {
+        if (!preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $name)) {
+            throw new \InvalidArgumentException("bad identifier: {$name}");
+        }
+        return '"' . $name . '"';
+    }
+
+    /**
+     * Build the primary-key byte string for a row. If no PK, returns rowid packed big-endian.
+     * @param string[] $pk
+     * @param array<string,mixed> $row
+     */
+    public static function makeKey(array $pk, array $row, ?int $rowid): string
+    {
+        if (!$pk) {
+            if ($rowid === null) {
+                throw new \RuntimeException('no pk and no rowid');
+            }
+            return "\x00rowid:" . pack('J', $rowid);
+        }
+        $parts = [];
+        foreach ($pk as $col) {
+            $v = $row[$col] ?? null;
+            $parts[] = $v === null ? 'N' : 'V:' . (string)$v;
+        }
+        return implode("\x1f", $parts);
+    }
+
+    /** List all user tables excluding internal sync tables and sqlite_* tables. */
+    public static function listTables(\SQLite3 $db): array
+    {
+        $out = [];
+        $res = $db->query("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name");
+        while ($row = $res->fetchArray(SQLITE3_ASSOC)) {
+            $n = $row['name'];
+            if (str_starts_with($n, 'sqlite_')) continue;
+            if (str_starts_with($n, '_sync_')) continue;
+            $out[] = $n;
+        }
+        return $out;
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Snapshot/SerializedPhpHandler.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Snapshot/SerializedPhpHandler.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Snapshot;
+
+/**
+ * Deterministic re-serialization of PHP values (PHP serialize() format).
+ *
+ * Problems we address:
+ *  - PHP serialize() preserves insertion order for assoc arrays.
+ *    Two sites with keys inserted in different orders produce different bytes.
+ *  - Length prefixes (s:N:"...") become incorrect when strings are mutated
+ *    (e.g., after URL rewriting).
+ *
+ * This serializer:
+ *  - Sorts associative-array keys lexicographically before serialization.
+ *  - Recomputes string lengths based on current byte length.
+ *  - Supports the subset WordPress uses: null, bool, int, double, string,
+ *    array (assoc + list). Objects deserialize as stdClass but are re-serialized
+ *    in object form with sorted property keys.
+ *  - Rejects inputs containing references (R:, r:) — rare in WP and unsafe to
+ *    "normalize" without breaking identity semantics.
+ */
+final class SerializedPhpHandler
+{
+    /** Quick heuristic: does this string look like a PHP serialized value? */
+    public static function looksSerialized(string $s): bool
+    {
+        if ($s === '') return false;
+        $c = $s[0];
+        if ($c === 'N' && ($s === 'N;' || str_starts_with($s, 'N;'))) return true;
+        if (!in_array($c, ['b','i','d','s','a','O'], true)) return false;
+        if (strlen($s) < 4) return false;
+        return $s[1] === ':';
+    }
+
+    /** Unserialize safely. Returns [ok, value]. */
+    public static function tryUnserialize(string $s): array
+    {
+        // WordPress's `maybe_unserialize` uses @unserialize. We do the same
+        // but also block references which we can't safely normalize.
+        if (str_contains($s, 'R:') || str_contains($s, 'r:')) {
+            return [false, null];
+        }
+        $old = error_reporting(0);
+        try {
+            $v = @unserialize($s, ['allowed_classes' => false]);
+        } finally {
+            error_reporting($old);
+        }
+        if ($v === false && $s !== 'b:0;') {
+            return [false, null];
+        }
+        return [true, $v];
+    }
+
+    /**
+     * Re-serialize deterministically.
+     * - Sort associative-array keys (preserve list indices for sequential lists).
+     * - Recompute string byte-lengths.
+     * - objects (stdClass) are re-serialized as arrays to avoid class-name binding.
+     */
+    public static function serialize(mixed $v): string
+    {
+        if ($v === null) return 'N;';
+        if (is_bool($v)) return 'b:' . ($v ? '1' : '0') . ';';
+        if (is_int($v)) return 'i:' . $v . ';';
+        if (is_float($v)) {
+            // PHP's serialize() uses serialize_precision. Force a deterministic repr.
+            return 'd:' . self::floatRepr($v) . ';';
+        }
+        if (is_string($v)) {
+            return 's:' . strlen($v) . ':"' . $v . '";';
+        }
+        if (is_array($v)) {
+            $isList = array_is_list($v);
+            if (!$isList) {
+                // Sort by key (string compare; numeric keys coerced to int by PHP).
+                // Preserve key types; ksort with SORT_STRING.
+                ksort($v, SORT_STRING);
+            }
+            $body = '';
+            foreach ($v as $k => $val) {
+                $body .= is_int($k) ? 'i:' . $k . ';' : 's:' . strlen((string)$k) . ':"' . $k . '";';
+                $body .= self::serialize($val);
+            }
+            return 'a:' . count($v) . ':{' . $body . '}';
+        }
+        if ($v instanceof \stdClass) {
+            // Serialize as array — we don't track class identity.
+            return self::serialize((array)$v);
+        }
+        throw new \InvalidArgumentException('serialize: unsupported type ' . get_debug_type($v));
+    }
+
+    /** IEEE 754 double -> decimal repr guaranteed to round-trip. */
+    private static function floatRepr(float $f): string
+    {
+        if (is_nan($f)) return 'NAN';
+        if ($f === INF) return 'INF';
+        if ($f === -INF) return '-INF';
+        if ($f === 0.0) return '0';
+        // PHP_FLOAT_DIG = 15 round-trips; use 17 to be lossless.
+        $s = sprintf('%.17G', $f);
+        // Round-trip check: if 15 digits suffices, prefer that for stability.
+        $short = sprintf('%.15G', $f);
+        if ((float)$short === $f) $s = $short;
+        return $s;
+    }
+
+    /**
+     * Apply a string transformation callback to every string inside a (maybe-serialized)
+     * value, normalizing the result. The callback receives plain strings and returns
+     * transformed plain strings.
+     *
+     * If $raw is not serialized, the transformation is applied to the raw string.
+     * If $raw is serialized, it's unserialized, transformed recursively, and
+     * re-serialized with correct length prefixes.
+     */
+    public static function transformStrings(string $raw, callable $xform): string
+    {
+        if (self::looksSerialized($raw)) {
+            [$ok, $value] = self::tryUnserialize($raw);
+            if ($ok) {
+                $walked = self::walk($value, $xform);
+                return self::serialize($walked);
+            }
+        }
+        return $xform($raw);
+    }
+
+    public static function walk(mixed $v, callable $xform): mixed
+    {
+        if (is_string($v)) {
+            // A string inside a serialized value may itself be serialized (nested).
+            if (self::looksSerialized($v)) {
+                [$ok, $inner] = self::tryUnserialize($v);
+                if ($ok) {
+                    return self::serialize(self::walk($inner, $xform));
+                }
+            }
+            return $xform($v);
+        }
+        if (is_array($v)) {
+            $out = [];
+            foreach ($v as $k => $val) {
+                $newKey = is_string($k) ? $xform($k) : $k;
+                $out[$newKey] = self::walk($val, $xform);
+            }
+            return $out;
+        }
+        if ($v instanceof \stdClass) {
+            $arr = (array)$v;
+            $out = new \stdClass();
+            foreach ($arr as $k => $val) {
+                $newKey = is_string($k) ? $xform($k) : $k;
+                $out->$newKey = self::walk($val, $xform);
+            }
+            return $out;
+        }
+        return $v;
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Snapshot/Snapshotter.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Snapshot/Snapshotter.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Snapshot;
+
+use WpSync\Encoding\CanonicalEncoder;
+use WpSync\Store\Chunk;
+use WpSync\Store\ChunkStore;
+use WpSync\Tree\TableTree;
+
+/**
+ * Reads the live WordPress SQLite database and produces a content-addressed
+ * commit in the chunk store.
+ */
+final class Snapshotter
+{
+    public function __construct(
+        private readonly \SQLite3 $db,
+        private readonly ChunkStore $chunks,
+        private readonly string $siteUrl,
+    ) {}
+
+    /**
+     * Produce a commit and return its hash.
+     *
+     * @param string[]       $tables            Tables to include.
+     * @param string[]       $parents           Parent commit hashes.
+     * @param ?string        $priorRootHash     If set, unchanged tables reuse the previous tree.
+     * @param array<string,callable> $rowFilter Optional per-table row filter: name => fn(row):?row
+     */
+    public function commit(
+        array $tables,
+        string $author,
+        string $message,
+        array $parents = [],
+        ?string $priorRootHash = null,
+        array $rowFilters = [],
+    ): string {
+        // Load prior root to reuse unchanged table trees.
+        $priorRoot = null;
+        $priorDirty = null;
+        if ($priorRootHash !== null) {
+            $priorRoot = self::loadRoot($priorRootHash, $this->chunks);
+            if (DirtyTracker::isInstalled($this->db)) {
+                $priorDirty = array_flip(DirtyTracker::dirtyTables($this->db));
+            }
+        }
+
+        $tablesOut = [];
+        foreach ($tables as $t) {
+            $schema = SchemaInspector::inspect($this->db, $t);
+            $reusePrior = $priorRoot
+                && isset($priorRoot['tables'][$t])
+                && $priorRoot['tables'][$t]['schema'] === $schema['schemaHash']
+                && $priorDirty !== null
+                && !isset($priorDirty[$t]);
+
+            if ($reusePrior) {
+                $tablesOut[$t] = $priorRoot['tables'][$t];
+                continue;
+            }
+
+            $filter = $rowFilters[$t] ?? null;
+            $tree = $this->buildTableTree($t, $schema, $filter);
+            $tablesOut[$t] = ['tree' => $tree, 'schema' => $schema['schemaHash']];
+        }
+
+        ksort($tablesOut, SORT_STRING);
+
+        $dbRoot = ['tables' => $tablesOut];
+        $rootBytes = CanonicalEncoder::encode($dbRoot);
+        $rootRefs = [];
+        foreach ($tablesOut as $t) {
+            $rootRefs[] = $t['tree'];
+        }
+        $rootChunk = Chunk::of($rootBytes, $rootRefs);
+        $this->chunks->putMany([$rootChunk]);
+
+        $commit = [
+            'root' => $rootChunk->hash,
+            'parents' => array_values($parents),
+            'author' => $author,
+            'message' => $message,
+            'timestamp' => time(),
+        ];
+        $commitBytes = CanonicalEncoder::encode($commit);
+        $commitChunk = Chunk::of($commitBytes, array_merge([$rootChunk->hash], $commit['parents']));
+        $this->chunks->putMany([$commitChunk]);
+
+        // Clear dirty log after successful commit.
+        if (DirtyTracker::isInstalled($this->db)) {
+            DirtyTracker::clear($this->db);
+        }
+
+        return $commitChunk->hash;
+    }
+
+    private function buildTableTree(string $table, array $schema, ?callable $filter): string
+    {
+        $pk = $schema['pk'];
+        $cols = $schema['columns'];
+        $quoted = SchemaInspector::quoteIdent($table);
+        $selectCols = $pk ? implode(',', array_map([SchemaInspector::class, 'quoteIdent'], $cols))
+                          : 'rowid AS __sync_rowid__, ' . implode(',', array_map([SchemaInspector::class, 'quoteIdent'], $cols));
+        $res = $this->db->query("SELECT {$selectCols} FROM {$quoted}");
+
+        $entries = [];
+        while ($row = $res->fetchArray(SQLITE3_ASSOC)) {
+            $rowid = $pk ? null : (int)$row['__sync_rowid__'];
+            if (!$pk) unset($row['__sync_rowid__']);
+
+            if ($filter !== null) {
+                $row = $filter($row);
+                if ($row === null) continue;
+            }
+
+            $normalized = RowNormalizer::normalizeForEncode($row, $this->siteUrl);
+            $key = SchemaInspector::makeKey($pk, $row, $rowid);
+            $value = CanonicalEncoder::encode($normalized);
+            $entries[] = [$key, $value];
+        }
+
+        return TableTree::build($entries, $this->chunks);
+    }
+
+    public static function loadCommit(string $hash, ChunkStore $chunks): array
+    {
+        $got = $chunks->getMany([$hash]);
+        if (!isset($got[$hash])) {
+            throw new \RuntimeException('commit not found: ' . $hash);
+        }
+        return CanonicalEncoder::decode($got[$hash]->bytes);
+    }
+
+    public static function loadRoot(string $hash, ChunkStore $chunks): array
+    {
+        $got = $chunks->getMany([$hash]);
+        if (!isset($got[$hash])) {
+            throw new \RuntimeException('root not found: ' . $hash);
+        }
+        return CanonicalEncoder::decode($got[$hash]->bytes);
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Store/Chunk.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Store/Chunk.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Store;
+
+final class Chunk
+{
+    public function __construct(
+        public readonly string $hash,
+        public readonly string $bytes,
+        public readonly array $refs = [],
+    ) {}
+
+    /** Compute hash and build a chunk. */
+    public static function of(string $bytes, array $refs = []): self
+    {
+        return new self(hash('sha256', $bytes), $bytes, array_values($refs));
+    }
+
+    /** Verify hash matches content. */
+    public function verify(): void
+    {
+        $actual = hash('sha256', $this->bytes);
+        if (!hash_equals($this->hash, $actual)) {
+            throw new \RuntimeException("Chunk hash mismatch: declared={$this->hash} actual={$actual}");
+        }
+        foreach ($this->refs as $r) {
+            if (!is_string($r) || !preg_match('/^[0-9a-f]{64}$/', $r)) {
+                throw new \RuntimeException('Chunk has invalid ref: ' . var_export($r, true));
+            }
+        }
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Store/ChunkStore.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Store/ChunkStore.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Store;
+
+interface ChunkStore
+{
+    /**
+     * @param string[] $hashes
+     * @return array<string, true> hash => true for each present hash
+     */
+    public function hasMany(array $hashes): array;
+
+    /**
+     * @param string[] $hashes
+     * @return array<string, Chunk> hash => Chunk for each found; missing hashes are omitted
+     */
+    public function getMany(array $hashes): array;
+
+    /**
+     * @param Chunk[] $chunks
+     * MUST verify hash matches content and reject bad chunks.
+     */
+    public function putMany(array $chunks): void;
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Store/HttpChunkStore.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Store/HttpChunkStore.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Store;
+
+/**
+ * HTTP-backed chunk store. Talks to the sync mu-plugin REST API.
+ *
+ * The transport callable must be one of:
+ *   - null: uses curl
+ *   - callable(string $method, string $path, ?string $body, array $headers): array{status:int, body:string}
+ */
+final class HttpChunkStore implements ChunkStore
+{
+    private $transport;
+
+    public function __construct(
+        private readonly string $baseUrl,
+        private readonly string $user,
+        private readonly string $appPassword,
+        ?callable $transport = null,
+    ) {
+        $this->transport = $transport ?? [$this, 'curlRequest'];
+    }
+
+    public function hasMany(array $hashes): array
+    {
+        if (!$hashes) return [];
+        $resp = $this->post('/wp-json/sync/v1/chunks/has', ['hashes' => array_values($hashes)]);
+        return isset($resp['present']) && is_array($resp['present']) ? $resp['present'] : [];
+    }
+
+    public function getMany(array $hashes): array
+    {
+        if (!$hashes) return [];
+        $resp = $this->post('/wp-json/sync/v1/chunks/get', ['hashes' => array_values($hashes)]);
+        $out = [];
+        foreach ($resp['chunks'] ?? [] as $c) {
+            $raw = base64_decode($c['data'], true);
+            if ($raw === false) {
+                throw new \RuntimeException('HttpChunkStore: base64 decode failed for ' . ($c['hash'] ?? '?'));
+            }
+            $chunk = new Chunk($c['hash'], $raw, $c['refs'] ?? []);
+            $chunk->verify();
+            $out[$chunk->hash] = $chunk;
+        }
+        return $out;
+    }
+
+    public function putMany(array $chunks): void
+    {
+        if (!$chunks) return;
+        $payload = ['chunks' => []];
+        foreach ($chunks as $c) {
+            if (!$c instanceof Chunk) throw new \InvalidArgumentException('expected Chunk');
+            $c->verify();
+            $payload['chunks'][] = [
+                'hash' => $c->hash,
+                'data' => base64_encode($c->bytes),
+                'refs' => $c->refs,
+            ];
+        }
+        $this->post('/wp-json/sync/v1/chunks/put', $payload);
+    }
+
+    public function getAllRefs(): array
+    {
+        return $this->request('GET', '/wp-json/sync/v1/refs', null);
+    }
+
+    public function casRef(string $name, ?string $expectedOld, string $newHash): bool
+    {
+        $resp = $this->request('PUT', '/wp-json/sync/v1/refs/' . rawurlencode($name), [
+            'old' => $expectedOld,
+            'new' => $newHash,
+        ], allowStatus: [200, 409]);
+        return !empty($resp['ok']);
+    }
+
+    private function post(string $path, array $body): array
+    {
+        return $this->request('POST', $path, $body);
+    }
+
+    private function request(string $method, string $path, ?array $body, array $allowStatus = [200]): array
+    {
+        $bodyJson = $body === null ? null : json_encode($body, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        $headers = ['Content-Type: application/json', 'Accept: application/json'];
+        $headers[] = 'Authorization: Basic ' . base64_encode($this->user . ':' . $this->appPassword);
+        $r = ($this->transport)($method, $path, $bodyJson, $headers);
+        if (!in_array($r['status'], $allowStatus, true)) {
+            throw new \RuntimeException("HTTP {$method} {$path} failed: HTTP {$r['status']} body=" . substr($r['body'], 0, 512));
+        }
+        if ($r['body'] === '') return [];
+        return json_decode($r['body'], true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    private function curlRequest(string $method, string $path, ?string $body, array $headers): array
+    {
+        $ch = curl_init($this->baseUrl . $path);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        if ($body !== null) {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+        }
+        curl_setopt($ch, CURLOPT_TIMEOUT, 60);
+        $resp = curl_exec($ch);
+        if ($resp === false) {
+            throw new \RuntimeException('curl error: ' . curl_error($ch));
+        }
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+        return ['status' => (int)$status, 'body' => (string)$resp];
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Store/RefStore.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Store/RefStore.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Store;
+
+interface RefStore
+{
+    public function getRef(string $name): ?string;
+
+    /** @return array<string,string> name => hash */
+    public function listRefs(string $prefix = ''): array;
+
+    /**
+     * Atomic compare-and-swap.
+     * $expectedOldHash === null means "ref must not exist".
+     * Returns true on success, false on mismatch.
+     */
+    public function casRef(string $name, ?string $expectedOldHash, string $newHash): bool;
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Store/SQLiteChunkStore.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Store/SQLiteChunkStore.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Store;
+
+final class SQLiteChunkStore implements ChunkStore
+{
+    private \SQLite3 $db;
+
+    public function __construct(string $path)
+    {
+        $this->db = new \SQLite3($path, SQLITE3_OPEN_CREATE | SQLITE3_OPEN_READWRITE);
+        $this->db->enableExceptions(true);
+        $this->db->exec('PRAGMA journal_mode=WAL');
+        $this->db->exec('PRAGMA synchronous=NORMAL');
+        $this->db->exec('PRAGMA foreign_keys=ON');
+        $this->db->exec(<<<SQL
+            CREATE TABLE IF NOT EXISTS chunks (
+                hash TEXT PRIMARY KEY,
+                data BLOB NOT NULL,
+                refs TEXT NOT NULL DEFAULT '[]'
+            )
+        SQL);
+    }
+
+    public function db(): \SQLite3
+    {
+        return $this->db;
+    }
+
+    public function close(): void
+    {
+        $this->db->close();
+    }
+
+    public function hasMany(array $hashes): array
+    {
+        $out = [];
+        if (!$hashes) return $out;
+        foreach (array_chunk(array_values($hashes), 200) as $batch) {
+            $marks = implode(',', array_fill(0, count($batch), '?'));
+            $stmt = $this->db->prepare("SELECT hash FROM chunks WHERE hash IN ($marks)");
+            foreach ($batch as $i => $h) {
+                $stmt->bindValue($i + 1, $h, SQLITE3_TEXT);
+            }
+            $res = $stmt->execute();
+            while ($row = $res->fetchArray(SQLITE3_ASSOC)) {
+                $out[$row['hash']] = true;
+            }
+        }
+        return $out;
+    }
+
+    public function getMany(array $hashes): array
+    {
+        $out = [];
+        if (!$hashes) return $out;
+        foreach (array_chunk(array_values($hashes), 200) as $batch) {
+            $marks = implode(',', array_fill(0, count($batch), '?'));
+            $stmt = $this->db->prepare("SELECT hash, data, refs FROM chunks WHERE hash IN ($marks)");
+            foreach ($batch as $i => $h) {
+                $stmt->bindValue($i + 1, $h, SQLITE3_TEXT);
+            }
+            $res = $stmt->execute();
+            while ($row = $res->fetchArray(SQLITE3_ASSOC)) {
+                $refs = json_decode($row['refs'], true, flags: JSON_THROW_ON_ERROR);
+                $out[$row['hash']] = new Chunk($row['hash'], $row['data'], $refs);
+            }
+        }
+        return $out;
+    }
+
+    public function putMany(array $chunks): void
+    {
+        if (!$chunks) return;
+        $this->db->exec('BEGIN IMMEDIATE');
+        try {
+            $stmt = $this->db->prepare(
+                'INSERT OR IGNORE INTO chunks (hash, data, refs) VALUES (?, ?, ?)'
+            );
+            foreach ($chunks as $c) {
+                if (!$c instanceof Chunk) {
+                    throw new \InvalidArgumentException('putMany expects Chunk objects');
+                }
+                $c->verify();
+                $stmt->bindValue(1, $c->hash, SQLITE3_TEXT);
+                $stmt->bindValue(2, $c->bytes, SQLITE3_BLOB);
+                $stmt->bindValue(3, json_encode($c->refs, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR), SQLITE3_TEXT);
+                $stmt->execute();
+                $stmt->reset();
+            }
+            $this->db->exec('COMMIT');
+        } catch (\Throwable $e) {
+            $this->db->exec('ROLLBACK');
+            throw $e;
+        }
+    }
+
+    public function count(): int
+    {
+        $res = $this->db->query('SELECT COUNT(*) AS n FROM chunks');
+        $row = $res->fetchArray(SQLITE3_ASSOC);
+        return (int)$row['n'];
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Store/SQLiteRefStore.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Store/SQLiteRefStore.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Store;
+
+final class SQLiteRefStore implements RefStore
+{
+    public function __construct(private readonly \SQLite3 $db)
+    {
+        $this->db->enableExceptions(true);
+        $this->db->exec(<<<SQL
+            CREATE TABLE IF NOT EXISTS refs (
+                name TEXT PRIMARY KEY,
+                hash TEXT NOT NULL
+            )
+        SQL);
+    }
+
+    public static function open(string $path): self
+    {
+        $db = new \SQLite3($path, SQLITE3_OPEN_CREATE | SQLITE3_OPEN_READWRITE);
+        $db->enableExceptions(true);
+        $db->exec('PRAGMA journal_mode=WAL');
+        $db->exec('PRAGMA synchronous=NORMAL');
+        return new self($db);
+    }
+
+    public function getRef(string $name): ?string
+    {
+        $stmt = $this->db->prepare('SELECT hash FROM refs WHERE name = ?');
+        $stmt->bindValue(1, $name, SQLITE3_TEXT);
+        $res = $stmt->execute();
+        $row = $res->fetchArray(SQLITE3_ASSOC);
+        return $row ? (string)$row['hash'] : null;
+    }
+
+    public function listRefs(string $prefix = ''): array
+    {
+        $out = [];
+        if ($prefix === '') {
+            $res = $this->db->query('SELECT name, hash FROM refs');
+        } else {
+            $stmt = $this->db->prepare('SELECT name, hash FROM refs WHERE name LIKE ?');
+            $stmt->bindValue(1, $prefix . '%', SQLITE3_TEXT);
+            $res = $stmt->execute();
+        }
+        while ($row = $res->fetchArray(SQLITE3_ASSOC)) {
+            $out[$row['name']] = $row['hash'];
+        }
+        return $out;
+    }
+
+    public function casRef(string $name, ?string $expectedOldHash, string $newHash): bool
+    {
+        $this->db->exec('BEGIN IMMEDIATE');
+        try {
+            if ($expectedOldHash === null) {
+                $stmt = $this->db->prepare('INSERT OR IGNORE INTO refs (name, hash) VALUES (?, ?)');
+                $stmt->bindValue(1, $name, SQLITE3_TEXT);
+                $stmt->bindValue(2, $newHash, SQLITE3_TEXT);
+                $stmt->execute();
+                $ok = $this->db->changes() === 1;
+            } else {
+                $stmt = $this->db->prepare('UPDATE refs SET hash = ? WHERE name = ? AND hash = ?');
+                $stmt->bindValue(1, $newHash, SQLITE3_TEXT);
+                $stmt->bindValue(2, $name, SQLITE3_TEXT);
+                $stmt->bindValue(3, $expectedOldHash, SQLITE3_TEXT);
+                $stmt->execute();
+                $ok = $this->db->changes() === 1;
+            }
+            $this->db->exec($ok ? 'COMMIT' : 'ROLLBACK');
+            return $ok;
+        } catch (\Throwable $e) {
+            $this->db->exec('ROLLBACK');
+            throw $e;
+        }
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Sync/FetchCommand.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Sync/FetchCommand.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Sync;
+
+use WpSync\Store\ChunkStore;
+use WpSync\Store\HttpChunkStore;
+use WpSync\Store\RefStore;
+
+/**
+ * Fetch flow:
+ *   1. remoteHash = remote.refs.get(refs/heads/main)
+ *   2. localTrackingHash = localRefs.get(refs/remotes/origin/main)
+ *   3. copyReachable(localChunks, remoteChunks, remoteHash)
+ *   4. localRefs.cas(refs/remotes/origin/main, oldTracking, remoteHash)
+ */
+final class FetchCommand
+{
+    public function __construct(
+        private readonly SyncEngine $engine,
+        private readonly ChunkStore $localChunks,
+        private readonly RefStore $localRefs,
+        private readonly HttpChunkStore $remote,
+    ) {}
+
+    public function run(string $refName = 'refs/heads/main', string $trackingName = 'refs/remotes/origin/main'): array
+    {
+        $remoteRefs = $this->remote->getAllRefs();
+        $remoteHash = $remoteRefs[$refName] ?? null;
+        if ($remoteHash === null) {
+            return ['transferred' => 0, 'hash' => null, 'status' => 'empty-remote'];
+        }
+        $localTracking = $this->localRefs->getRef($trackingName);
+        $transferred = 0;
+        if ($localTracking !== $remoteHash) {
+            $transferred = $this->engine->copyReachable($this->localChunks, $this->remote, $remoteHash);
+            $ok = $this->localRefs->casRef($trackingName, $localTracking, $remoteHash);
+            if (!$ok) {
+                throw new \RuntimeException('fetch: local tracking ref moved concurrently');
+            }
+        }
+        return ['transferred' => $transferred, 'hash' => $remoteHash, 'status' => 'ok'];
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Sync/PushCommand.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Sync/PushCommand.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Sync;
+
+use WpSync\Store\ChunkStore;
+use WpSync\Store\HttpChunkStore;
+use WpSync\Store\RefStore;
+
+/**
+ * Push flow:
+ *   1. Read local and remote ref hashes.
+ *   2. If equal, no-op.
+ *   3. Verify fast-forward (remote is ancestor of local).
+ *   4. copyReachable(remoteChunks, localChunks, localHash).
+ *   5. casRef(remote, name, expected=remoteOld, new=localHash). If fail: abort.
+ */
+final class PushCommand
+{
+    public function __construct(
+        private readonly SyncEngine $engine,
+        private readonly ChunkStore $localChunks,
+        private readonly RefStore $localRefs,
+        private readonly HttpChunkStore $remote,
+    ) {}
+
+    public function run(string $refName = 'refs/heads/main'): array
+    {
+        $localHash = $this->localRefs->getRef($refName);
+        if ($localHash === null) {
+            throw new \RuntimeException("no local ref: {$refName}");
+        }
+        $remoteRefs = $this->remote->getAllRefs();
+        $remoteHash = $remoteRefs[$refName] ?? null;
+
+        if ($localHash === $remoteHash) {
+            return ['transferred' => 0, 'status' => 'up-to-date'];
+        }
+        if ($remoteHash !== null && !$this->engine->isFastForward($this->localChunks, $localHash, $remoteHash)) {
+            throw new \RuntimeException('push rejected: non-fast-forward');
+        }
+
+        $transferred = $this->engine->copyReachable($this->remote, $this->localChunks, $localHash);
+
+        $ok = $this->remote->casRef($refName, $remoteHash, $localHash);
+        if (!$ok) {
+            throw new \RuntimeException('push rejected: remote ref moved concurrently; pull first');
+        }
+        return ['transferred' => $transferred, 'status' => 'pushed'];
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Sync/SyncEngine.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Sync/SyncEngine.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Sync;
+
+use WpSync\Store\Chunk;
+use WpSync\Store\ChunkStore;
+use WpSync\Store\RefStore;
+use WpSync\Snapshot\Snapshotter;
+use WpSync\Encoding\CanonicalEncoder;
+
+final class SyncEngine
+{
+    public int $getManyCalls = 0;
+
+    /**
+     * Walk the DAG from $rootHash. Copy every chunk reachable from it
+     * that is not already present in $to. Writes are ordered so each chunk's
+     * children are present before it.
+     *
+     * Returns count of chunks transferred.
+     */
+    public function copyReachable(
+        ChunkStore $to,
+        ChunkStore $from,
+        string $rootHash,
+        int $batchSize = 256,
+    ): int {
+        $transferred = 0;
+        $seen = [];            // hashes we've already scheduled or processed
+        $queue = [$rootHash];
+        $seen[$rootHash] = true;
+
+        // Phase 1: discovery — collect all reachable chunks missing from $to.
+        // Phase 2: topological write — write children before parents.
+        //
+        // Since we don't know refs until we fetch the chunk, we do interleaved
+        // discovery: ask `hasMany` first to avoid fetching present chunks.
+
+        $pendingChunks = []; // hash => Chunk (fetched but not yet written)
+        $childrenOf = [];    // hash => string[] of child hashes
+
+        while ($queue) {
+            $batch = array_splice($queue, 0, $batchSize);
+            // Ask remote's target which are already present.
+            $present = $to->hasMany($batch);
+
+            $need = [];
+            foreach ($batch as $h) {
+                if (isset($present[$h])) continue;
+                $need[] = $h;
+            }
+
+            if ($need) {
+                $this->getManyCalls++;
+                $got = $from->getMany($need);
+                if (count($got) !== count($need)) {
+                    $missing = array_diff($need, array_keys($got));
+                    throw new \RuntimeException('sync: getMany returned fewer than requested: ' . implode(',', $missing));
+                }
+                foreach ($got as $h => $c) {
+                    $c->verify();
+                    $pendingChunks[$h] = $c;
+                    $childrenOf[$h] = $c->refs;
+                    foreach ($c->refs as $child) {
+                        if (!isset($seen[$child])) {
+                            $seen[$child] = true;
+                            $queue[] = $child;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Topological write: a chunk is ready when all its children are either
+        // already in $to or have been written in this run.
+        $written = [];
+        $writtenCount = 0;
+        // We combine "present in target" with "written in this run" into a
+        // single "exists" check. We'll check target presence in batches when needed.
+
+        // First, batch-check which pendings' children are already in $to.
+        $childrenAll = [];
+        foreach ($pendingChunks as $h => $c) {
+            foreach ($c->refs as $cref) {
+                $childrenAll[$cref] = true;
+            }
+        }
+        $targetPresent = $to->hasMany(array_keys($childrenAll));
+
+        while ($pendingChunks) {
+            $writeBatch = [];
+            foreach ($pendingChunks as $h => $c) {
+                $ready = true;
+                foreach ($c->refs as $child) {
+                    if (isset($written[$child])) continue;
+                    if (isset($targetPresent[$child])) continue;
+                    if (isset($pendingChunks[$child])) { $ready = false; break; }
+                    // Not in any known set — impossible if we tracked refs correctly.
+                    // Optimistically re-check target.
+                    $ready = false; break;
+                }
+                if ($ready) {
+                    $writeBatch[$h] = $c;
+                    if (count($writeBatch) >= $batchSize) break;
+                }
+            }
+            if (!$writeBatch) {
+                // Cycle or missing dependency.
+                throw new \RuntimeException('sync: cycle or missing dependency in DAG (pending=' . count($pendingChunks) . ')');
+            }
+            $to->putMany(array_values($writeBatch));
+            foreach ($writeBatch as $h => $_) {
+                $written[$h] = true;
+                unset($pendingChunks[$h]);
+                $writtenCount++;
+            }
+        }
+        return $writtenCount;
+    }
+
+    /** True iff walking local commit parents from $localRefHash reaches $remoteRefHash. */
+    public function isFastForward(ChunkStore $store, string $localRefHash, ?string $remoteRefHash): bool
+    {
+        if ($remoteRefHash === null) return true;
+        if ($localRefHash === $remoteRefHash) return true;
+        $seen = [];
+        $q = [$localRefHash];
+        while ($q) {
+            $h = array_shift($q);
+            if (isset($seen[$h])) continue;
+            $seen[$h] = true;
+            if ($h === $remoteRefHash) return true;
+            $got = $store->getMany([$h]);
+            if (!isset($got[$h])) return false;
+            $commit = CanonicalEncoder::decode($got[$h]->bytes);
+            foreach ($commit['parents'] ?? [] as $p) {
+                if (!isset($seen[$p])) $q[] = $p;
+            }
+        }
+        return false;
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Tree/InternalNode.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Tree/InternalNode.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Tree;
+
+use WpSync\Encoding\CanonicalEncoder;
+use WpSync\Store\Chunk;
+
+/**
+ * Internal node: sorted list of [separator_key, child_hash] pairs.
+ * The separator_key is the MINIMUM key of the subtree rooted at child_hash.
+ *
+ * Encoded CBOR body:
+ *   { "type": "internal", "children": [[sep_key, hash], ...] }
+ */
+final class InternalNode
+{
+    /** @param array<int,array{0:string,1:string}> $children */
+    public function __construct(public readonly array $children) {}
+
+    public function toChunk(): Chunk
+    {
+        $payload = [
+            'type' => 'internal',
+            'children' => array_map(
+                static fn(array $c) => [
+                    CanonicalEncoder::bytes($c[0]),
+                    $c[1], // child hash is hex text
+                ],
+                $this->children,
+            ),
+        ];
+        $bytes = CanonicalEncoder::encode($payload);
+        $refs = array_map(static fn(array $c) => $c[1], $this->children);
+        return Chunk::of($bytes, $refs);
+    }
+
+    public static function fromDecoded(array $decoded): self
+    {
+        if (($decoded['type'] ?? null) !== 'internal') {
+            throw new \RuntimeException('not an internal node');
+        }
+        $children = [];
+        foreach ($decoded['children'] as $pair) {
+            $children[] = [$pair[0], $pair[1]];
+        }
+        return new self($children);
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Tree/LeafNode.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Tree/LeafNode.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Tree;
+
+use WpSync\Encoding\CanonicalEncoder;
+use WpSync\Store\Chunk;
+
+/**
+ * Leaf node: sorted list of [key,value] byte-string pairs.
+ *
+ * Encoded CBOR body:
+ *   { "type": "leaf", "entries": [[key,value], [key,value], ...] }
+ *
+ * Both key and value encode as CBOR byte strings (not text).
+ */
+final class LeafNode
+{
+    /** @param array<int,array{0:string,1:string}> $entries */
+    public function __construct(public readonly array $entries) {}
+
+    public function toChunk(): Chunk
+    {
+        $payload = [
+            'type' => 'leaf',
+            'entries' => array_map(
+                static fn(array $e) => [
+                    CanonicalEncoder::bytes($e[0]),
+                    CanonicalEncoder::bytes($e[1]),
+                ],
+                $this->entries,
+            ),
+        ];
+        $bytes = CanonicalEncoder::encode($payload);
+        return Chunk::of($bytes, []);
+    }
+
+    /** Inverse of toChunk: parse a decoded payload back into a LeafNode. */
+    public static function fromDecoded(array $decoded): self
+    {
+        if (($decoded['type'] ?? null) !== 'leaf') {
+            throw new \RuntimeException('not a leaf node');
+        }
+        $entries = [];
+        foreach ($decoded['entries'] as $pair) {
+            $entries[] = [$pair[0], $pair[1]];
+        }
+        return new self($entries);
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Tree/TableTree.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Tree/TableTree.php
@@ -1,0 +1,238 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Tree;
+
+use WpSync\Encoding\CanonicalEncoder;
+use WpSync\Store\Chunk;
+use WpSync\Store\ChunkStore;
+
+/**
+ * Sorted B-tree over byte-string keys, all nodes are content-addressed chunks.
+ * Built bottom-up from sorted entries; deterministic (same entries -> same root).
+ */
+final class TableTree
+{
+    public const FANOUT = 64;
+
+    /**
+     * @param array<int,array{0:string,1:string}> $entries Unordered [key,value] pairs.
+     * @return string Root chunk hash.
+     */
+    public static function build(array $entries, ChunkStore $store, int $fanout = self::FANOUT): string
+    {
+        // Deduplicate by key (last wins) and sort by key bytes.
+        $map = [];
+        foreach ($entries as $e) {
+            $map[$e[0]] = $e[1];
+        }
+        ksort($map, SORT_STRING);
+        $sorted = [];
+        foreach ($map as $k => $v) {
+            $sorted[] = [(string)$k, (string)$v];
+        }
+
+        // Empty tree: single empty leaf.
+        if ($sorted === []) {
+            $leaf = new LeafNode([]);
+            $chunk = $leaf->toChunk();
+            $store->putMany([$chunk]);
+            return $chunk->hash;
+        }
+
+        // Build leaves.
+        $level = [];
+        $pages = array_chunk($sorted, $fanout);
+        $chunks = [];
+        foreach ($pages as $page) {
+            $leaf = new LeafNode($page);
+            $chunk = $leaf->toChunk();
+            $chunks[] = $chunk;
+            $level[] = [$page[0][0], $chunk->hash]; // separator = min key in page
+        }
+        $store->putMany($chunks);
+
+        // Build internal levels until single root.
+        while (count($level) > 1) {
+            $next = [];
+            $levelChunks = [];
+            foreach (array_chunk($level, $fanout) as $group) {
+                $node = new InternalNode($group);
+                $chunk = $node->toChunk();
+                $levelChunks[] = $chunk;
+                $next[] = [$group[0][0], $chunk->hash];
+            }
+            $store->putMany($levelChunks);
+            $level = $next;
+        }
+        return $level[0][1];
+    }
+
+    public static function get(string $rootHash, string $key, ChunkStore $store): ?string
+    {
+        $nodeHash = $rootHash;
+        while (true) {
+            $decoded = self::loadNode($nodeHash, $store);
+            if (($decoded['type'] ?? null) === 'leaf') {
+                foreach ($decoded['entries'] as $pair) {
+                    if ($pair[0] === $key) {
+                        return $pair[1];
+                    }
+                }
+                return null;
+            }
+            // internal: find rightmost child whose separator <= key
+            $childHash = null;
+            foreach ($decoded['children'] as $pair) {
+                if (strcmp($pair[0], $key) <= 0) {
+                    $childHash = $pair[1];
+                } else {
+                    break;
+                }
+            }
+            if ($childHash === null) {
+                return null; // key precedes first separator
+            }
+            $nodeHash = $childHash;
+        }
+    }
+
+    /**
+     * Iterate all entries in sorted order.
+     * @return \Generator<int,array{0:string,1:string}>
+     */
+    public static function iterate(string $rootHash, ChunkStore $store): \Generator
+    {
+        yield from self::iterateNode($rootHash, $store);
+    }
+
+    private static function iterateNode(string $nodeHash, ChunkStore $store): \Generator
+    {
+        $decoded = self::loadNode($nodeHash, $store);
+        if (($decoded['type'] ?? null) === 'leaf') {
+            foreach ($decoded['entries'] as $pair) {
+                yield [$pair[0], $pair[1]];
+            }
+            return;
+        }
+        foreach ($decoded['children'] as $c) {
+            yield from self::iterateNode($c[1], $store);
+        }
+    }
+
+    /**
+     * Diff two trees. Yields triples [key, valueA|null, valueB|null]
+     * for entries that differ. Entries present in only one side have null on the other.
+     * Subtrees with identical hashes are skipped (O(log n) behavior for small diffs).
+     *
+     * @return \Generator<int,array{0:string,1:?string,2:?string}>
+     */
+    public static function diff(string $rootA, string $rootB, ChunkStore $store): \Generator
+    {
+        if ($rootA === $rootB) return;
+
+        // Stack of [hashA|null, hashB|null, isLeafA, isLeafB]
+        // We traverse in sync, descending where hashes differ.
+        yield from self::diffNodes($rootA, $rootB, $store);
+    }
+
+    private static function diffNodes(?string $hashA, ?string $hashB, ChunkStore $store): \Generator
+    {
+        if ($hashA === $hashB) return;
+
+        $a = $hashA !== null ? self::loadNode($hashA, $store) : null;
+        $b = $hashB !== null ? self::loadNode($hashB, $store) : null;
+
+        $aIsLeaf = $a !== null && ($a['type'] ?? null) === 'leaf';
+        $bIsLeaf = $b !== null && ($b['type'] ?? null) === 'leaf';
+
+        if (($a === null || $aIsLeaf) && ($b === null || $bIsLeaf)) {
+            // Compare two leaves (or leaf vs missing) directly.
+            $entriesA = $a ? $a['entries'] : [];
+            $entriesB = $b ? $b['entries'] : [];
+            yield from self::diffLeafEntries($entriesA, $entriesB);
+            return;
+        }
+
+        // At least one side is internal. Flatten sides to a list of
+        // (minKey, maxKey, childHash, isLeaf) to walk in sorted order.
+        $aChildren = self::nodeToChildRanges($a, $hashA);
+        $bChildren = self::nodeToChildRanges($b, $hashB);
+
+        // Walk both child lists in parallel by key range.
+        $i = 0;
+        $j = 0;
+        while ($i < count($aChildren) || $j < count($bChildren)) {
+            $ca = $aChildren[$i] ?? null;
+            $cb = $bChildren[$j] ?? null;
+            if ($ca && $cb && $ca['min'] === $cb['min']) {
+                // Same key range entry point — descend both.
+                if ($ca['hash'] !== $cb['hash']) {
+                    yield from self::diffNodes($ca['hash'], $cb['hash'], $store);
+                }
+                $i++; $j++;
+                continue;
+            }
+            if ($cb === null || ($ca !== null && strcmp($ca['min'], $cb['min']) < 0)) {
+                // only-in-A subtree
+                yield from self::diffNodes($ca['hash'], null, $store);
+                $i++;
+            } else {
+                yield from self::diffNodes(null, $cb['hash'], $store);
+                $j++;
+            }
+        }
+    }
+
+    private static function nodeToChildRanges(?array $node, ?string $selfHash): array
+    {
+        // For internal nodes: list their children. For leaf nodes, treat as a single child
+        // (so diffNodes can descend into diffLeafEntries on the next recursion).
+        if ($node === null) return [];
+        if (($node['type'] ?? null) === 'leaf') {
+            if ($node['entries'] === []) {
+                return [];
+            }
+            return [[
+                'min' => $node['entries'][0][0],
+                'hash' => $selfHash,
+                'leaf' => true,
+            ]];
+        }
+        $out = [];
+        foreach ($node['children'] as $c) {
+            $out[] = ['min' => $c[0], 'hash' => $c[1], 'leaf' => false];
+        }
+        return $out;
+    }
+
+    private static function diffLeafEntries(array $a, array $b): \Generator
+    {
+        $ai = 0; $bi = 0;
+        while ($ai < count($a) || $bi < count($b)) {
+            $ea = $a[$ai] ?? null;
+            $eb = $b[$bi] ?? null;
+            if ($ea && $eb && $ea[0] === $eb[0]) {
+                if ($ea[1] !== $eb[1]) {
+                    yield [$ea[0], $ea[1], $eb[1]];
+                }
+                $ai++; $bi++;
+            } elseif ($eb === null || ($ea !== null && strcmp($ea[0], $eb[0]) < 0)) {
+                yield [$ea[0], $ea[1], null];
+                $ai++;
+            } else {
+                yield [$eb[0], null, $eb[1]];
+                $bi++;
+            }
+        }
+    }
+
+    private static function loadNode(string $hash, ChunkStore $store): array
+    {
+        $chunks = $store->getMany([$hash]);
+        if (!isset($chunks[$hash])) {
+            throw new \RuntimeException("TableTree: chunk not found: {$hash}");
+        }
+        return CanonicalEncoder::decode($chunks[$hash]->bytes);
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/Tree/TreeDiff.php
+++ b/php-dolt-sync/plugin/wp-sync/src/Tree/TreeDiff.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Tree;
+
+use WpSync\Store\ChunkStore;
+
+/** Thin wrapper around TableTree::diff. */
+final class TreeDiff
+{
+    /** @return \Generator<int,array{0:string,1:?string,2:?string}> */
+    public static function diff(string $rootA, string $rootB, ChunkStore $store): \Generator
+    {
+        yield from TableTree::diff($rootA, $rootB, $store);
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/WordPress/SyncPlugin.php
+++ b/php-dolt-sync/plugin/wp-sync/src/WordPress/SyncPlugin.php
@@ -1,0 +1,139 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\WordPress;
+
+use WpSync\Store\Chunk;
+use WpSync\Store\SQLiteChunkStore;
+use WpSync\Store\SQLiteRefStore;
+use WpSync\Snapshot\DirtyTracker;
+use WpSync\Snapshot\SchemaInspector;
+
+/**
+ * WordPress mu-plugin: exposes /wp-json/sync/v1/* REST endpoints and
+ * installs dirty-tracking triggers on activation.
+ *
+ * Intended to be loaded as: wp-content/mu-plugins/sync.php, which
+ * requires this class.
+ */
+final class SyncPlugin
+{
+    /** Path to the content-addressed chunks/refs database (separate from WP DB). */
+    public static function chunkDbPath(): string
+    {
+        $path = defined('WPSYNC_CHUNK_DB') ? (string)WPSYNC_CHUNK_DB
+                                           : (defined('WP_CONTENT_DIR') ? WP_CONTENT_DIR . '/wpsync-chunks.sqlite' : sys_get_temp_dir() . '/wpsync-chunks.sqlite');
+        return $path;
+    }
+
+    /** Path to the WP SQLite DB (from the sqlite-database-integration plugin). */
+    public static function wpDbPath(): string
+    {
+        if (defined('WPSYNC_WP_DB')) return (string)WPSYNC_WP_DB;
+        $default = defined('WP_CONTENT_DIR') ? WP_CONTENT_DIR . '/database/.ht.sqlite' : '';
+        return $default;
+    }
+
+    public static function bootstrap(): void
+    {
+        if (!function_exists('add_action')) return;
+        add_action('rest_api_init', [self::class, 'registerRoutes']);
+    }
+
+    public static function registerRoutes(): void
+    {
+        $perm = static function (\WP_REST_Request $req) {
+            return current_user_can('manage_options') ? true : new \WP_Error('forbidden', 'forbidden', ['status' => 403]);
+        };
+
+        register_rest_route('sync/v1', '/chunks/has', [
+            'methods' => 'POST',
+            'permission_callback' => $perm,
+            'callback' => [self::class, 'routeHas'],
+        ]);
+        register_rest_route('sync/v1', '/chunks/get', [
+            'methods' => 'POST',
+            'permission_callback' => $perm,
+            'callback' => [self::class, 'routeGet'],
+        ]);
+        register_rest_route('sync/v1', '/chunks/put', [
+            'methods' => 'POST',
+            'permission_callback' => $perm,
+            'callback' => [self::class, 'routePut'],
+        ]);
+        register_rest_route('sync/v1', '/refs', [
+            'methods' => 'GET',
+            'permission_callback' => $perm,
+            'callback' => [self::class, 'routeListRefs'],
+        ]);
+        register_rest_route('sync/v1', '/refs/(?P<name>.+)', [
+            'methods' => 'PUT',
+            'permission_callback' => $perm,
+            'callback' => [self::class, 'routeCasRef'],
+        ]);
+    }
+
+    public static function routeHas(\WP_REST_Request $req): \WP_REST_Response
+    {
+        $hashes = $req->get_param('hashes') ?? [];
+        $cs = new SQLiteChunkStore(self::chunkDbPath());
+        return new \WP_REST_Response(['present' => $cs->hasMany($hashes)]);
+    }
+
+    public static function routeGet(\WP_REST_Request $req): \WP_REST_Response
+    {
+        $hashes = $req->get_param('hashes') ?? [];
+        $cs = new SQLiteChunkStore(self::chunkDbPath());
+        $out = [];
+        foreach ($cs->getMany($hashes) as $c) {
+            $out[] = ['hash' => $c->hash, 'data' => base64_encode($c->bytes), 'refs' => $c->refs];
+        }
+        return new \WP_REST_Response(['chunks' => $out]);
+    }
+
+    public static function routePut(\WP_REST_Request $req): \WP_REST_Response
+    {
+        $chunks = $req->get_param('chunks') ?? [];
+        $cs = new SQLiteChunkStore(self::chunkDbPath());
+        $objs = [];
+        foreach ($chunks as $c) {
+            $raw = base64_decode($c['data'], true);
+            if ($raw === false) {
+                return new \WP_REST_Response(['error' => 'bad base64'], 400);
+            }
+            $objs[] = new Chunk($c['hash'], $raw, $c['refs'] ?? []);
+        }
+        try {
+            $cs->putMany($objs);
+        } catch (\Throwable $e) {
+            return new \WP_REST_Response(['error' => $e->getMessage()], 400);
+        }
+        return new \WP_REST_Response(['stored' => count($objs)]);
+    }
+
+    public static function routeListRefs(\WP_REST_Request $req): \WP_REST_Response
+    {
+        $rs = SQLiteRefStore::open(self::chunkDbPath());
+        return new \WP_REST_Response($rs->listRefs());
+    }
+
+    public static function routeCasRef(\WP_REST_Request $req): \WP_REST_Response
+    {
+        $name = (string)$req['name'];
+        $old = $req->get_param('old');
+        $new = (string)$req->get_param('new');
+        $rs = SQLiteRefStore::open(self::chunkDbPath());
+        $ok = $rs->casRef($name, $old === null || $old === '' ? null : (string)$old, $new);
+        if (!$ok) {
+            return new \WP_REST_Response(['ok' => false, 'error' => 'cas_mismatch'], 409);
+        }
+        return new \WP_REST_Response(['ok' => true]);
+    }
+
+    /** Install dirty-tracking triggers on all WP tables. */
+    public static function installTriggers(\SQLite3 $db): void
+    {
+        $tables = SchemaInspector::listTables($db);
+        DirtyTracker::install($db, $tables);
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/WordPress/WpCliCommands.php
+++ b/php-dolt-sync/plugin/wp-sync/src/WordPress/WpCliCommands.php
@@ -1,0 +1,150 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\WordPress;
+
+use WpSync\Encoding\CanonicalEncoder;
+use WpSync\Snapshot\Materializer;
+use WpSync\Snapshot\Snapshotter;
+use WpSync\Snapshot\RowNormalizer;
+use WpSync\Snapshot\SchemaInspector;
+use WpSync\Store\HttpChunkStore;
+use WpSync\Store\SQLiteChunkStore;
+use WpSync\Store\SQLiteRefStore;
+use WpSync\Sync\FetchCommand;
+use WpSync\Sync\PushCommand;
+use WpSync\Sync\SyncEngine;
+
+/**
+ * WP-CLI commands. Registered with `WP_CLI::add_command('sync', WpCliCommands::class)`.
+ */
+final class WpCliCommands
+{
+    /** sync commit --message=<msg> [--author=<name>] */
+    public function commit(array $args, array $assoc): void
+    {
+        $db = $this->openWpDb();
+        $cs = new SQLiteChunkStore(SyncPlugin::chunkDbPath());
+        $rs = SQLiteRefStore::open(SyncPlugin::chunkDbPath());
+        $tables = SchemaInspector::listTables($db);
+        $siteUrl = $this->siteUrl($db);
+
+        $filters = [];
+        if (in_array('wp_options', $tables, true)) {
+            $filters['wp_options'] = static function (array $row) {
+                $name = (string)($row['option_name'] ?? '');
+                if (RowNormalizer::isExcludedOption($name)) return null;
+                return $row;
+            };
+        }
+
+        $snap = new Snapshotter($db, $cs, $siteUrl);
+        $parent = $rs->getRef('refs/heads/main');
+        $priorRoot = null;
+        $parents = [];
+        if ($parent !== null) {
+            $parents = [$parent];
+            $commit = Snapshotter::loadCommit($parent, $cs);
+            $priorRoot = $commit['root'];
+        }
+        $hash = $snap->commit(
+            tables: $tables,
+            author: (string)($assoc['author'] ?? 'wp-sync'),
+            message: (string)($assoc['message'] ?? ''),
+            parents: $parents,
+            priorRootHash: $priorRoot,
+            rowFilters: $filters,
+        );
+        $ok = $rs->casRef('refs/heads/main', $parent, $hash);
+        if (!$ok) throw new \RuntimeException('ref update failed');
+        $this->log("committed: {$hash}");
+    }
+
+    /** sync push --remote=<url> --user=<user> --password=<app-password> */
+    public function push(array $args, array $assoc): void
+    {
+        $cs = new SQLiteChunkStore(SyncPlugin::chunkDbPath());
+        $rs = SQLiteRefStore::open(SyncPlugin::chunkDbPath());
+        $http = new HttpChunkStore((string)$assoc['remote'], (string)$assoc['user'], (string)$assoc['password']);
+        $engine = new SyncEngine();
+        $push = new PushCommand($engine, $cs, $rs, $http);
+        $r = $push->run();
+        $this->log("push: {$r['status']} transferred={$r['transferred']}");
+    }
+
+    /** sync pull --remote=<url> --user=<user> --password=<app-password> */
+    public function pull(array $args, array $assoc): void
+    {
+        $db = $this->openWpDb();
+        $cs = new SQLiteChunkStore(SyncPlugin::chunkDbPath());
+        $rs = SQLiteRefStore::open(SyncPlugin::chunkDbPath());
+        $http = new HttpChunkStore((string)$assoc['remote'], (string)$assoc['user'], (string)$assoc['password']);
+        $engine = new SyncEngine();
+        $fetch = new FetchCommand($engine, $cs, $rs, $http);
+        $r = $fetch->run();
+        if ($r['hash'] === null) {
+            $this->log('pull: empty remote'); return;
+        }
+        $mat = new Materializer($db, $cs, $this->siteUrl($db));
+        $filters = [
+            'wp_options' => fn($row) => RowNormalizer::isExcludedOption((string)($row['option_name'] ?? '')) ? null : $row,
+        ];
+        $mat->materialize($r['hash'], null, $filters);
+        foreach ($mat->warnings as $w) $this->log("warn: {$w}");
+        // Fast-forward local main to fetched commit.
+        $localMain = $rs->getRef('refs/heads/main');
+        $rs->casRef('refs/heads/main', $localMain, $r['hash']);
+        $this->log("pulled: {$r['hash']}");
+    }
+
+    /** sync status */
+    public function status(array $args, array $assoc): void
+    {
+        $rs = SQLiteRefStore::open(SyncPlugin::chunkDbPath());
+        foreach ($rs->listRefs() as $n => $h) {
+            $this->log("{$n} {$h}");
+        }
+    }
+
+    /** sync log [--max=<n>] */
+    public function log_(array $args, array $assoc): void
+    {
+        $cs = new SQLiteChunkStore(SyncPlugin::chunkDbPath());
+        $rs = SQLiteRefStore::open(SyncPlugin::chunkDbPath());
+        $h = $rs->getRef('refs/heads/main');
+        $max = (int)($assoc['max'] ?? 20);
+        while ($h && $max-- > 0) {
+            $c = Snapshotter::loadCommit($h, $cs);
+            $ts = date('c', (int)$c['timestamp']);
+            $this->log("{$h} {$ts} {$c['author']}: {$c['message']}");
+            $h = $c['parents'][0] ?? null;
+        }
+    }
+
+    private function openWpDb(): \SQLite3
+    {
+        $path = SyncPlugin::wpDbPath();
+        $db = new \SQLite3($path, SQLITE3_OPEN_READWRITE);
+        $db->enableExceptions(true);
+        $db->exec('PRAGMA journal_mode=WAL');
+        return $db;
+    }
+
+    private function siteUrl(\SQLite3 $db): string
+    {
+        $res = $db->query("SELECT option_value FROM wp_options WHERE option_name='siteurl'");
+        if ($res && ($row = $res->fetchArray(SQLITE3_ASSOC))) {
+            return (string)$row['option_value'];
+        }
+        return 'http://localhost';
+    }
+
+    private function log(string $msg): void
+    {
+        if (class_exists('WP_CLI')) {
+            \WP_CLI::log($msg);
+        } else {
+            fwrite(STDOUT, $msg . "\n");
+        }
+    }
+}

--- a/php-dolt-sync/plugin/wp-sync/src/autoload.php
+++ b/php-dolt-sync/plugin/wp-sync/src/autoload.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+spl_autoload_register(function (string $class): void {
+    $prefix = 'WpSync\\';
+    if (!str_starts_with($class, $prefix)) return;
+    $rel = substr($class, strlen($prefix));
+    $path = __DIR__ . '/' . str_replace('\\', '/', $rel) . '.php';
+    if (is_file($path)) {
+        require $path;
+    }
+});

--- a/php-dolt-sync/plugin/wp-sync/wp-sync.php
+++ b/php-dolt-sync/plugin/wp-sync/wp-sync.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Plugin Name: WP Sync
+ * Description: Content-addressed DB sync between two WordPress + SQLite sites. Dolt-style DAG of commits, push/pull over the REST API, materialize on the other side.
+ * Version:     0.1.0
+ * Requires PHP: 8.2
+ * License:     MIT
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) exit;
+
+require_once __DIR__ . '/src/autoload.php';
+
+WpSync\WordPress\SyncPlugin::bootstrap();
+
+if (defined('WP_CLI') && WP_CLI) {
+    $cli = new WpSync\WordPress\WpCliCommands();
+    WP_CLI::add_command('sync commit', [$cli, 'commit']);
+    WP_CLI::add_command('sync push',   [$cli, 'push']);
+    WP_CLI::add_command('sync pull',   [$cli, 'pull']);
+    WP_CLI::add_command('sync status', [$cli, 'status']);
+    WP_CLI::add_command('sync log',    [$cli, 'log_']);
+}

--- a/php-dolt-sync/run-tests.sh
+++ b/php-dolt-sync/run-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Runs the wp-sync test suite. Needs php 8.2+ with sqlite3, intl, mbstring.
+set -euo pipefail
+cd "$(dirname "$0")"
+exec php tests/run.php "$@"

--- a/php-dolt-sync/tests/EndToEnd/ConflictDetectionTest.php
+++ b/php-dolt-sync/tests/EndToEnd/ConflictDetectionTest.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Snapshot\Snapshotter;
+use WpSync\Snapshot\SchemaInspector;
+use WpSync\Snapshot\RowNormalizer;
+use WpSync\Store\SQLiteChunkStore;
+use WpSync\Store\SQLiteRefStore;
+use WpSync\Store\HttpChunkStore;
+use WpSync\Sync\SyncEngine;
+use WpSync\Sync\PushCommand;
+
+require_once __DIR__ . '/../harness/WpFixture.php';
+require_once __DIR__ . '/../harness/InProcessTransport.php';
+
+TestRun::group('ConflictDetection', function () {
+    TestRun::it('non-fast-forward push is rejected', function () {
+        // Setup: A and B share a common ancestor C0. Each commits its own C1.
+        // A pushes first; B's push must be rejected non-fast-forward.
+        $dbA = \WpSync\Test\Harness\WpFixture::createDb('https://a.test');
+        $dbB = \WpSync\Test\Harness\WpFixture::createDb('https://b.test');
+
+        $filters = ['wp_options' => fn($r) => RowNormalizer::isExcludedOption((string)$r['option_name']) ? null : $r];
+
+        // A builds C0, pushes to remote.
+        $pA = tempnam(sys_get_temp_dir(), 'a_'); unlink($pA);
+        $csA = new SQLiteChunkStore($pA); $rsA = SQLiteRefStore::open($pA);
+        $pR = tempnam(sys_get_temp_dir(), 'r_'); unlink($pR);
+        $csR = new SQLiteChunkStore($pR); $rsR = SQLiteRefStore::open($pR);
+        $xport = new \WpSync\Test\Harness\InProcessTransport($csR, $rsR);
+        $http = new HttpChunkStore('http://x','u','p', $xport->asCallable());
+
+        $c0 = (new Snapshotter($dbA, $csA, 'https://a.test'))
+            ->commit(SchemaInspector::listTables($dbA), 'a', 'c0', [], null, $filters);
+        $rsA->casRef('refs/heads/main', null, $c0);
+        (new PushCommand(new SyncEngine(), $csA, $rsA, $http))->run();
+
+        // B fetches C0 (by copying refs + chunks) via a simple copy, not testing fetch here.
+        $pB = tempnam(sys_get_temp_dir(), 'b_'); unlink($pB);
+        $csB = new SQLiteChunkStore($pB); $rsB = SQLiteRefStore::open($pB);
+        // Manually mirror: copy the chunk reachable from c0 into B's store.
+        $eng = new SyncEngine();
+        $eng->copyReachable($csB, $csR, $c0);
+        $rsB->casRef('refs/heads/main', null, $c0);
+
+        // Both make divergent commits from c0.
+        \WpSync\Test\Harness\WpFixture::insertPost($dbA, 'A-only', 'aa');
+        $cA = (new Snapshotter($dbA, $csA, 'https://a.test'))
+            ->commit(SchemaInspector::listTables($dbA), 'a', 'cA', [$c0], null, $filters);
+        $rsA->casRef('refs/heads/main', $c0, $cA);
+
+        \WpSync\Test\Harness\WpFixture::insertPost($dbB, 'B-only', 'bb');
+        $cB = (new Snapshotter($dbB, $csB, 'https://b.test'))
+            ->commit(SchemaInspector::listTables($dbB), 'b', 'cB', [$c0], null, $filters);
+        $rsB->casRef('refs/heads/main', $c0, $cB);
+
+        // A pushes cA successfully.
+        (new PushCommand(new SyncEngine(), $csA, $rsA, $http))->run();
+
+        // B now tries to push cB which is NOT a descendant of cA -> reject.
+        $e = assertThrows(fn() => (new PushCommand(new SyncEngine(), $csB, $rsB, $http))->run());
+        assertTrue(str_contains($e->getMessage(), 'non-fast-forward') || str_contains($e->getMessage(), 'concurrently'),
+            'expected rejection, got: ' . $e->getMessage());
+    });
+});

--- a/php-dolt-sync/tests/EndToEnd/FullPushPullCycleTest.php
+++ b/php-dolt-sync/tests/EndToEnd/FullPushPullCycleTest.php
@@ -1,0 +1,115 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Snapshot\Snapshotter;
+use WpSync\Snapshot\Materializer;
+use WpSync\Snapshot\SchemaInspector;
+use WpSync\Snapshot\RowNormalizer;
+use WpSync\Store\SQLiteChunkStore;
+use WpSync\Store\SQLiteRefStore;
+use WpSync\Store\HttpChunkStore;
+use WpSync\Sync\SyncEngine;
+use WpSync\Sync\PushCommand;
+use WpSync\Sync\FetchCommand;
+
+require_once __DIR__ . '/../harness/WpFixture.php';
+require_once __DIR__ . '/../harness/InProcessTransport.php';
+
+TestRun::group('FullPushPullCycle (A<->B via HTTP transport)', function () {
+    TestRun::it('A pushes, B pulls+materializes, B commits+pushes, A pulls+materializes', function () {
+        // Two WP-like dbs.
+        $dbA = \WpSync\Test\Harness\WpFixture::createDb('https://site-a.test');
+        \WpSync\Test\Harness\WpFixture::insertPost($dbA, 'Post from A', '<img src="https://site-a.test/a.png">');
+        $stmt = $dbA->prepare("INSERT INTO wp_options(option_name, option_value) VALUES('shared', ?)");
+$stmt->bindValue(1, serialize(['k' => 'v'])); $stmt->execute();
+
+        $dbB = \WpSync\Test\Harness\WpFixture::createDb('https://site-b.test');
+
+        // Two chunk stores (one per site).
+        $pA = tempnam(sys_get_temp_dir(), 'a_'); unlink($pA);
+        $csA = new SQLiteChunkStore($pA); $rsA = SQLiteRefStore::open($pA);
+        $pB = tempnam(sys_get_temp_dir(), 'b_'); unlink($pB);
+        $csB = new SQLiteChunkStore($pB); $rsB = SQLiteRefStore::open($pB);
+
+        // In-process HTTP transports: A's client hits B's stores, and B's client hits A's stores.
+        $xportToB = new \WpSync\Test\Harness\InProcessTransport($csB, $rsB);
+        $httpToB = new HttpChunkStore('http://b', 'u', 'p', $xportToB->asCallable());
+        $xportToA = new \WpSync\Test\Harness\InProcessTransport($csA, $rsA);
+        $httpToA = new HttpChunkStore('http://a', 'u', 'p', $xportToA->asCallable());
+
+        $filters = ['wp_options' => fn($r) => RowNormalizer::isExcludedOption((string)$r['option_name']) ? null : $r];
+
+        // --- A commits & pushes to B ---
+        $snapA = new Snapshotter($dbA, $csA, 'https://site-a.test');
+        $cA1 = $snapA->commit(SchemaInspector::listTables($dbA), 'alice', 'from A', [], null, $filters);
+        $rsA->casRef('refs/heads/main', null, $cA1);
+        (new PushCommand(new SyncEngine(), $csA, $rsA, $httpToB))->run();
+
+        // --- B pulls (fetch + materialize) ---
+        $fetchB = new FetchCommand(new SyncEngine(), $csB, $rsB, $httpToB);
+        $r = $fetchB->run();
+        assertEq($cA1, $r['hash']);
+        (new Materializer($dbB, $csB, 'https://site-b.test'))->materialize($cA1, null, $filters);
+        // Fast-forward B's main to the fetched commit.
+        $rsB->casRef('refs/heads/main', null, $cA1);
+
+        // Verify B sees A's post (with URL rewritten).
+        $res = $dbB->query("SELECT post_title, post_content FROM wp_posts");
+        $row = $res->fetchArray(SQLITE3_ASSOC);
+        assertEq('Post from A', $row['post_title']);
+        assertEq('<img src="https://site-b.test/a.png">', $row['post_content']);
+
+        // --- B makes changes and pushes back to A ---
+        \WpSync\Test\Harness\WpFixture::insertPost($dbB, 'Post from B', 'hello');
+        $snapB = new Snapshotter($dbB, $csB, 'https://site-b.test');
+        $cB1 = $snapB->commit(
+            SchemaInspector::listTables($dbB), 'bob', 'from B',
+            [$cA1], $cA1 ? \WpSync\Snapshot\Snapshotter::loadCommit($cA1, $csB)['root'] : null,
+            $filters,
+        );
+        $rsB->casRef('refs/heads/main', $cA1, $cB1);
+        (new PushCommand(new SyncEngine(), $csB, $rsB, $httpToA))->run();
+
+        // --- A fetches + materializes ---
+        $fetchA = new FetchCommand(new SyncEngine(), $csA, $rsA, $httpToA);
+        $rA = $fetchA->run();
+        assertEq($cB1, $rA['hash']);
+        (new Materializer($dbA, $csA, 'https://site-a.test'))->materialize($cB1, null, $filters);
+        // Fast-forward A's main.
+        $rsA->casRef('refs/heads/main', $cA1, $cB1);
+
+        // Verify A has BOTH posts, with A's URL on the image.
+        $res = $dbA->query("SELECT post_title, post_content FROM wp_posts ORDER BY post_title");
+        $rows = []; while ($r = $res->fetchArray(SQLITE3_ASSOC)) $rows[] = $r;
+        assertEq(2, count($rows));
+        assertEq('Post from A', $rows[0]['post_title']);
+        // A's original image URL should still be A's (placeholder->a on materialize).
+        assertEq('<img src="https://site-a.test/a.png">', $rows[0]['post_content']);
+        assertEq('Post from B', $rows[1]['post_title']);
+
+        // A's siteurl must be unchanged.
+        $res = $dbA->query("SELECT option_value FROM wp_options WHERE option_name='siteurl'");
+        assertEq('https://site-a.test', $res->fetchArray(SQLITE3_ASSOC)['option_value']);
+    });
+
+    TestRun::it('empty commit has same db root hash as parent', function () {
+        $db = \WpSync\Test\Harness\WpFixture::createDb('https://a.test');
+        $p = tempnam(sys_get_temp_dir(), 'cs_'); unlink($p);
+        $cs = new SQLiteChunkStore($p);
+        $filters = ['wp_options' => fn($r) => RowNormalizer::isExcludedOption((string)$r['option_name']) ? null : $r];
+        $snap = new Snapshotter($db, $cs, 'https://a.test');
+        $c1 = $snap->commit(SchemaInspector::listTables($db), 'a', 'first', [], null, $filters);
+
+        // Second commit, no changes.
+        \WpSync\Snapshot\DirtyTracker::install($db, SchemaInspector::listTables($db));
+        // Without dirty tracking the second commit rebuilds everything but the
+        // deterministic tree still produces the same root. Verify.
+        $c2 = $snap->commit(SchemaInspector::listTables($db), 'a', 'empty', [$c1],
+            \WpSync\Snapshot\Snapshotter::loadCommit($c1, $cs)['root'],
+            $filters);
+        assertNotEq($c1, $c2);
+        $r1 = \WpSync\Snapshot\Snapshotter::loadCommit($c1, $cs)['root'];
+        $r2 = \WpSync\Snapshot\Snapshotter::loadCommit($c2, $cs)['root'];
+        assertEq($r1, $r2);
+    });
+});

--- a/php-dolt-sync/tests/EndToEnd/features/sync-commit.feature
+++ b/php-dolt-sync/tests/EndToEnd/features/sync-commit.feature
@@ -1,0 +1,24 @@
+Feature: wp sync commit
+  Create a content-addressed commit of the live WordPress SQLite database.
+
+  Scenario: First commit with no parent
+    Given a fresh WordPress site using SQLite
+    And a post titled "Hello world" exists
+    When I run `wp sync commit --message="initial"`
+    Then STDOUT should contain "committed:"
+    And the chunk database should contain at least one chunk
+    And refs/heads/main should point to the new commit hash
+
+  Scenario: Incremental commit reuses unchanged table trees
+    Given an existing commit C1 on main
+    And dirty-tracking triggers are installed
+    And I insert one row into wp_postmeta
+    When I run `wp sync commit --message="add meta"`
+    Then the wp_posts table tree hash should equal the one recorded in C1
+    And the wp_postmeta table tree hash should differ
+
+  Scenario: Empty commit (no dirty rows) reuses prior db root
+    Given an existing commit C1 on main
+    When I run `wp sync commit --message="nothing"`
+    Then the new commit's root hash should equal C1's root hash
+    And the new commit's hash should differ from C1 (timestamp differs)

--- a/php-dolt-sync/tests/EndToEnd/features/sync-pull.feature
+++ b/php-dolt-sync/tests/EndToEnd/features/sync-pull.feature
@@ -1,0 +1,15 @@
+Feature: wp sync pull
+  Fetch remote chunks and materialize them into the local database.
+
+  Scenario: Pull applies remote changes to live WP DB
+    Given site A has committed and pushed a post with URL https://site-a.test/p.jpg
+    When on site B I run `wp sync pull --remote=https://a.test --user=bob --password=APP`
+    Then wp_posts should contain the post with URL https://site-b.test/p.jpg
+    And wp_options.siteurl should remain https://site-b.test
+    And _sync_dirty should be empty
+
+  Scenario: Pull is idempotent
+    Given site B already has the latest commit from site A
+    When I run `wp sync pull --remote=https://a.test --user=bob --password=APP`
+    Then zero chunks should be transferred
+    And the local working directory should be unchanged

--- a/php-dolt-sync/tests/EndToEnd/features/sync-push.feature
+++ b/php-dolt-sync/tests/EndToEnd/features/sync-push.feature
@@ -1,0 +1,27 @@
+Feature: wp sync push
+  Push the local ref to a remote WordPress site.
+
+  Scenario: Push transfers reachable chunks and updates remote ref
+    Given site A has committed changes and site B is empty
+    When I run `wp sync push --remote=https://b.test --user=alice --password=APP`
+    Then STDOUT should contain "pushed"
+    And the remote refs/heads/main should equal the local refs/heads/main
+    And the remote chunk store should contain every chunk reachable from the commit
+
+  Scenario: Idempotent push transfers zero chunks
+    Given site A and site B share the same commit hash for refs/heads/main
+    When I run `wp sync push --remote=https://b.test --user=alice --password=APP`
+    Then STDOUT should contain "up-to-date"
+    And zero chunks should be transferred
+
+  Scenario: Non-fast-forward push is rejected
+    Given site A and site B diverge from the same ancestor
+    When I run `wp sync push --remote=https://b.test --user=alice --password=APP`
+    Then the command should exit with a non-zero status
+    And STDERR should mention "non-fast-forward" or "pull first"
+
+  Scenario: Push resumes after interruption without duplicate transfer
+    Given a push is interrupted after 50% of chunks
+    When I re-run the push
+    Then only the missing chunks should be transferred
+    And no orphan ref should exist on the remote

--- a/php-dolt-sync/tests/Integration/DirtyTrackingTest.php
+++ b/php-dolt-sync/tests/Integration/DirtyTrackingTest.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Snapshot\DirtyTracker;
+use WpSync\Snapshot\SchemaInspector;
+use WpSync\Snapshot\Materializer;
+use WpSync\Snapshot\Snapshotter;
+use WpSync\Snapshot\RowNormalizer;
+use WpSync\Store\SQLiteChunkStore;
+
+require_once __DIR__ . '/../harness/WpFixture.php';
+
+TestRun::group('DirtyTracking', function () {
+    TestRun::it('INSERT records dirty row', function () {
+        $db = \WpSync\Test\Harness\WpFixture::createDb();
+        DirtyTracker::install($db, SchemaInspector::listTables($db));
+        DirtyTracker::clear($db);
+        \WpSync\Test\Harness\WpFixture::insertPost($db, 'x', 'y');
+        $res = $db->query('SELECT tbl, op FROM _sync_dirty');
+        $rows = []; while ($r = $res->fetchArray(SQLITE3_ASSOC)) $rows[] = $r;
+        assertTrue(count($rows) >= 1);
+        $ops = array_column($rows, 'op');
+        assertTrue(in_array('I', $ops, true));
+    });
+
+    TestRun::it('UPDATE then INSERT collapse (last op wins per rowid)', function () {
+        $db = \WpSync\Test\Harness\WpFixture::createDb();
+        DirtyTracker::install($db, SchemaInspector::listTables($db));
+        DirtyTracker::clear($db);
+        $id = \WpSync\Test\Harness\WpFixture::insertPost($db, 'x', 'y');
+        $db->exec("UPDATE wp_posts SET post_title='z' WHERE ID={$id}");
+        $res = $db->query("SELECT op FROM _sync_dirty WHERE tbl='wp_posts' AND rowid={$id}");
+        $row = $res->fetchArray(SQLITE3_ASSOC);
+        assertEq('U', $row['op']);
+    });
+
+    TestRun::it('materialize does not populate dirty log', function () {
+        $src = \WpSync\Test\Harness\WpFixture::createDb('https://a.test');
+        \WpSync\Test\Harness\WpFixture::insertPost($src, 'Post', 'content');
+
+        $p = tempnam(sys_get_temp_dir(), 'cs_'); unlink($p);
+        $cs = new SQLiteChunkStore($p);
+        $filters = ['wp_options' => fn($r) => RowNormalizer::isExcludedOption((string)$r['option_name']) ? null : $r];
+        $commit = (new Snapshotter($src, $cs, 'https://a.test'))
+            ->commit(SchemaInspector::listTables($src), 'a', 'm', [], null, $filters);
+
+        $dst = \WpSync\Test\Harness\WpFixture::createDb('https://b.test');
+        DirtyTracker::install($dst, SchemaInspector::listTables($dst));
+        DirtyTracker::clear($dst);
+        (new Materializer($dst, $cs, 'https://b.test'))->materialize($commit, null, $filters);
+        $res = $dst->query('SELECT COUNT(*) AS n FROM _sync_dirty');
+        assertEq(0, (int)$res->fetchArray(SQLITE3_ASSOC)['n']);
+    });
+
+    TestRun::it('commit reuses unchanged table tree when only one table is dirty', function () {
+        $src = \WpSync\Test\Harness\WpFixture::createDb('https://a.test');
+        DirtyTracker::install($src, SchemaInspector::listTables($src));
+        \WpSync\Test\Harness\WpFixture::insertPost($src, 'Post', 'content');
+
+        $p = tempnam(sys_get_temp_dir(), 'cs_'); unlink($p);
+        $cs = new SQLiteChunkStore($p);
+        $filters = ['wp_options' => fn($r) => RowNormalizer::isExcludedOption((string)$r['option_name']) ? null : $r];
+        $snap = new Snapshotter($src, $cs, 'https://a.test');
+        $tables = SchemaInspector::listTables($src);
+        $c1 = $snap->commit($tables, 'a', 'first', [], null, $filters);
+
+        // Only modify wp_options (add a non-excluded one).
+        $src->exec("INSERT INTO wp_options(option_name, option_value) VALUES('new_opt', 'v')");
+
+        // Load prior root's table tree for wp_posts.
+        $commit1 = Snapshotter::loadCommit($c1, $cs);
+        $priorRoot = Snapshotter::loadRoot($commit1['root'], $cs);
+        $priorPostsTree = $priorRoot['tables']['wp_posts']['tree'];
+
+        $c2 = $snap->commit($tables, 'a', 'second', [$c1], $commit1['root'], $filters);
+        $commit2 = Snapshotter::loadCommit($c2, $cs);
+        $newRoot = Snapshotter::loadRoot($commit2['root'], $cs);
+        assertEq($priorPostsTree, $newRoot['tables']['wp_posts']['tree'],
+            'unchanged wp_posts tree should be reused');
+    });
+});

--- a/php-dolt-sync/tests/Integration/FailureModesTest.php
+++ b/php-dolt-sync/tests/Integration/FailureModesTest.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Snapshot\Snapshotter;
+use WpSync\Snapshot\Materializer;
+use WpSync\Snapshot\SchemaInspector;
+use WpSync\Snapshot\RowNormalizer;
+use WpSync\Snapshot\DirtyTracker;
+use WpSync\Store\SQLiteChunkStore;
+use WpSync\Store\Chunk;
+use WpSync\Sync\SyncEngine;
+use WpSync\Encoding\CanonicalEncoder;
+use WpSync\Tree\TableTree;
+
+require_once __DIR__ . '/../harness/WpFixture.php';
+
+TestRun::group('FailureModes (named scenarios from spec)', function () {
+
+    // #5 UTF-8 NFC
+    TestRun::it('UTF-8 NFC: precomposed and decomposed produce same hash (post title)', function () {
+        $srcA = \WpSync\Test\Harness\WpFixture::createDb('https://a.test');
+        $srcB = \WpSync\Test\Harness\WpFixture::createDb('https://a.test');
+        \WpSync\Test\Harness\WpFixture::insertPost($srcA, "caf\xc3\xa9", 'x', 'https://a.test', 100); // NFC
+        \WpSync\Test\Harness\WpFixture::insertPost($srcB, "cafe\xcc\x81", 'x', 'https://a.test', 100); // NFD
+
+        $pA = tempnam(sys_get_temp_dir(), 'a_'); unlink($pA);
+        $pB = tempnam(sys_get_temp_dir(), 'b_'); unlink($pB);
+        $csA = new SQLiteChunkStore($pA);
+        $csB = new SQLiteChunkStore($pB);
+        $filters = ['wp_options' => fn($r) => RowNormalizer::isExcludedOption((string)$r['option_name']) ? null : $r];
+        $cA = (new Snapshotter($srcA, $csA, 'https://a.test'))
+            ->commit(['wp_posts'], 'a', 'm', [], null, $filters);
+        $cB = (new Snapshotter($srcB, $csB, 'https://a.test'))
+            ->commit(['wp_posts'], 'a', 'm', [], null, $filters);
+        // Commits differ because of timestamps, but db roots (which hash rows) must match.
+        $rA = Snapshotter::loadCommit($cA, $csA)['root'];
+        $rB = Snapshotter::loadCommit($cB, $csB)['root'];
+        assertEq($rA, $rB, 'NFC/NFD row must produce same db-root hash');
+    });
+
+    // #10 table with no PK -> rowid fallback
+    TestRun::it('table without primary key snapshots & materializes using rowid', function () {
+        $src = \WpSync\Test\Harness\WpFixture::createDb('https://a.test');
+        $src->exec("INSERT INTO plugin_noprimary (a,b) VALUES ('1','x')");
+        $src->exec("INSERT INTO plugin_noprimary (a,b) VALUES ('2','y')");
+
+        $p = tempnam(sys_get_temp_dir(), 'cs_'); unlink($p);
+        $cs = new SQLiteChunkStore($p);
+        $filters = ['wp_options' => fn($r) => RowNormalizer::isExcludedOption((string)$r['option_name']) ? null : $r];
+        $c = (new Snapshotter($src, $cs, 'https://a.test'))
+            ->commit(['plugin_noprimary'], 'a', 'm', [], null, $filters);
+
+        $dst = \WpSync\Test\Harness\WpFixture::createDb('https://b.test');
+        (new Materializer($dst, $cs, 'https://b.test'))->materialize($c);
+        $res = $dst->query('SELECT a,b FROM plugin_noprimary ORDER BY a');
+        $rows = []; while ($r = $res->fetchArray(SQLITE3_ASSOC)) $rows[] = $r;
+        assertEq([['a'=>'1','b'=>'x'], ['a'=>'2','b'=>'y']], $rows);
+    });
+
+    // #15 large batch handling memory bound
+    TestRun::it('large batch (>10k chunks) stays within memory bound', function () {
+        $p = tempnam(sys_get_temp_dir(), 'cs_'); unlink($p);
+        $cs = new SQLiteChunkStore($p);
+        $entries = [];
+        for ($i = 0; $i < 10000; $i++) {
+            $entries[] = [pack('J', $i), str_repeat('v', 64) . $i];
+        }
+        $before = memory_get_peak_usage();
+        $root = TableTree::build($entries, $cs);
+        $after = memory_get_peak_usage();
+        $deltaMB = ($after - $before) / 1024 / 1024;
+        // Extremely loose bound; just ensure we're not O(n^2) memory.
+        assertTrue($deltaMB < 256, "peak memory delta was {$deltaMB}MB, expected < 256MB");
+        assertTrue(strlen($root) === 64);
+    });
+
+    // #14 duplicate chunks in DAG walk (shared subtree)
+    TestRun::it('shared subtree is fetched once during sync', function () {
+        $srcP = tempnam(sys_get_temp_dir(), 's_'); unlink($srcP);
+        $dstP = tempnam(sys_get_temp_dir(), 'd_'); unlink($dstP);
+        $src = new SQLiteChunkStore($srcP);
+        $dst = new SQLiteChunkStore($dstP);
+        $shared = Chunk::of('SHARED');
+        $a = Chunk::of('A', [$shared->hash]);
+        $b = Chunk::of('B', [$shared->hash]);
+        $root = Chunk::of('R', [$a->hash, $b->hash]);
+        $src->putMany([$shared, $a, $b, $root]);
+
+        // Counting wrapper
+        $calls = 0;
+        $wrapped = new class($src, $calls) implements \WpSync\Store\ChunkStore {
+            public int $fetches = 0;
+            public function __construct(private \WpSync\Store\ChunkStore $inner, public int &$calls) {}
+            public function hasMany(array $h): array { return $this->inner->hasMany($h); }
+            public function getMany(array $h): array { $this->fetches += count($h); return $this->inner->getMany($h); }
+            public function putMany(array $c): void { $this->inner->putMany($c); }
+        };
+        $eng = new SyncEngine();
+        $n = $eng->copyReachable($dst, $wrapped, $root->hash);
+        assertEq(4, $n);
+        // Shared must not be fetched twice. Total unique chunks = 4.
+        assertEq(4, $wrapped->fetches);
+    });
+
+    // #11 interrupted push: remote ref unchanged
+    TestRun::it('interrupted push does not update remote ref', function () {
+        $srcP = tempnam(sys_get_temp_dir(), 's_'); unlink($srcP);
+        $dstP = tempnam(sys_get_temp_dir(), 'd_'); unlink($dstP);
+        $src = new SQLiteChunkStore($srcP);
+        $dst = new SQLiteChunkStore($dstP);
+        $leaf = Chunk::of('L');
+        $root = Chunk::of('R', [$leaf->hash]);
+        $src->putMany([$leaf, $root]);
+
+        $refP = tempnam(sys_get_temp_dir(), 'r_'); unlink($refP);
+        $rsR = \WpSync\Store\SQLiteRefStore::open($refP);
+        // Create remote ref store with nothing set. Simulate push via copyReachable
+        // that fails, and ensure rs wasn't touched.
+        $failing = new class($src) implements \WpSync\Store\ChunkStore {
+            public function __construct(private \WpSync\Store\ChunkStore $inner) {}
+            public function hasMany(array $h): array { return []; }
+            public function getMany(array $h): array { return $this->inner->getMany($h); }
+            public function putMany(array $c): void { throw new \RuntimeException('simulated'); }
+        };
+        $eng = new SyncEngine();
+        $caught = false;
+        try { $eng->copyReachable($failing, $src, $root->hash); } catch (\Throwable) { $caught = true; }
+        assertTrue($caught);
+        assertEq(null, $rsR->getRef('refs/heads/main'));
+    });
+
+});

--- a/php-dolt-sync/tests/Integration/IncrementalSyncTest.php
+++ b/php-dolt-sync/tests/Integration/IncrementalSyncTest.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Snapshot\Snapshotter;
+use WpSync\Snapshot\SchemaInspector;
+use WpSync\Snapshot\RowNormalizer;
+use WpSync\Store\SQLiteChunkStore;
+use WpSync\Store\SQLiteRefStore;
+use WpSync\Store\HttpChunkStore;
+use WpSync\Sync\SyncEngine;
+use WpSync\Sync\PushCommand;
+
+require_once __DIR__ . '/../harness/WpFixture.php';
+require_once __DIR__ . '/../harness/InProcessTransport.php';
+
+TestRun::group('IncrementalSync', function () {
+    TestRun::it('changing one row in a large table transfers << n chunks', function () {
+        $src = \WpSync\Test\Harness\WpFixture::createDb('https://site-a.test');
+        $src->exec('BEGIN');
+        for ($i = 0; $i < 2000; $i++) {
+            \WpSync\Test\Harness\WpFixture::insertPost($src, "Post {$i}", "content {$i}");
+        }
+        $src->exec('COMMIT');
+
+        $pA = tempnam(sys_get_temp_dir(), 'a_'); unlink($pA);
+        $csA = new SQLiteChunkStore($pA);
+        $rsA = SQLiteRefStore::open($pA);
+        $pR = tempnam(sys_get_temp_dir(), 'r_'); unlink($pR);
+        $csR = new SQLiteChunkStore($pR);
+        $rsR = SQLiteRefStore::open($pR);
+        $xport = new \WpSync\Test\Harness\InProcessTransport($csR, $rsR);
+        $http = new HttpChunkStore('http://x', 'u', 'p', $xport->asCallable());
+
+        $filters = ['wp_options' => fn($r) => RowNormalizer::isExcludedOption((string)$r['option_name']) ? null : $r];
+        $snap = new Snapshotter($src, $csA, 'https://site-a.test');
+        $c1 = $snap->commit(SchemaInspector::listTables($src), 'a', 'first', [], null, $filters);
+        $rsA->casRef('refs/heads/main', null, $c1);
+        (new PushCommand(new SyncEngine(), $csA, $rsA, $http))->run();
+
+        // Change one row.
+        $src->exec("UPDATE wp_posts SET post_title='CHANGED' WHERE ID=1000");
+
+        $before = $xport->putCount;
+        $c2 = $snap->commit(SchemaInspector::listTables($src), 'a', 'second', [$c1], null, $filters);
+        $rsA->casRef('refs/heads/main', $c1, $c2);
+        (new PushCommand(new SyncEngine(), $csA, $rsA, $http))->run();
+        $transferred = $xport->putCount - $before;
+
+        // 2000 posts / 64 fanout = 32 leaves -> ~1 internal level.
+        // Incremental push should transfer O(log n) chunks, not O(n).
+        assertTrue($transferred < 50, "incremental push transferred {$transferred} chunks, expected << 2000");
+    });
+});

--- a/php-dolt-sync/tests/Integration/SnapshotRoundTripTest.php
+++ b/php-dolt-sync/tests/Integration/SnapshotRoundTripTest.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Snapshot\Snapshotter;
+use WpSync\Snapshot\Materializer;
+use WpSync\Snapshot\SchemaInspector;
+use WpSync\Snapshot\RowNormalizer;
+use WpSync\Store\SQLiteChunkStore;
+
+require_once __DIR__ . '/../harness/WpFixture.php';
+
+TestRun::group('SnapshotRoundTrip', function () {
+    TestRun::it('commit -> materialize to fresh DB yields equal content', function () {
+        $src = \WpSync\Test\Harness\WpFixture::createDb('https://site-a.test');
+        \WpSync\Test\Harness\WpFixture::insertPost($src, 'Hello', '<img src="https://site-a.test/p.jpg">');
+        \WpSync\Test\Harness\WpFixture::insertPost($src, 'Second', 'plain content');
+        $stmt = $src->prepare("INSERT INTO wp_options(option_name, option_value) VALUES('my_opt', ?)");
+        $stmt->bindValue(1, serialize(['b' => 1, 'a' => 2]));
+        $stmt->execute();
+
+        $cp = tempnam(sys_get_temp_dir(), 'cs_'); unlink($cp);
+        $cs = new SQLiteChunkStore($cp);
+        $snap = new Snapshotter($src, $cs, 'https://site-a.test');
+        $tables = SchemaInspector::listTables($src);
+        $filters = ['wp_options' => function ($row) {
+            return RowNormalizer::isExcludedOption((string)$row['option_name']) ? null : $row;
+        }];
+        $commit = $snap->commit($tables, 'tester', 'initial', [], null, $filters);
+
+        // Fresh DB with same schema but URL is different.
+        $dst = \WpSync\Test\Harness\WpFixture::createDb('https://site-b.test');
+        $mat = new Materializer($dst, $cs, 'https://site-b.test');
+        $mat->materialize($commit, null, $filters);
+
+        // Posts copied.
+        $res = $dst->query("SELECT post_title, post_content FROM wp_posts ORDER BY post_title");
+        $rows = [];
+        while ($r = $res->fetchArray(SQLITE3_ASSOC)) $rows[] = $r;
+        assertEq(2, count($rows));
+        assertEq('Hello', $rows[0]['post_title']);
+        assertEq('<img src="https://site-b.test/p.jpg">', $rows[0]['post_content'],
+            'URLs should be rewritten to local site');
+
+        // Site-identity options unchanged.
+        $res = $dst->query("SELECT option_value FROM wp_options WHERE option_name='siteurl'");
+        $row = $res->fetchArray(SQLITE3_ASSOC);
+        assertEq('https://site-b.test', $row['option_value']);
+
+        // Custom option rewritten URL (n/a) and correctly unserialized.
+        $res = $dst->query("SELECT option_value FROM wp_options WHERE option_name='my_opt'");
+        $row = $res->fetchArray(SQLITE3_ASSOC);
+        $u = unserialize($row['option_value']);
+        assertEq(['a' => 2, 'b' => 1], $u);
+    });
+
+    TestRun::it('empty table survives round trip (siteurl row excluded yields non-empty; exercise plugin_noprimary empty)', function () {
+        $src = \WpSync\Test\Harness\WpFixture::createDb('https://site-a.test');
+        $cp = tempnam(sys_get_temp_dir(), 'cs_'); unlink($cp);
+        $cs = new SQLiteChunkStore($cp);
+        $snap = new Snapshotter($src, $cs, 'https://site-a.test');
+        $commit = $snap->commit(SchemaInspector::listTables($src), 'tester', 'empty', [], null);
+        assertTrue(is_string($commit) && strlen($commit) === 64);
+    });
+
+    TestRun::it('deleted row is deleted on materialize', function () {
+        $src = \WpSync\Test\Harness\WpFixture::createDb('https://site-a.test');
+        $id1 = \WpSync\Test\Harness\WpFixture::insertPost($src, 'KeepMe', 'a');
+        $id2 = \WpSync\Test\Harness\WpFixture::insertPost($src, 'DeleteMe', 'b');
+
+        $cp = tempnam(sys_get_temp_dir(), 'cs_'); unlink($cp);
+        $cs = new SQLiteChunkStore($cp);
+        $snap = new Snapshotter($src, $cs, 'https://site-a.test');
+        $tables = SchemaInspector::listTables($src);
+        $filters = ['wp_options' => fn($r) => \WpSync\Snapshot\RowNormalizer::isExcludedOption((string)$r['option_name']) ? null : $r];
+        $c1 = $snap->commit($tables, 'a', 'first', [], null, $filters);
+
+        $dst = \WpSync\Test\Harness\WpFixture::createDb('https://site-b.test');
+        (new Materializer($dst, $cs, 'https://site-b.test'))->materialize($c1, null, $filters);
+
+        // Now delete post 2 on src, commit again, re-materialize.
+        $src->exec("DELETE FROM wp_posts WHERE ID = {$id2}");
+        $c2 = $snap->commit($tables, 'a', 'del', [$c1], null, $filters);
+        (new Materializer($dst, $cs, 'https://site-b.test'))->materialize($c2, null, $filters);
+
+        $res = $dst->query("SELECT post_title FROM wp_posts ORDER BY post_title");
+        $rows = [];
+        while ($r = $res->fetchArray(SQLITE3_ASSOC)) $rows[] = $r['post_title'];
+        assertEq(['KeepMe'], $rows);
+    });
+});

--- a/php-dolt-sync/tests/Integration/SyncBetweenStoresTest.php
+++ b/php-dolt-sync/tests/Integration/SyncBetweenStoresTest.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Snapshot\Snapshotter;
+use WpSync\Snapshot\Materializer;
+use WpSync\Snapshot\SchemaInspector;
+use WpSync\Snapshot\RowNormalizer;
+use WpSync\Store\SQLiteChunkStore;
+use WpSync\Store\SQLiteRefStore;
+use WpSync\Store\HttpChunkStore;
+use WpSync\Sync\SyncEngine;
+use WpSync\Sync\PushCommand;
+use WpSync\Sync\FetchCommand;
+
+require_once __DIR__ . '/../harness/WpFixture.php';
+require_once __DIR__ . '/../harness/InProcessTransport.php';
+
+TestRun::group('SyncBetweenStores (HTTP-over-in-process)', function () {
+    TestRun::it('push from A to B via HTTP transport, then materialize on B', function () {
+        $srcDb = \WpSync\Test\Harness\WpFixture::createDb('https://site-a.test');
+        \WpSync\Test\Harness\WpFixture::insertPost($srcDb, 'Post 1', '<a href="https://site-a.test/x">link</a>');
+        \WpSync\Test\Harness\WpFixture::insertPost($srcDb, 'Post 2', 'content');
+
+        // Local (site A) chunk store + ref store
+        $pA = tempnam(sys_get_temp_dir(), 'cs_A_'); unlink($pA);
+        $csA = new SQLiteChunkStore($pA);
+        $rsA = SQLiteRefStore::open($pA);
+
+        // Remote (site B) chunk store + ref store
+        $pB = tempnam(sys_get_temp_dir(), 'cs_B_'); unlink($pB);
+        $csB = new SQLiteChunkStore($pB);
+        $rsB = SQLiteRefStore::open($pB);
+
+        // Snapshot site A -> commit to local A chunk store.
+        $snap = new Snapshotter($srcDb, $csA, 'https://site-a.test');
+        $tables = SchemaInspector::listTables($srcDb);
+        $filters = ['wp_options' => fn($r) => RowNormalizer::isExcludedOption((string)$r['option_name']) ? null : $r];
+        $commit = $snap->commit($tables, 'a', 'first', [], null, $filters);
+        $rsA->casRef('refs/heads/main', null, $commit);
+
+        // HTTP transport routes directly to B's stores.
+        $xport = new \WpSync\Test\Harness\InProcessTransport($csB, $rsB);
+        $http = new HttpChunkStore('http://fake', 'u', 'p', $xport->asCallable());
+
+        // Push.
+        $push = new PushCommand(new SyncEngine(), $csA, $rsA, $http);
+        $r = $push->run();
+        assertEq('pushed', $r['status']);
+        assertTrue($r['transferred'] > 0);
+
+        // Idempotent re-push: zero chunks transferred, ref unchanged.
+        $putBefore = $xport->putCount;
+        $r2 = $push->run();
+        assertEq('up-to-date', $r2['status']);
+        assertEq($putBefore, $xport->putCount, 'no further chunks should flow');
+
+        // Now B materializes locally. Use dst WP DB configured for site-b.
+        $dstDb = \WpSync\Test\Harness\WpFixture::createDb('https://site-b.test');
+        $mat = new Materializer($dstDb, $csB, 'https://site-b.test');
+        $mat->materialize($commit, null, $filters);
+
+        // Site B has posts with URL rewritten.
+        $res = $dstDb->query("SELECT post_title, post_content FROM wp_posts ORDER BY post_title");
+        $rows = [];
+        while ($r = $res->fetchArray(SQLITE3_ASSOC)) $rows[] = $r;
+        assertEq(2, count($rows));
+        assertEq('<a href="https://site-b.test/x">link</a>', $rows[0]['post_content']);
+        // Site-identity options must not have been overwritten.
+        $res = $dstDb->query("SELECT option_value FROM wp_options WHERE option_name='siteurl'");
+        assertEq('https://site-b.test', $res->fetchArray(SQLITE3_ASSOC)['option_value']);
+    });
+
+    TestRun::it('concurrent push: second pusher gets CAS failure', function () {
+        $srcA = \WpSync\Test\Harness\WpFixture::createDb('https://site-a.test');
+        $srcB = \WpSync\Test\Harness\WpFixture::createDb('https://site-b.test');
+        \WpSync\Test\Harness\WpFixture::insertPost($srcA, 'A', 'aa');
+        \WpSync\Test\Harness\WpFixture::insertPost($srcB, 'B', 'bb');
+
+        $remoteP = tempnam(sys_get_temp_dir(), 'r_'); unlink($remoteP);
+        $csR = new SQLiteChunkStore($remoteP);
+        $rsR = SQLiteRefStore::open($remoteP);
+        $xport = new \WpSync\Test\Harness\InProcessTransport($csR, $rsR);
+        $httpFactory = fn() => new HttpChunkStore('http://x', 'u', 'p', $xport->asCallable());
+
+        $filters = ['wp_options' => fn($r) => RowNormalizer::isExcludedOption((string)$r['option_name']) ? null : $r];
+
+        // Pusher A commits & pushes first.
+        $pA = tempnam(sys_get_temp_dir(), 'a_'); unlink($pA);
+        $csA = new SQLiteChunkStore($pA); $rsA = SQLiteRefStore::open($pA);
+        $commitA = (new Snapshotter($srcA, $csA, 'https://site-a.test'))
+            ->commit(SchemaInspector::listTables($srcA), 'a', 'm', [], null, $filters);
+        $rsA->casRef('refs/heads/main', null, $commitA);
+        (new PushCommand(new SyncEngine(), $csA, $rsA, $httpFactory()))->run();
+
+        // Pusher B also thinks remote is null (stale view), commits from own root.
+        // Since A already set the ref, B's push must fail non-fast-forward OR
+        // CAS — either is acceptable.
+        $pB = tempnam(sys_get_temp_dir(), 'b_'); unlink($pB);
+        $csB = new SQLiteChunkStore($pB); $rsB = SQLiteRefStore::open($pB);
+        $commitB = (new Snapshotter($srcB, $csB, 'https://site-b.test'))
+            ->commit(SchemaInspector::listTables($srcB), 'b', 'm', [], null, $filters);
+        $rsB->casRef('refs/heads/main', null, $commitB);
+
+        $e = assertThrows(fn() => (new PushCommand(new SyncEngine(), $csB, $rsB, $httpFactory()))->run());
+        $msg = $e->getMessage();
+        assertTrue(str_contains($msg, 'non-fast-forward') || str_contains($msg, 'concurrently'),
+            "expected non-fast-forward or CAS error, got: {$msg}");
+    });
+});

--- a/php-dolt-sync/tests/Unit/CanonicalEncoderTest.php
+++ b/php-dolt-sync/tests/Unit/CanonicalEncoderTest.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Encoding\CanonicalEncoder;
+
+TestRun::group('CanonicalEncoder', function () {
+    TestRun::it('primitive encodings', function () {
+        assertEq('00', bin2hex(CanonicalEncoder::encode(0)));
+        assertEq('17', bin2hex(CanonicalEncoder::encode(23)));
+        assertEq('1864', bin2hex(CanonicalEncoder::encode(100)));
+        assertEq('20', bin2hex(CanonicalEncoder::encode(-1)));
+        assertEq('f4', bin2hex(CanonicalEncoder::encode(false)));
+        assertEq('f5', bin2hex(CanonicalEncoder::encode(true)));
+        assertEq('f6', bin2hex(CanonicalEncoder::encode(null)));
+        assertEq('80', bin2hex(CanonicalEncoder::encode([])));
+    });
+
+    TestRun::it('determinism across 1000 encodings of same complex value', function () {
+        $v = ['z' => 1, 'a' => ['b' => 2, 'a' => ['x' => null, 'w' => [1,2,3]]]];
+        $first = CanonicalEncoder::encode($v);
+        for ($i = 0; $i < 1000; $i++) {
+            assertEq($first, CanonicalEncoder::encode($v));
+        }
+    });
+
+    TestRun::it('map keys sort length-first', function () {
+        $a = ['aa' => 1, 'b' => 2];
+        $b = ['b' => 2, 'aa' => 1];
+        assertEq(CanonicalEncoder::encode($a), CanonicalEncoder::encode($b));
+        // 'b' is shorter -> comes first
+        $enc = CanonicalEncoder::encode($a);
+        // a2 (map len 2) + 61 'b' + 02 + 62 61 'aa' + 01
+        // map(2) | 'b'(61 62) | 2(02) | 'aa'(62 61 61) | 1(01)
+        assertEq('a261620262616101', bin2hex($enc));
+    });
+
+    TestRun::it('round trip nested', function () {
+        $v = ['x' => [1, 2.5, 'hello', true, null, [-1, -2]]];
+        $dec = CanonicalEncoder::decode(CanonicalEncoder::encode($v));
+        assertEq($v, $dec);
+    });
+
+    TestRun::it('NaN canonical', function () {
+        $a = CanonicalEncoder::encode(NAN);
+        assertEq('fb7ff8000000000000', bin2hex($a));
+    });
+
+    TestRun::it('negative zero normalizes', function () {
+        assertEq(CanonicalEncoder::encode(0.0), CanonicalEncoder::encode(-0.0));
+    });
+
+    TestRun::it('integer-valued float coerces', function () {
+        assertEq(CanonicalEncoder::encode(3), CanonicalEncoder::encode(3.0));
+        assertEq(CanonicalEncoder::encode(-1), CanonicalEncoder::encode(-1.0));
+    });
+
+    TestRun::it('null vs empty string distinct', function () {
+        assertNotEq(CanonicalEncoder::hash(null), CanonicalEncoder::hash(''));
+        assertNotEq(CanonicalEncoder::hash(null), CanonicalEncoder::hash(0));
+        assertNotEq(CanonicalEncoder::hash(null), CanonicalEncoder::hash(false));
+    });
+
+    TestRun::it('UTF-8 NFC normalization', function () {
+        $nfd = "cafe\xcc\x81";
+        $nfc = "caf\xc3\xa9";
+        assertEq(CanonicalEncoder::hash($nfd), CanonicalEncoder::hash($nfc));
+    });
+
+    TestRun::it('invalid UTF-8 rejected', function () {
+        assertThrows(fn() => CanonicalEncoder::encode("\xff\xfe_bad"));
+    });
+
+    TestRun::it('float 1/3 round-trips deterministically', function () {
+        $f = 1.0 / 3.0;
+        $enc1 = CanonicalEncoder::encode($f);
+        $enc2 = CanonicalEncoder::encode($f);
+        assertEq($enc1, $enc2);
+        $dec = CanonicalEncoder::decode($enc1);
+        assertEq($f, $dec);
+    });
+
+    TestRun::it('large integers encode at 64-bit', function () {
+        assertEq('1b7fffffffffffffff', bin2hex(CanonicalEncoder::encode(PHP_INT_MAX)));
+    });
+});

--- a/php-dolt-sync/tests/Unit/CborTestVectorsTest.php
+++ b/php-dolt-sync/tests/Unit/CborTestVectorsTest.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Encoding\CanonicalEncoder;
+
+TestRun::group('CBOR test vectors (RFC 8949 Appendix A subset)', function () {
+    // (value, hex) pairs from Appendix A; we only include vectors we can represent.
+    $vectors = [
+        [0, '00'],
+        [1, '01'],
+        [10, '0a'],
+        [23, '17'],
+        [24, '1818'],
+        [25, '1819'],
+        [100, '1864'],
+        [1000, '1903e8'],
+        [1000000, '1a000f4240'],
+        [-1, '20'],
+        [-10, '29'],
+        [-100, '3863'],
+        [-1000, '3903e7'],
+        [false, 'f4'],
+        [true, 'f5'],
+        [null, 'f6'],
+        [[], '80'],
+        [[1, 2, 3], '83010203'],
+        ['', '60'],
+        ['a', '6161'],
+        ['IETF', '6449455446'],
+        ["\"\\", '62225c'],
+        [[1, [2, 3], [4, 5]], '8301820203820405'],
+    ];
+    foreach ($vectors as $i => [$val, $hex]) {
+        TestRun::it("vector[{$i}]", function () use ($val, $hex) {
+            assertEq($hex, bin2hex(CanonicalEncoder::encode($val)));
+        });
+    }
+});

--- a/php-dolt-sync/tests/Unit/RowNormalizerTest.php
+++ b/php-dolt-sync/tests/Unit/RowNormalizerTest.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Snapshot\RowNormalizer;
+use WpSync\Encoding\CanonicalEncoder;
+
+TestRun::group('RowNormalizer', function () {
+    TestRun::it('columns encoded in alphabetical order', function () {
+        $row = ['z' => 1, 'a' => 2, 'm' => 3];
+        $norm = RowNormalizer::normalizeForEncode($row, 'https://a.test');
+        assertEq(['a', 'm', 'z'], array_keys($norm));
+    });
+
+    TestRun::it('plain URL rewritten to placeholder and back', function () {
+        $row = ['post_content' => '<img src="https://site-a.test/p.jpg">'];
+        $n = RowNormalizer::normalizeForEncode($row, 'https://site-a.test');
+        assertEq('<img src="{{SITE_URL}}/p.jpg">', $n['post_content']);
+        $r = RowNormalizer::denormalizeForApply($n, 'https://site-b.test');
+        assertEq('<img src="https://site-b.test/p.jpg">', $r['post_content']);
+    });
+
+    TestRun::it('serialized PHP with URL of different lengths roundtrips', function () {
+        $value = serialize(['url' => 'https://site-a.test/img.png', 'n' => 1]);
+        $row = ['option_value' => $value];
+        // Encode as if on site A
+        $n = RowNormalizer::normalizeForEncode($row, 'https://site-a.test');
+        // Decode on site B with *shorter* URL: length prefixes must be right.
+        $r = RowNormalizer::denormalizeForApply($n, 'https://b.test');
+        $u = unserialize($r['option_value']);
+        assertEq('https://b.test/img.png', $u['url']);
+        assertEq(1, $u['n']);
+    });
+
+    TestRun::it('GMT columns drop their non-GMT siblings', function () {
+        $row = [
+            'post_date' => '2024-01-01 12:00:00',
+            'post_date_gmt' => '2024-01-01 12:00:00',
+            'title' => 'x',
+        ];
+        $n = RowNormalizer::normalizeForEncode($row, 'https://a.test');
+        assertTrue(!isset($n['post_date']));
+        assertTrue(isset($n['post_date_gmt']));
+    });
+
+    TestRun::it('excluded options list', function () {
+        assertTrue(RowNormalizer::isExcludedOption('siteurl'));
+        assertTrue(RowNormalizer::isExcludedOption('home'));
+        assertTrue(RowNormalizer::isExcludedOption('_transient_foo'));
+        assertTrue(RowNormalizer::isExcludedOption('_site_transient_bar'));
+        assertTrue(!RowNormalizer::isExcludedOption('regular_option'));
+    });
+
+    TestRun::it('two sites with different insertion orders produce equal hashes', function () {
+        // Site A: option serialized with keys in order [b,a]
+        $valA = serialize(['b' => 1, 'a' => 2]);
+        $valB = serialize(['a' => 2, 'b' => 1]);
+        $rowA = ['option_name' => 'foo', 'option_value' => $valA];
+        $rowB = ['option_name' => 'foo', 'option_value' => $valB];
+        $nA = RowNormalizer::normalizeForEncode($rowA, 'https://a.test');
+        $nB = RowNormalizer::normalizeForEncode($rowB, 'https://b.test');
+        assertEq(CanonicalEncoder::hash($nA), CanonicalEncoder::hash($nB));
+    });
+
+    TestRun::it('NULL distinct from empty string', function () {
+        $r1 = ['c' => null];
+        $r2 = ['c' => ''];
+        $n1 = RowNormalizer::normalizeForEncode($r1, 'https://a.test');
+        $n2 = RowNormalizer::normalizeForEncode($r2, 'https://a.test');
+        assertNotEq(CanonicalEncoder::hash($n1), CanonicalEncoder::hash($n2));
+    });
+});

--- a/php-dolt-sync/tests/Unit/SQLiteChunkStoreTest.php
+++ b/php-dolt-sync/tests/Unit/SQLiteChunkStoreTest.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Store\Chunk;
+use WpSync\Store\SQLiteChunkStore;
+
+TestRun::group('SQLiteChunkStore', function () {
+    $newStore = static function () {
+        $p = tempnam(sys_get_temp_dir(), 'cs_'); unlink($p);
+        return [new SQLiteChunkStore($p), $p];
+    };
+
+    TestRun::it('put, has, get round-trip', function () use ($newStore) {
+        [$cs] = $newStore();
+        $c = Chunk::of('hello', []);
+        $cs->putMany([$c]);
+        assertEq([$c->hash => true], $cs->hasMany([$c->hash]));
+        $got = $cs->getMany([$c->hash]);
+        assertEq('hello', $got[$c->hash]->bytes);
+    });
+
+    TestRun::it('rejects wrong-hash chunk', function () use ($newStore) {
+        [$cs] = $newStore();
+        $bad = new Chunk(str_repeat('0', 64), 'different', []);
+        assertThrows(fn() => $cs->putMany([$bad]));
+    });
+
+    TestRun::it('idempotent put', function () use ($newStore) {
+        [$cs] = $newStore();
+        $c = Chunk::of('x');
+        $cs->putMany([$c, $c]);
+        assertEq(1, $cs->count());
+    });
+
+    TestRun::it('hasMany/getMany with mix of present and absent', function () use ($newStore) {
+        [$cs] = $newStore();
+        $c = Chunk::of('yo');
+        $cs->putMany([$c]);
+        $ghost = str_repeat('a', 64);
+        $has = $cs->hasMany([$c->hash, $ghost]);
+        assertTrue(isset($has[$c->hash]));
+        assertTrue(!isset($has[$ghost]));
+        $got = $cs->getMany([$c->hash, $ghost]);
+        assertEq(1, count($got));
+        assertTrue(isset($got[$c->hash]));
+    });
+
+    TestRun::it('stores refs list', function () use ($newStore) {
+        [$cs] = $newStore();
+        $child = Chunk::of('child');
+        $parent = Chunk::of('parent', [$child->hash]);
+        $cs->putMany([$child, $parent]);
+        $got = $cs->getMany([$parent->hash]);
+        assertEq([$child->hash], $got[$parent->hash]->refs);
+    });
+});

--- a/php-dolt-sync/tests/Unit/SQLiteRefStoreTest.php
+++ b/php-dolt-sync/tests/Unit/SQLiteRefStoreTest.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Store\SQLiteRefStore;
+
+TestRun::group('SQLiteRefStore', function () {
+    $newStore = static function () {
+        $p = tempnam(sys_get_temp_dir(), 'refs_'); unlink($p);
+        return SQLiteRefStore::open($p);
+    };
+
+    TestRun::it('getRef nonexistent returns null', function () use ($newStore) {
+        $rs = $newStore();
+        assertEq(null, $rs->getRef('refs/heads/main'));
+    });
+
+    TestRun::it('casRef with null creates new', function () use ($newStore) {
+        $rs = $newStore();
+        $h = str_repeat('1', 64);
+        assertTrue($rs->casRef('refs/heads/main', null, $h));
+        assertEq($h, $rs->getRef('refs/heads/main'));
+    });
+
+    TestRun::it('casRef with null fails if ref exists', function () use ($newStore) {
+        $rs = $newStore();
+        $h = str_repeat('1', 64);
+        $rs->casRef('refs/heads/main', null, $h);
+        assertTrue(!$rs->casRef('refs/heads/main', null, str_repeat('2', 64)));
+    });
+
+    TestRun::it('casRef succeeds when expected matches', function () use ($newStore) {
+        $rs = $newStore();
+        $h1 = str_repeat('1', 64); $h2 = str_repeat('2', 64);
+        $rs->casRef('refs/heads/main', null, $h1);
+        assertTrue($rs->casRef('refs/heads/main', $h1, $h2));
+        assertEq($h2, $rs->getRef('refs/heads/main'));
+    });
+
+    TestRun::it('casRef fails when expected mismatches', function () use ($newStore) {
+        $rs = $newStore();
+        $h1 = str_repeat('1', 64); $h2 = str_repeat('2', 64); $h3 = str_repeat('3', 64);
+        $rs->casRef('refs/heads/main', null, $h1);
+        assertTrue(!$rs->casRef('refs/heads/main', $h2, $h3));
+        assertEq($h1, $rs->getRef('refs/heads/main'));
+    });
+
+    TestRun::it('listRefs with prefix', function () use ($newStore) {
+        $rs = $newStore();
+        $h = str_repeat('a', 64);
+        $rs->casRef('refs/heads/main', null, $h);
+        $rs->casRef('refs/remotes/origin/main', null, $h);
+        $heads = $rs->listRefs('refs/heads/');
+        assertEq(1, count($heads));
+        assertTrue(isset($heads['refs/heads/main']));
+    });
+});

--- a/php-dolt-sync/tests/Unit/SerializedPhpHandlerTest.php
+++ b/php-dolt-sync/tests/Unit/SerializedPhpHandlerTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Snapshot\SerializedPhpHandler;
+
+TestRun::group('SerializedPhpHandler', function () {
+    TestRun::it('detects serialized values', function () {
+        assertTrue(SerializedPhpHandler::looksSerialized('a:1:{s:1:"a";i:1;}'));
+        assertTrue(SerializedPhpHandler::looksSerialized('i:5;'));
+        assertTrue(!SerializedPhpHandler::looksSerialized('plain text'));
+    });
+
+    TestRun::it('deterministic serialize with sorted keys', function () {
+        $a = ['b' => 1, 'a' => 2];
+        $b = ['a' => 2, 'b' => 1];
+        assertEq(SerializedPhpHandler::serialize($a), SerializedPhpHandler::serialize($b));
+    });
+
+    TestRun::it('nested arrays sorted recursively', function () {
+        $a = ['x' => ['z' => 1, 'y' => 2], 'w' => 3];
+        $b = ['w' => 3, 'x' => ['y' => 2, 'z' => 1]];
+        assertEq(SerializedPhpHandler::serialize($a), SerializedPhpHandler::serialize($b));
+    });
+
+    TestRun::it('lists preserve order', function () {
+        $a = [10, 20, 30];
+        $s = SerializedPhpHandler::serialize($a);
+        $r = unserialize($s);
+        assertEq([10, 20, 30], $r);
+    });
+
+    TestRun::it('transformStrings rewrites length prefixes correctly', function () {
+        $orig = serialize(['url' => 'https://site-a.test/x', 'other' => 'ok']);
+        $xformed = SerializedPhpHandler::transformStrings(
+            $orig,
+            fn(string $s) => str_replace('https://site-a.test', 'https://b.test', $s),
+        );
+        // Must still be valid unserialize-able
+        $u = unserialize($xformed);
+        assertEq('https://b.test/x', $u['url']);
+        assertEq('ok', $u['other']);
+    });
+
+    TestRun::it('transformStrings handles nested serialized data', function () {
+        $inner = serialize(['widget_url' => 'https://site-a.test/img.png']);
+        $outer = serialize(['widget' => $inner]);
+        $xformed = SerializedPhpHandler::transformStrings(
+            $outer,
+            fn(string $s) => str_replace('https://site-a.test', 'https://much-longer.example.com', $s),
+        );
+        // Outer unserialize, then inner (nested serialized inside a string)
+        $ol = unserialize($xformed);
+        $il = unserialize($ol['widget']);
+        assertEq('https://much-longer.example.com/img.png', $il['widget_url']);
+    });
+
+    TestRun::it('5 URL length variants all roundtrip correctly', function () {
+        $urls = [
+            'https://a.test',
+            'https://bb.test',
+            'https://site-b.test',
+            'https://very-long-hostname.example.com',
+            'https://x.y',
+        ];
+        $base = 'https://site-a.test';
+        foreach ($urls as $u) {
+            $s = serialize(['a' => "prefix {$base}/img.png suffix", 'b' => [$base . '/logo.png']]);
+            $x = SerializedPhpHandler::transformStrings($s, fn($str) => str_replace($base, $u, $str));
+            $parsed = unserialize($x);
+            assertEq("prefix {$u}/img.png suffix", $parsed['a']);
+            assertEq("{$u}/logo.png", $parsed['b'][0]);
+        }
+    });
+
+    TestRun::it('non-serialized plain string: transform applied directly', function () {
+        $out = SerializedPhpHandler::transformStrings('abc', fn($s) => strtoupper($s));
+        assertEq('ABC', $out);
+    });
+
+    TestRun::it('deterministic float repr', function () {
+        $f = 1.0 / 3.0;
+        $s1 = SerializedPhpHandler::serialize($f);
+        $s2 = SerializedPhpHandler::serialize($f);
+        assertEq($s1, $s2);
+        assertEq($f, unserialize($s1));
+    });
+});

--- a/php-dolt-sync/tests/Unit/SyncEngineTest.php
+++ b/php-dolt-sync/tests/Unit/SyncEngineTest.php
@@ -1,0 +1,173 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Store\Chunk;
+use WpSync\Store\ChunkStore;
+use WpSync\Store\SQLiteChunkStore;
+use WpSync\Sync\SyncEngine;
+
+/** Chunk store that counts calls and can fail after N get calls or during put. */
+final class FlakeyStore implements ChunkStore {
+    public int $failAfterCalls = -1;
+    public int $calls = 0;
+    public int $served = 0;
+    public function __construct(private ChunkStore $inner) {}
+    public function hasMany(array $hashes): array { return $this->inner->hasMany($hashes); }
+    public function getMany(array $hashes): array {
+        $this->calls++;
+        if ($this->failAfterCalls >= 0 && $this->calls > $this->failAfterCalls) {
+            throw new \RuntimeException('simulated network failure');
+        }
+        $r = $this->inner->getMany($hashes);
+        $this->served += count($r);
+        return $r;
+    }
+    public function putMany(array $chunks): void { $this->inner->putMany($chunks); }
+}
+
+/** Wraps a target chunk store to fail putMany after N total chunks written. */
+final class FlakeyTarget implements ChunkStore {
+    public int $written = 0;
+    public int $failAfterWrites = -1;
+    public function __construct(private ChunkStore $inner) {}
+    public function hasMany(array $hashes): array { return $this->inner->hasMany($hashes); }
+    public function getMany(array $hashes): array { return $this->inner->getMany($hashes); }
+    public function putMany(array $chunks): void {
+        if ($this->failAfterWrites >= 0 && $this->written + count($chunks) > $this->failAfterWrites) {
+            // Write the first N we're allowed, then throw.
+            $canWrite = max(0, $this->failAfterWrites - $this->written);
+            if ($canWrite > 0) {
+                $this->inner->putMany(array_slice($chunks, 0, $canWrite));
+                $this->written += $canWrite;
+            }
+            throw new \RuntimeException('simulated put failure');
+        }
+        $this->inner->putMany($chunks);
+        $this->written += count($chunks);
+    }
+}
+
+TestRun::group('SyncEngine', function () {
+    $newStore = static function () {
+        $p = tempnam(sys_get_temp_dir(), 'sync_'); unlink($p);
+        return new SQLiteChunkStore($p);
+    };
+
+    TestRun::it('copies chunks from source to target with refs', function () use ($newStore) {
+        $src = $newStore();
+        $dst = $newStore();
+        $leaf1 = Chunk::of('leaf1');
+        $leaf2 = Chunk::of('leaf2');
+        $root  = Chunk::of('root', [$leaf1->hash, $leaf2->hash]);
+        $src->putMany([$leaf1, $leaf2, $root]);
+
+        $eng = new SyncEngine();
+        $n = $eng->copyReachable($dst, $src, $root->hash);
+        assertEq(3, $n);
+        assertTrue(isset($dst->hasMany([$root->hash])[$root->hash]));
+    });
+
+    TestRun::it('skips chunks already present in target', function () use ($newStore) {
+        $src = $newStore();
+        $dst = $newStore();
+        $leaf1 = Chunk::of('leaf1');
+        $leaf2 = Chunk::of('leaf2');
+        $root  = Chunk::of('root', [$leaf1->hash, $leaf2->hash]);
+        $src->putMany([$leaf1, $leaf2, $root]);
+        $dst->putMany([$leaf1]); // pre-populate
+
+        $eng = new SyncEngine();
+        $n = $eng->copyReachable($dst, $src, $root->hash);
+        assertEq(2, $n);
+    });
+
+    TestRun::it('does not re-fetch duplicate refs', function () use ($newStore) {
+        $src = $newStore();
+        $dst = $newStore();
+        $shared = Chunk::of('shared');
+        $a = Chunk::of('A', [$shared->hash]);
+        $b = Chunk::of('B', [$shared->hash]);
+        $root = Chunk::of('R', [$a->hash, $b->hash]);
+        $src->putMany([$shared, $a, $b, $root]);
+
+        $flakey = new FlakeyStore($src);
+        $eng = new SyncEngine();
+        $n = $eng->copyReachable($dst, $flakey, $root->hash);
+        assertEq(4, $n);
+        // $shared must be fetched at most once (flakey counts total chunks served).
+        assertEq(4, $flakey->served);
+    });
+
+    TestRun::it('idempotent: second copy transfers zero', function () use ($newStore) {
+        $src = $newStore();
+        $dst = $newStore();
+        $leaf = Chunk::of('L');
+        $root = Chunk::of('R', [$leaf->hash]);
+        $src->putMany([$leaf, $root]);
+
+        $eng = new SyncEngine();
+        assertEq(2, $eng->copyReachable($dst, $src, $root->hash));
+        assertEq(0, $eng->copyReachable($dst, $src, $root->hash));
+    });
+
+    TestRun::it('interrupted copy leaves target consistent (no orphan chunks past failure)', function () use ($newStore) {
+        // We verify that after a failure, the target only contains chunks
+        // whose refs are all already satisfied (children written before parents).
+        $src = $newStore();
+        $dst = $newStore();
+        $leaves = [];
+        for ($i = 0; $i < 10; $i++) $leaves[] = Chunk::of("leaf{$i}");
+        $refs = array_map(fn(Chunk $c) => $c->hash, $leaves);
+        $root = Chunk::of('root', $refs);
+        $src->putMany(array_merge($leaves, [$root]));
+
+        $flakey = new FlakeyStore($src);
+        $flakey->failAfterCalls = 1;
+        $eng = new SyncEngine();
+        assertThrows(fn() => $eng->copyReachable($dst, $flakey, $root->hash));
+        // Root must not have been written (children incomplete).
+        assertTrue(!isset($dst->hasMany([$root->hash])[$root->hash]));
+    });
+
+    TestRun::it('resume after interruption transfers remaining', function () use ($newStore) {
+        // Interrupt during write phase. Some leaves get written, then put fails.
+        // On resume: already-written leaves are skipped; remaining leaves + root transfer.
+        $src = $newStore();
+        $dstInner = $newStore();
+        $leaves = [];
+        for ($i = 0; $i < 10; $i++) $leaves[] = Chunk::of("leaf{$i}");
+        $refs = array_map(fn(Chunk $c) => $c->hash, $leaves);
+        $root = Chunk::of('root', $refs);
+        $src->putMany(array_merge($leaves, [$root]));
+
+        $dst = new FlakeyTarget($dstInner);
+        $dst->failAfterWrites = 5; // allow 5 leaves to be written then fail
+        $eng = new SyncEngine();
+        try { $eng->copyReachable($dst, $src, $root->hash); } catch (\Throwable) {}
+        // Now 5 leaves are in dstInner; root not written.
+        $dst->failAfterWrites = -1;
+        $transferred = $eng->copyReachable($dst, $src, $root->hash);
+        // Should only transfer the remaining 5 leaves + root = 6.
+        assertTrue($transferred < 11, "resume transferred {$transferred}, expected < 11");
+        assertTrue(isset($dstInner->hasMany([$root->hash])[$root->hash]));
+    });
+
+    TestRun::it('isFastForward detects ancestor via commit walk', function () use ($newStore) {
+        $cs = $newStore();
+        // Build a fake commit chain: C0 <- C1 <- C2
+        $makeCommit = function (string $parent = null) use ($cs) {
+            $c = ['parents' => $parent ? [$parent] : [], 'root' => str_repeat('0', 64)];
+            $bytes = \WpSync\Encoding\CanonicalEncoder::encode($c);
+            $chunk = Chunk::of($bytes);
+            $cs->putMany([$chunk]);
+            return $chunk->hash;
+        };
+        $c0 = $makeCommit();
+        $c1 = $makeCommit($c0);
+        $c2 = $makeCommit($c1);
+        $eng = new SyncEngine();
+        assertTrue($eng->isFastForward($cs, $c2, $c0));
+        assertTrue($eng->isFastForward($cs, $c2, $c1));
+        assertTrue(!$eng->isFastForward($cs, $c1, $c2));
+    });
+});

--- a/php-dolt-sync/tests/Unit/TableTreeTest.php
+++ b/php-dolt-sync/tests/Unit/TableTreeTest.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Store\SQLiteChunkStore;
+use WpSync\Tree\TableTree;
+
+TestRun::group('TableTree', function () {
+    $newStore = static function () {
+        $p = tempnam(sys_get_temp_dir(), 'tree_'); unlink($p);
+        return new SQLiteChunkStore($p);
+    };
+
+    TestRun::it('empty tree has deterministic root', function () use ($newStore) {
+        $cs = $newStore();
+        $r1 = TableTree::build([], $cs);
+        $r2 = TableTree::build([], $cs);
+        assertEq($r1, $r2);
+    });
+
+    TestRun::it('single entry', function () use ($newStore) {
+        $cs = $newStore();
+        $r = TableTree::build([['k1', 'v1']], $cs);
+        assertEq('v1', TableTree::get($r, 'k1', $cs));
+        assertEq(null, TableTree::get($r, 'missing', $cs));
+    });
+
+    TestRun::it('exactly FANOUT entries (one full leaf)', function () use ($newStore) {
+        $cs = $newStore();
+        $entries = [];
+        for ($i = 1; $i <= TableTree::FANOUT; $i++) {
+            $entries[] = [sprintf('%08d', $i), "v{$i}"];
+        }
+        $r = TableTree::build($entries, $cs);
+        assertEq('v32', TableTree::get($r, sprintf('%08d', 32), $cs));
+    });
+
+    TestRun::it('FANOUT+1 entries forces a split', function () use ($newStore) {
+        $cs = $newStore();
+        $n = TableTree::FANOUT + 1;
+        $entries = [];
+        for ($i = 1; $i <= $n; $i++) {
+            $entries[] = [sprintf('%08d', $i), "v{$i}"];
+        }
+        $r = TableTree::build($entries, $cs);
+        assertEq("v{$n}", TableTree::get($r, sprintf('%08d', $n), $cs));
+    });
+
+    TestRun::it('determinism across insertion orders (10k entries)', function () use ($newStore) {
+        $cs = $newStore();
+        $entries1 = [];
+        for ($i = 0; $i < 10000; $i++) {
+            $entries1[] = [pack('J', $i), "v{$i}"];
+        }
+        $entries2 = $entries1;
+        shuffle($entries2);
+        $r1 = TableTree::build($entries1, $cs);
+        $r2 = TableTree::build($entries2, $cs);
+        assertEq($r1, $r2);
+    });
+
+    TestRun::it('iterate yields sorted entries', function () use ($newStore) {
+        $cs = $newStore();
+        $entries = [['b', '2'], ['a', '1'], ['c', '3']];
+        $r = TableTree::build($entries, $cs);
+        $out = iterator_to_array(TableTree::iterate($r, $cs), false);
+        assertEq([['a','1'], ['b','2'], ['c','3']], $out);
+    });
+});

--- a/php-dolt-sync/tests/Unit/TreeDiffTest.php
+++ b/php-dolt-sync/tests/Unit/TreeDiffTest.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+use WpSync\Store\SQLiteChunkStore;
+use WpSync\Tree\TableTree;
+
+/**
+ * A ChunkStore decorator counting getMany calls, to verify diff is O(log n).
+ */
+final class CountingStore implements \WpSync\Store\ChunkStore {
+    public int $getCalls = 0;
+    public int $chunksFetched = 0;
+    public function __construct(private \WpSync\Store\ChunkStore $inner) {}
+    public function hasMany(array $hashes): array { return $this->inner->hasMany($hashes); }
+    public function getMany(array $hashes): array {
+        $this->getCalls++;
+        $r = $this->inner->getMany($hashes);
+        $this->chunksFetched += count($r);
+        return $r;
+    }
+    public function putMany(array $chunks): void { $this->inner->putMany($chunks); }
+}
+
+TestRun::group('TreeDiff', function () {
+    $newStore = static function () {
+        $p = tempnam(sys_get_temp_dir(), 'tree_'); unlink($p);
+        return new SQLiteChunkStore($p);
+    };
+
+    TestRun::it('identical trees -> zero diff', function () use ($newStore) {
+        $cs = $newStore();
+        $e = [['a','1'], ['b','2']];
+        $r = TableTree::build($e, $cs);
+        assertEq([], iterator_to_array(TableTree::diff($r, $r, $cs), false));
+    });
+
+    TestRun::it('changed entry yields exactly one diff', function () use ($newStore) {
+        $cs = $newStore();
+        $e1 = [['a','1'], ['b','2'], ['c','3']];
+        $e2 = [['a','1'], ['b','X'], ['c','3']];
+        $r1 = TableTree::build($e1, $cs);
+        $r2 = TableTree::build($e2, $cs);
+        $d = iterator_to_array(TableTree::diff($r1, $r2, $cs), false);
+        assertEq(1, count($d));
+        assertEq(['b', '2', 'X'], $d[0]);
+    });
+
+    TestRun::it('added entry', function () use ($newStore) {
+        $cs = $newStore();
+        $r1 = TableTree::build([['a','1']], $cs);
+        $r2 = TableTree::build([['a','1'], ['b','2']], $cs);
+        $d = iterator_to_array(TableTree::diff($r1, $r2, $cs), false);
+        assertEq([['b', null, '2']], $d);
+    });
+
+    TestRun::it('deleted entry', function () use ($newStore) {
+        $cs = $newStore();
+        $r1 = TableTree::build([['a','1'], ['b','2']], $cs);
+        $r2 = TableTree::build([['a','1']], $cs);
+        $d = iterator_to_array(TableTree::diff($r1, $r2, $cs), false);
+        assertEq([['b', '2', null]], $d);
+    });
+
+    TestRun::it('diff skips unchanged subtrees (logarithmic fetch)', function () use ($newStore) {
+        $cs = $newStore();
+        $entries = [];
+        for ($i = 0; $i < 10000; $i++) {
+            $entries[] = [sprintf('%08d', $i), "v{$i}"];
+        }
+        $r1 = TableTree::build($entries, $cs);
+        // change one entry
+        $entries[5000] = [sprintf('%08d', 5000), 'CHANGED'];
+        $r2 = TableTree::build($entries, $cs);
+
+        $counter = new CountingStore($cs);
+        $d = iterator_to_array(TableTree::diff($r1, $r2, $counter), false);
+        assertEq(1, count($d));
+        // For 10k entries, FANOUT=64: depth ~ log_64(10000/64) = ~ 2 levels above leaves.
+        // Diff should fetch at most a handful of chunks; bound at 100 is very loose but
+        // guarantees not O(n).
+        assertTrue($counter->chunksFetched < 100, "diff fetched {$counter->chunksFetched} chunks, expected << 10000");
+    });
+});

--- a/php-dolt-sync/tests/harness/InProcessTransport.php
+++ b/php-dolt-sync/tests/harness/InProcessTransport.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Test\Harness;
+
+use WpSync\Store\Chunk;
+use WpSync\Store\ChunkStore;
+use WpSync\Store\RefStore;
+
+/**
+ * In-process transport that routes HttpChunkStore calls directly to a
+ * server-side ChunkStore + RefStore, without actually making HTTP requests.
+ * Drives the same JSON protocol the real mu-plugin REST endpoints implement,
+ * so it exercises the same code paths.
+ */
+final class InProcessTransport
+{
+    /** Optional failure hook: called with ($method, $path, $chunksSeen) -> null|throw */
+    public $failureHook = null;
+
+    /** Count of chunks transferred via /chunks/put so far. */
+    public int $putCount = 0;
+    public int $getCount = 0;
+    public int $hasCount = 0;
+
+    public function __construct(
+        public readonly ChunkStore $chunks,
+        public readonly RefStore $refs,
+    ) {}
+
+    public function asCallable(): callable
+    {
+        return function (string $method, string $path, ?string $body, array $headers): array {
+            return $this->handle($method, $path, $body);
+        };
+    }
+
+    public function handle(string $method, string $path, ?string $body): array
+    {
+        $json = $body === null ? [] : json_decode($body, true, flags: JSON_THROW_ON_ERROR);
+
+        if ($method === 'POST' && $path === '/wp-json/sync/v1/chunks/has') {
+            $this->hasCount++;
+            return ['status' => 200, 'body' => json_encode([
+                'present' => $this->chunks->hasMany($json['hashes'] ?? [])
+            ])];
+        }
+        if ($method === 'POST' && $path === '/wp-json/sync/v1/chunks/get') {
+            $this->getCount++;
+            $out = [];
+            foreach ($this->chunks->getMany($json['hashes'] ?? []) as $c) {
+                $out[] = ['hash' => $c->hash, 'data' => base64_encode($c->bytes), 'refs' => $c->refs];
+            }
+            return ['status' => 200, 'body' => json_encode(['chunks' => $out])];
+        }
+        if ($method === 'POST' && $path === '/wp-json/sync/v1/chunks/put') {
+            $input = $json['chunks'] ?? [];
+            if ($this->failureHook) {
+                $r = ($this->failureHook)($method, $path, $this->putCount);
+                if ($r === 'fail') {
+                    return ['status' => 500, 'body' => '{"error":"simulated"}'];
+                }
+            }
+            $objs = [];
+            foreach ($input as $c) {
+                $raw = base64_decode($c['data'], true);
+                $objs[] = new Chunk($c['hash'], $raw, $c['refs'] ?? []);
+            }
+            $this->chunks->putMany($objs);
+            $this->putCount += count($objs);
+            return ['status' => 200, 'body' => json_encode(['stored' => count($objs)])];
+        }
+        if ($method === 'GET' && $path === '/wp-json/sync/v1/refs') {
+            return ['status' => 200, 'body' => json_encode($this->refs->listRefs())];
+        }
+        if ($method === 'PUT' && str_starts_with($path, '/wp-json/sync/v1/refs/')) {
+            $name = rawurldecode(substr($path, strlen('/wp-json/sync/v1/refs/')));
+            $old = $json['old'] ?? null;
+            $new = (string)($json['new'] ?? '');
+            $ok = $this->refs->casRef($name, $old === null || $old === '' ? null : (string)$old, $new);
+            if (!$ok) {
+                return ['status' => 409, 'body' => '{"ok":false,"error":"cas_mismatch"}'];
+            }
+            return ['status' => 200, 'body' => '{"ok":true}'];
+        }
+        return ['status' => 404, 'body' => '{"error":"not-found"}'];
+    }
+}

--- a/php-dolt-sync/tests/harness/WpFixture.php
+++ b/php-dolt-sync/tests/harness/WpFixture.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace WpSync\Test\Harness;
+
+/** Minimal WordPress-like SQLite schema for integration tests. */
+final class WpFixture
+{
+    public static function createDb(string $siteUrl = 'https://site-a.test'): \SQLite3
+    {
+        $p = tempnam(sys_get_temp_dir(), 'wp_'); unlink($p);
+        $db = new \SQLite3($p);
+        $db->enableExceptions(true);
+        $db->exec('PRAGMA journal_mode=WAL');
+        $db->exec(<<<SQL
+            CREATE TABLE wp_posts (
+                ID INTEGER PRIMARY KEY AUTOINCREMENT,
+                post_author INTEGER NOT NULL DEFAULT 0,
+                post_date TEXT NOT NULL,
+                post_date_gmt TEXT NOT NULL,
+                post_content TEXT NOT NULL,
+                post_title TEXT NOT NULL,
+                post_excerpt TEXT NOT NULL DEFAULT '',
+                post_status TEXT NOT NULL DEFAULT 'publish',
+                post_modified TEXT NOT NULL,
+                post_modified_gmt TEXT NOT NULL,
+                guid TEXT NOT NULL
+            )
+        SQL);
+        $db->exec(<<<SQL
+            CREATE TABLE wp_options (
+                option_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                option_name TEXT NOT NULL UNIQUE,
+                option_value TEXT NOT NULL,
+                autoload TEXT NOT NULL DEFAULT 'yes'
+            )
+        SQL);
+        $db->exec(<<<SQL
+            CREATE TABLE wp_postmeta (
+                meta_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                post_id INTEGER NOT NULL,
+                meta_key TEXT NOT NULL,
+                meta_value TEXT
+            )
+        SQL);
+        // A plugin table without a primary key (exercises rowid fallback).
+        $db->exec(<<<SQL
+            CREATE TABLE plugin_noprimary (
+                a TEXT NOT NULL,
+                b TEXT NOT NULL
+            )
+        SQL);
+        $db->exec("INSERT INTO wp_options(option_name, option_value) VALUES('siteurl', '" . $siteUrl . "')");
+        $db->exec("INSERT INTO wp_options(option_name, option_value) VALUES('home', '" . $siteUrl . "')");
+        return $db;
+    }
+
+    private static int $nextGuid = 100;
+    public static function insertPost(\SQLite3 $db, string $title, string $content, string $guidHost = 'https://site-a.test', ?int $guidN = null): int
+    {
+        $date = '2024-01-01 12:00:00';
+        $stmt = $db->prepare(<<<SQL
+            INSERT INTO wp_posts (post_date, post_date_gmt, post_content, post_title, post_modified, post_modified_gmt, guid)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        SQL);
+        $stmt->bindValue(1, $date); $stmt->bindValue(2, $date);
+        $stmt->bindValue(3, $content); $stmt->bindValue(4, $title);
+        $stmt->bindValue(5, $date); $stmt->bindValue(6, $date);
+        $stmt->bindValue(7, "{$guidHost}/?p=" . ($guidN ?? self::$nextGuid++));
+        $stmt->execute();
+        return (int)$db->lastInsertRowID();
+    }
+}

--- a/php-dolt-sync/tests/run.php
+++ b/php-dolt-sync/tests/run.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+/**
+ * Test runner. Discovers tests/*Test.php files and runs assertions.
+ * Zero-dependency: uses a tiny in-file test framework.
+ */
+
+require __DIR__ . '/../plugin/wp-sync/src/autoload.php';
+
+spl_autoload_register(function (string $class): void {
+    $prefix = 'WpSync\\Test\\';
+    if (!str_starts_with($class, $prefix)) return;
+    $rel = substr($class, strlen($prefix));
+    $path = __DIR__ . '/' . str_replace('\\', '/', $rel) . '.php';
+    if (is_file($path)) require $path;
+});
+
+final class TestRun {
+    public static int $pass = 0;
+    public static int $fail = 0;
+    public static array $currentGroup = [];
+
+    public static function group(string $name, callable $fn): void {
+        echo "\n=== {$name} ===\n";
+        self::$currentGroup[] = $name;
+        try { $fn(); } catch (\Throwable $e) {
+            self::$fail++;
+            echo "  FAIL (uncaught): " . $e->getMessage() . "\n" . $e->getTraceAsString() . "\n";
+        }
+        array_pop(self::$currentGroup);
+    }
+
+    public static function it(string $name, callable $fn): void {
+        try {
+            $fn();
+            self::$pass++;
+            echo "  ok: {$name}\n";
+        } catch (\Throwable $e) {
+            self::$fail++;
+            echo "  FAIL: {$name}\n    " . $e->getMessage() . "\n";
+        }
+    }
+}
+
+function assertTrue(bool $cond, string $msg = ''): void {
+    if (!$cond) throw new \RuntimeException('assertTrue: ' . $msg);
+}
+function assertEq(mixed $expected, mixed $actual, string $msg = ''): void {
+    if ($expected !== $actual) {
+        throw new \RuntimeException("assertEq failed ({$msg}): expected=" . var_export($expected, true) . ' actual=' . var_export($actual, true));
+    }
+}
+function assertNotEq(mixed $a, mixed $b, string $msg = ''): void {
+    if ($a === $b) throw new \RuntimeException('assertNotEq failed: ' . $msg);
+}
+function assertThrows(callable $fn, string $msg = ''): \Throwable {
+    try { $fn(); } catch (\Throwable $e) { return $e; }
+    throw new \RuntimeException('assertThrows: no exception thrown: ' . $msg);
+}
+
+$dir = __DIR__;
+$tests = [
+    $dir . '/Unit/CanonicalEncoderTest.php',
+    $dir . '/Unit/CborTestVectorsTest.php',
+    $dir . '/Unit/SQLiteChunkStoreTest.php',
+    $dir . '/Unit/SQLiteRefStoreTest.php',
+    $dir . '/Unit/TableTreeTest.php',
+    $dir . '/Unit/TreeDiffTest.php',
+    $dir . '/Unit/SyncEngineTest.php',
+    $dir . '/Unit/RowNormalizerTest.php',
+    $dir . '/Unit/SerializedPhpHandlerTest.php',
+    $dir . '/Integration/SnapshotRoundTripTest.php',
+    $dir . '/Integration/SyncBetweenStoresTest.php',
+    $dir . '/Integration/IncrementalSyncTest.php',
+    $dir . '/Integration/DirtyTrackingTest.php',
+    $dir . '/Integration/FailureModesTest.php',
+    $dir . '/EndToEnd/FullPushPullCycleTest.php',
+    $dir . '/EndToEnd/ConflictDetectionTest.php',
+];
+
+foreach ($tests as $f) {
+    if (is_file($f)) require $f;
+}
+
+echo "\n--- TOTAL: " . TestRun::$pass . " passed, " . TestRun::$fail . " failed ---\n";
+exit(TestRun::$fail === 0 ? 0 : 1);

--- a/php-dolt-sync/tests/smoke.php
+++ b/php-dolt-sync/tests/smoke.php
@@ -1,0 +1,124 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../src/autoload.php';
+
+use WpSync\Encoding\CanonicalEncoder;
+use WpSync\Store\SQLiteChunkStore;
+use WpSync\Store\Chunk;
+use WpSync\Tree\TableTree;
+
+function check(bool $cond, string $msg): void {
+    if (!$cond) {
+        fwrite(STDERR, "FAIL: $msg\n");
+        exit(1);
+    }
+    echo "ok: $msg\n";
+}
+
+// --- Canonical encoder determinism ---
+$a = ['b' => 1, 'a' => 2];
+$b = ['a' => 2, 'b' => 1];
+check(CanonicalEncoder::encode($a) === CanonicalEncoder::encode($b), 'map key sort: different insertion order -> same bytes');
+
+// RFC 8949 Appendix A examples
+check(bin2hex(CanonicalEncoder::encode(0)) === '00', 'uint 0 -> 0x00');
+check(bin2hex(CanonicalEncoder::encode(1)) === '01', 'uint 1 -> 0x01');
+check(bin2hex(CanonicalEncoder::encode(10)) === '0a', 'uint 10 -> 0x0a');
+check(bin2hex(CanonicalEncoder::encode(23)) === '17', 'uint 23 -> 0x17');
+check(bin2hex(CanonicalEncoder::encode(24)) === '1818', 'uint 24 -> 0x1818');
+check(bin2hex(CanonicalEncoder::encode(100)) === '1864', 'uint 100 -> 0x1864');
+check(bin2hex(CanonicalEncoder::encode(1000)) === '1903e8', 'uint 1000 -> 0x1903e8');
+check(bin2hex(CanonicalEncoder::encode(-1)) === '20', 'nint -1 -> 0x20');
+check(bin2hex(CanonicalEncoder::encode(-10)) === '29', 'nint -10 -> 0x29');
+check(bin2hex(CanonicalEncoder::encode(-100)) === '3863', 'nint -100 -> 0x3863');
+check(bin2hex(CanonicalEncoder::encode(false)) === 'f4', 'false -> 0xf4');
+check(bin2hex(CanonicalEncoder::encode(true)) === 'f5', 'true -> 0xf5');
+check(bin2hex(CanonicalEncoder::encode(null)) === 'f6', 'null -> 0xf6');
+check(bin2hex(CanonicalEncoder::encode([])) === '80', 'empty array -> 0x80');
+check(bin2hex(CanonicalEncoder::encode([1,2,3])) === '83010203', '[1,2,3] -> 0x83010203');
+
+// Float NaN normalization
+$n1 = CanonicalEncoder::encode(NAN);
+$n2 = CanonicalEncoder::encode(NAN);
+check($n1 === $n2, 'NaN encodes deterministically');
+check(bin2hex($n1) === 'fb7ff8000000000000', 'NaN -> canonical quiet NaN');
+
+// -0 normalization
+check(CanonicalEncoder::encode(-0.0) === CanonicalEncoder::encode(0.0), '-0.0 == 0.0');
+
+// Integer-float coercion
+check(CanonicalEncoder::encode(3.0) === CanonicalEncoder::encode(3), '3.0 coerces to 3');
+
+// Round trip
+$v = ['x' => [1, 2.5, 'hello', true, null], 'y' => 'world'];
+check(CanonicalEncoder::decode(CanonicalEncoder::encode($v)) == $v, 'round trip map/list/scalars');
+
+// NULL vs ''
+check(CanonicalEncoder::hash(null) !== CanonicalEncoder::hash(''), 'null distinct from empty string');
+
+// UTF-8 NFC
+$nfd = "cafe\xcc\x81"; // café with combining acute
+$nfc = "caf\xc3\xa9";
+check(CanonicalEncoder::hash($nfd) === CanonicalEncoder::hash($nfc), 'NFC normalization unifies accents');
+
+// Invalid UTF-8 rejected
+$caught = false;
+try { CanonicalEncoder::encode("\xff\xfe"); } catch (\InvalidArgumentException) { $caught = true; }
+check($caught, 'invalid UTF-8 is rejected');
+
+// --- Chunk store ---
+$tmp = tempnam(sys_get_temp_dir(), 'chunks_');
+unlink($tmp);
+$cs = new SQLiteChunkStore($tmp);
+$c = Chunk::of('hello world');
+$cs->putMany([$c]);
+$has = $cs->hasMany([$c->hash, 'abc']);
+check(isset($has[$c->hash]) && !isset($has['abc']), 'hasMany works');
+$got = $cs->getMany([$c->hash]);
+check($got[$c->hash]->bytes === 'hello world', 'getMany works');
+
+// Bad hash rejected
+$bad = new Chunk(str_repeat('a', 64), 'different');
+$rejected = false;
+try { $cs->putMany([$bad]); } catch (\RuntimeException $e) { $rejected = true; }
+check($rejected, 'bad hash rejected');
+
+// Idempotent put
+$cs->putMany([$c]);
+check($cs->count() === 1, 'idempotent put');
+
+// --- TableTree determinism ---
+$entries1 = [];
+for ($i = 1; $i <= 100; $i++) {
+    $entries1[] = [pack('J', $i), "value_$i"];
+}
+$entries2 = $entries1;
+shuffle($entries2);
+
+$r1 = TableTree::build($entries1, $cs);
+$r2 = TableTree::build($entries2, $cs);
+check($r1 === $r2, 'tree determinism across insertion order');
+
+$val = TableTree::get($r1, pack('J', 42), $cs);
+check($val === 'value_42', 'tree get returns correct value');
+
+$iterated = iterator_to_array(TableTree::iterate($r1, $cs), false);
+check(count($iterated) === 100, 'iterate yields all entries');
+check($iterated[0][1] === 'value_1', 'iterate is sorted');
+
+// Empty tree
+$re = TableTree::build([], $cs);
+$re2 = TableTree::build([], $cs);
+check($re === $re2, 'empty tree deterministic');
+check(iterator_to_array(TableTree::iterate($re, $cs), false) === [], 'empty tree iterates empty');
+
+// Diff
+$entriesMod = $entries1;
+$entriesMod[42] = [pack('J', 43), 'CHANGED']; // changing the 43rd entry
+$rMod = TableTree::build($entriesMod, $cs);
+$diff = iterator_to_array(TableTree::diff($r1, $rMod, $cs), false);
+$changed = array_filter($diff, fn($d) => $d[0] === pack('J', 43));
+check(count($diff) === 1 && count($changed) === 1, 'diff yields exactly changed entry');
+
+echo "\nAll smoke tests passed.\n";


### PR DESCRIPTION
## Summary

- Dolt-style content-addressed storage (canonical CBOR, SHA-256 chunks, atomic ref CAS, sorted B-tree with hash-skipping diff) for a WordPress + SQLite database
- Packaged as a regular WP plugin (`plugin/wp-sync/`) with REST endpoints under `/wp-json/sync/v1/*` and wp-cli commands (`wp sync commit|push|pull|log|status`)
- Two-container docker-compose demo (`docker/`) with `setup.sh` + scripted `demo.sh` that exercises a full A→B→A round-trip in ~15s
- Built in a single-shot adversarial implementer/verifier loop; full brief in `SPEC.md`

## Test plan
- [ ] \`cd php-dolt-sync && ./run-tests.sh\` — 98/98 pass
- [ ] \`cd php-dolt-sync/docker && ./setup.sh && ./demo.sh\` — create post on A, sync to B, edit on B, sync back to A
- [ ] Inspect \`http://localhost:8081\` and \`:8082\` in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)