### PR TITLE
Fix update-readme workflow: assign Copilot via GraphQL, not REST

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -77,11 +77,44 @@ jobs:
               `Triggered by commit ${context.sha.slice(0, 7)} on \`main\`.`,
             ].join("\n");
 
-            await github.rest.issues.create({
+            const created = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: 'Update README.md',
               body,
               labels: ['auto-readme'],
-              assignees: ['copilot'],
             });
+
+            // Assign the GitHub Copilot coding agent via GraphQL, since
+            // Copilot is a bot actor and the REST `assignees` field only
+            // accepts real user logins. If Copilot isn't enabled on this
+            // repo, log and move on — the issue still exists.
+            try {
+              const suggested = await github.graphql(
+                `query($owner:String!, $name:String!) {
+                  repository(owner:$owner, name:$name) {
+                    suggestedActors(capabilities:[CAN_BE_ASSIGNED], first: 50) {
+                      nodes { login __typename ... on Bot { id } ... on User { id } }
+                    }
+                  }
+                }`,
+                { owner: context.repo.owner, name: context.repo.repo },
+              );
+              const copilot = (suggested.repository.suggestedActors.nodes || [])
+                .find(n => n && n.login && /copilot/i.test(n.login) && n.id);
+              if (!copilot) {
+                core.warning('Copilot coding agent is not available as a suggested assignee on this repository; issue created without assignee.');
+              } else {
+                await github.graphql(
+                  `mutation($assignable:ID!, $actor:ID!) {
+                    replaceActorsForAssignable(input:{ assignableId:$assignable, actorIds:[$actor] }) {
+                      assignable { ... on Issue { number } }
+                    }
+                  }`,
+                  { assignable: created.data.node_id, actor: copilot.id },
+                );
+                core.info(`Assigned ${copilot.login} to issue #${created.data.number}`);
+              }
+            } catch (err) {
+              core.warning(`Could not assign Copilot: ${err.message}`);
+            }


### PR DESCRIPTION
## Summary
- `POST /repos/{o}/{r}/issues` with `assignees: ['copilot']` returns `422 Validation Failed` because Copilot is a bot actor, not a user login — the REST `assignees` field only accepts real user logins. Every run of Update README has been failing here (example: https://github.com/adamziel/experiments/actions/runs/24441677868).
- Split into two calls: create the issue via REST (no assignees), then assign Copilot via GraphQL `replaceActorsForAssignable` using the bot ID returned by `repository.suggestedActors(capabilities:[CAN_BE_ASSIGNED])`.
- Wrapped the GraphQL block in try/catch so the workflow still succeeds if Copilot isn't enabled on the repo — the issue is still created.

## Verification
Queried the real API against this repo to confirm `copilot-swe-agent` is in `suggestedActors` with a usable node ID:

```
{"login":"copilot-swe-agent","__typename":"Bot","id":"BOT_kgDOC9w8XQ"}
```

So on the next push to `main` after merge, the workflow will create the issue and assign `copilot-swe-agent` via GraphQL.

## Test plan
- [ ] Merge this PR
- [ ] Watch the next push-to-`main` run of Update README complete successfully
- [ ] Confirm the created issue is assigned to Copilot

🤖 Generated with [Claude Code](https://claude.com/claude-code)