### PR TITLE
Fix update-readme workflow: missing contents:read permission

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -8,6 +8,7 @@ jobs:
   update-readme:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- The `update-readme` workflow declared `permissions: issues: write`, which implicitly zeroes every other permission — so `actions/checkout` couldn't read the repo and every run failed at clone time with `Repository not found / exit 128`.
- Example failing run: https://github.com/adamziel/experiments/actions/runs/24429337741
- Fix is a single line: add `contents: read` to the permissions block.

## Test plan
- [ ] Merge this PR
- [ ] Watch the next push-to-main run of the Update README workflow reach the issue-creation step without failing at checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)