### PR TITLE
Add wp-themes: 10 WordPress block themes inspired by famous artists

### DIFF
--- a/.github/workflows/wp-themes.yml
+++ b/.github/workflows/wp-themes.yml
@@ -1,0 +1,31 @@
+name: wp-themes
+
+on:
+  pull_request:
+    paths:
+      - 'wp-themes/**'
+      - '.github/workflows/wp-themes.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'wp-themes/**'
+      - '.github/workflows/wp-themes.yml'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Validate 10 artist themes
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: wp-themes
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, intl, json
+          coverage: none
+          tools: none
+      - run: php --version
+      - run: ./run-tests.sh

--- a/wp-themes/README.md
+++ b/wp-themes/README.md
@@ -1,0 +1,40 @@
+# Artist-Inspired WordPress Block Themes
+
+A collection of 10 WordPress block themes, each inspired by a famous artist from a different medium.
+
+| # | Theme | Artist | Medium | Design Rationale |
+|---|-------|--------|--------|-----------------|
+| 1 | `gaudi` | Antoni Gaudí | Architecture / Art Nouveau | Organic mosaic palettes and curvilinear sensibility inspired by Park Güell and the Sagrada Família |
+| 2 | `rafael` | Raphael (Raffaello Sanzio) | Renaissance Painting | Warm golden tones, balanced proportions, and classical elegance from the Italian High Renaissance |
+| 3 | `hundertwasser` | Friedensreich Hundertwasser | Architecture + Painting | Vivid, irregular colors and whimsical nature-loving forms from the Hundertwasserhaus era |
+| 4 | `hitchcock` | Alfred Hitchcock | Cinema / Thriller | Dramatic noir contrasts, suspenseful typography, and dark palettes from classic thriller cinema |
+| 5 | `basquiat` | Jean-Michel Basquiat | Neo-Expressionist Painting | Raw primary colors, gritty street-art typography, and urban energy from 1980s New York |
+| 6 | `ansel-adams` | Ansel Adams | Photography | Monochromatic zone-system tonal range evoking the grandeur of American West landscapes |
+| 7 | `giacometti` | Alberto Giacometti | Sculpture | Spare bronze-and-stone palette with elongated vertical rhythms and existentialist minimalism |
+| 8 | `wes-anderson` | Wes Anderson | Cinema | Pastel symmetry, whimsical retro-modern typography, and meticulously composed layouts |
+| 9 | `bjork` | Björk | Music / Avant-Garde | Otherworldly glacial-volcanic palettes and organic-digital hybrid aesthetics |
+| 10 | `kusama` | Yayoi Kusama | Installation Art | Bold polka-dot-inspired contrasts and immersive infinity-room color experiences |
+
+## Media Coverage
+
+- **Architecture**: Gaudí, Hundertwasser
+- **Painting**: Raphael, Basquiat
+- **Photography**: Ansel Adams
+- **Sculpture**: Giacometti
+- **Cinema**: Hitchcock, Wes Anderson
+- **Music**: Björk
+- **Installation Art**: Kusama
+
+## Usage
+
+Each theme is a standalone WordPress block theme compatible with WordPress 6.4+. Install by copying the theme directory into `wp-content/themes/`.
+
+## Testing
+
+```bash
+./run-tests.sh
+```
+
+## License
+
+All themes are licensed under GPL v2 or later. These are stylized homages to each artist's aesthetic — no copyrighted imagery is used.

--- a/wp-themes/ansel-adams/README.md
+++ b/wp-themes/ansel-adams/README.md
@@ -1,0 +1,37 @@
+# Ansel Adams -- WordPress Block Theme
+
+A WordPress block theme inspired by the dramatic black-and-white landscape photography of Ansel Adams (1902--1984).
+
+## Design Notes
+
+This theme draws from the visual language of Adams' iconic photographic work:
+
+- **Zone System palette**: The color palette references Adams' famous Zone System, a technique for precise exposure and development control. Each swatch maps to a tonal zone, from pure black (Zone 0) through middle gray (Zone VI) to pure white (Zone X).
+- **Typography**: Playfair Display is used for headings, evoking the elegance of mid-century fine-art printing. Source Serif Pro provides a clean, readable body font with a traditional serif character.
+- **Layout**: Generous whitespace and constrained content widths mirror the careful compositions and print borders Adams was known for.
+- **High contrast**: Strong blacks and clean whites reflect the hallmark tonal range of Adams' gelatin silver prints.
+- **Moonrise style variation**: A warmer sepia-toned palette inspired by the warm-tone printing papers and selenium toning that Adams sometimes used, particularly in prints like "Moonrise, Hernandez, New Mexico."
+
+## Included Files
+
+- `theme.json` -- Global settings and styles (palette, typography, layout, element styles)
+- `style.css` -- Theme metadata header
+- `templates/index.html` -- Blog index template with query loop
+- `templates/single.html` -- Single post template with comments
+- `parts/header.html` -- Site header with title and navigation
+- `parts/footer.html` -- Site footer with credits
+- `patterns/hero.php` -- Dramatic full-screen hero section
+- `styles/moonrise.json` -- Warm sepia style variation
+
+## Requirements
+
+- WordPress 6.4 or later
+- PHP 7.4 or later
+
+## Homage Disclaimer
+
+This theme is an artistic homage and educational project. It is not affiliated with, endorsed by, or connected to the Ansel Adams Publishing Rights Trust or the Ansel Adams Gallery. The theme does not contain any copyrighted photographs or proprietary material belonging to Ansel Adams or his estate. All design choices are original interpretations inspired by the public aesthetic legacy of Adams' photographic style.
+
+## License
+
+GNU General Public License v2 or later. See [LICENSE](http://www.gnu.org/licenses/gpl-2.0.html).

--- a/wp-themes/ansel-adams/parts/footer.html
+++ b/wp-themes/ansel-adams/parts/footer.html
@@ -1,0 +1,15 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"2rem","bottom":"2rem"}},"border":{"top":{"color":"var(--wp--preset--color--pure-black)","width":"2px","style":"solid"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--pure-black);border-top-style:solid;border-top-width:2px;padding-top:2rem;padding-bottom:2rem">
+	<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":"var(--wp--preset--font-size--small)"}}} -->
+		<p style="font-size:var(--wp--preset--font-size--small)">Designed with the spirit of Ansel Adams. Powered by WordPress.</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":"var(--wp--preset--font-size--small)"}}} -->
+		<p style="font-size:var(--wp--preset--font-size--small)">&copy; 2024 &middot; All rights reserved.</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/ansel-adams/parts/header.html
+++ b/wp-themes/ansel-adams/parts/header.html
@@ -1,0 +1,11 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"1.5rem","bottom":"1.5rem"}},"border":{"bottom":{"color":"var(--wp--preset--color--pure-black)","width":"2px","style":"solid"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="border-bottom-color:var(--wp--preset--color--pure-black);border-bottom-style:solid;border-bottom-width:2px;padding-top:1.5rem;padding-bottom:1.5rem">
+	<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group">
+		<!-- wp:site-title {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var(--wp--preset--color--pure-black)"},":hover":{"color":{"text":"var(--wp--preset--color--zone-iv)"}}}}}} /-->
+
+		<!-- wp:navigation {"overlayMenu":"mobile","layout":{"type":"flex","justifyContent":"right"},"style":{"typography":{"fontFamily":"var(--wp--preset--font-family--system-sans)","fontSize":"var(--wp--preset--font-size--small)","letterSpacing":"0.08em","textTransform":"uppercase"}}} /-->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/ansel-adams/patterns/hero.php
+++ b/wp-themes/ansel-adams/patterns/hero.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Title: Hero
+ * Slug: ansel-adams/hero
+ * Categories: featured
+ * Description: A dramatic hero section inspired by Ansel Adams' monochrome landscape photography
+ */
+?>
+<!-- wp:cover {"dimRatio":60,"overlayColor":"pure-black","isUserOverlayColor":true,"minHeight":85,"minHeightUnit":"vh","align":"full","style":{"spacing":{"padding":{"top":"4rem","bottom":"4rem","left":"2rem","right":"2rem"}}}} -->
+<div class="wp-block-cover alignfull" style="padding-top:4rem;padding-right:2rem;padding-bottom:4rem;padding-left:2rem;min-height:85vh">
+	<span aria-hidden="true" class="wp-block-cover__background has-pure-black-background-color has-background-dim-60 has-background-dim"></span>
+	<div class="wp-block-cover__inner-container">
+		<!-- wp:group {"layout":{"type":"constrained","contentSize":"720px"}} -->
+		<div class="wp-block-group">
+			<!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontSize":"var(--wp--preset--font-size--xx-large)","letterSpacing":"0.05em","textTransform":"uppercase","fontWeight":"700"},"color":{"text":"var(--wp--preset--color--pure-white)"}}} -->
+			<h1 class="has-text-align-center has-text-color" style="color:var(--wp--preset--color--pure-white);font-size:var(--wp--preset--font-size--xx-large);font-weight:700;letter-spacing:0.05em;text-transform:uppercase"><?php echo esc_html__( 'The Mountains Are Calling', 'ansel-adams' ); ?></h1>
+			<!-- /wp:heading -->
+
+			<!-- wp:separator {"style":{"color":{"text":"var(--wp--preset--color--zone-viii)"}},"className":"is-style-wide"} -->
+			<hr class="wp-block-separator has-text-color is-style-wide" style="color:var(--wp--preset--color--zone-viii)"/>
+			<!-- /wp:separator -->
+
+			<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"var(--wp--preset--font-size--large)","fontStyle":"italic","fontWeight":"400"},"color":{"text":"var(--wp--preset--color--zone-viii)"}}} -->
+			<p class="has-text-align-center has-text-color" style="color:var(--wp--preset--color--zone-viii);font-size:var(--wp--preset--font-size--large);font-style:italic;font-weight:400"><?php echo esc_html__( 'A landscape photograph that does not convey a sense of awe is not a landscape photograph at all.', 'ansel-adams' ); ?></p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:spacer {"height":"2rem"} -->
+			<div style="height:2rem" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+
+			<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+			<div class="wp-block-buttons">
+				<!-- wp:button {"backgroundColor":"pure-white","textColor":"pure-black","style":{"typography":{"letterSpacing":"0.15em","textTransform":"uppercase","fontSize":"var(--wp--preset--font-size--small)"},"border":{"radius":"0"},"spacing":{"padding":{"top":"0.9rem","bottom":"0.9rem","left":"2.5rem","right":"2.5rem"}}}} -->
+				<div class="wp-block-button" style="font-size:var(--wp--preset--font-size--small);letter-spacing:0.15em;text-transform:uppercase"><a class="wp-block-button__link has-pure-black-color has-pure-white-background-color has-text-color has-background wp-element-button" style="border-radius:0;padding-top:0.9rem;padding-right:2.5rem;padding-bottom:0.9rem;padding-left:2.5rem"><?php echo esc_html__( 'View the Gallery', 'ansel-adams' ); ?></a></div>
+				<!-- /wp:button -->
+			</div>
+			<!-- /wp:buttons -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+</div>
+<!-- /wp:cover -->

--- a/wp-themes/ansel-adams/style.css
+++ b/wp-themes/ansel-adams/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Ansel Adams
+Theme URI: #
+Author: Artist Themes Collection
+Author URI: #
+Description: A WordPress block theme inspired by the dramatic black-and-white landscape photography of Ansel Adams. Features a monochromatic palette with rich tonal range, clean typography, and compositions that evoke the grandeur of the American West.
+Version: 1.0.0
+Requires at least: 6.4
+Tested up to: 6.7
+Requires PHP: 7.4
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: ansel-adams
+Tags: block-patterns, full-site-editing, wide-blocks, custom-colors, custom-fonts
+*/

--- a/wp-themes/ansel-adams/styles/moonrise.json
+++ b/wp-themes/ansel-adams/styles/moonrise.json
@@ -1,0 +1,169 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"title": "Moonrise",
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "pure-black",
+					"color": "#1B1408",
+					"name": "Pure Black"
+				},
+				{
+					"slug": "zone-ii",
+					"color": "#2C2315",
+					"name": "Zone II"
+				},
+				{
+					"slug": "zone-iv",
+					"color": "#5C4A32",
+					"name": "Zone IV"
+				},
+				{
+					"slug": "zone-vi",
+					"color": "#9C8B73",
+					"name": "Zone VI"
+				},
+				{
+					"slug": "zone-viii",
+					"color": "#C9BAA3",
+					"name": "Zone VIII"
+				},
+				{
+					"slug": "pure-white",
+					"color": "#FAF6F0",
+					"name": "Pure White"
+				},
+				{
+					"slug": "warm-tone",
+					"color": "#F0E6D6",
+					"name": "Warm Tone"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "'Libre Baskerville', serif",
+					"slug": "libre-baskerville",
+					"name": "Libre Baskerville",
+					"fontFace": [
+						{
+							"fontFamily": "Libre Baskerville",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/librebaskerville/v14/kmKnZrc3Hgbbcjq75U4uslyuy4kn0qNZaxM.woff2"
+							]
+						},
+						{
+							"fontFamily": "Libre Baskerville",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/librebaskerville/v14/kmKiZrc3Hgbbcjq75U4uslyuy4kn0qviTjYwI8Gcw6Oi.woff2"
+							]
+						},
+						{
+							"fontFamily": "Libre Baskerville",
+							"fontWeight": "400",
+							"fontStyle": "italic",
+							"src": [
+								"https://fonts.gstatic.com/s/librebaskerville/v14/kmKhZrc3Hgbbcjq75U4uslyuy4kn0qNcaxRPAi-j.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "'Source Serif Pro', serif",
+					"slug": "source-serif-pro",
+					"name": "Source Serif Pro",
+					"fontFace": [
+						{
+							"fontFamily": "Source Serif Pro",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/sourceserifpro/v15/neIQzD-0qpwxpaWvJW_CGxGQo9LJttl1cfjy.woff2"
+							]
+						},
+						{
+							"fontFamily": "Source Serif Pro",
+							"fontWeight": "600",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/sourceserifpro/v15/neIXzD-0qpwxpaWvJW_CGxGQo9TFxnOI6EJN.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+					"slug": "system-sans",
+					"name": "System Sans"
+				}
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--warm-tone)",
+			"text": "var(--wp--preset--color--zone-ii)"
+		},
+		"elements": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--libre-baskerville)",
+					"fontWeight": "700"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--pure-black)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--zone-iv)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--pure-black)"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--zone-iv)",
+					"text": "var(--wp--preset--color--pure-white)"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--pure-black)",
+						"text": "var(--wp--preset--color--pure-white)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/separator": {
+				"color": {
+					"text": "var(--wp--preset--color--zone-viii)"
+				}
+			},
+			"core/quote": {
+				"border": {
+					"left": {
+						"color": "var(--wp--preset--color--zone-iv)",
+						"width": "3px",
+						"style": "solid"
+					}
+				}
+			},
+			"core/site-title": {
+				"color": {
+					"text": "var(--wp--preset--color--pure-black)"
+				}
+			}
+		}
+	}
+}

--- a/wp-themes/ansel-adams/templates/index.html
+++ b/wp-themes/ansel-adams/templates/index.html
@@ -1,0 +1,51 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+	<div class="wp-block-query">
+		<!-- wp:post-template {"layout":{"type":"default"}} -->
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"2rem","bottom":"2rem"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-top:2rem;padding-bottom:2rem">
+				<!-- wp:post-featured-image {"isLink":true,"align":"wide","style":{"border":{"radius":"0"}}} /-->
+
+				<!-- wp:post-title {"isLink":true,"style":{"typography":{"fontSize":"var(--wp--preset--font-size--x-large)"}}} /-->
+
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.5rem"},"typography":{"fontSize":"var(--wp--preset--font-size--small)"}}} -->
+				<div class="wp-block-group" style="font-size:var(--wp--preset--font-size--small)">
+					<!-- wp:post-date /-->
+
+					<!-- wp:paragraph -->
+					<p>&mdash;</p>
+					<!-- /wp:paragraph -->
+
+					<!-- wp:post-author {"showAvatar":false} /-->
+				</div>
+				<!-- /wp:group -->
+
+				<!-- wp:post-excerpt {"moreText":"Continue Reading","excerptLength":40} /-->
+
+				<!-- wp:separator {"style":{"color":{"text":"var(--wp--preset--color--zone-viii)"}},"className":"is-style-wide"} -->
+				<hr class="wp-block-separator has-text-color is-style-wide" style="color:var(--wp--preset--color--zone-viii)"/>
+				<!-- /wp:separator -->
+			</div>
+			<!-- /wp:group -->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"},"style":{"typography":{"fontSize":"var(--wp--preset--font-size--small)"}}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center">No posts found.</p>
+			<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
+	</div>
+	<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/ansel-adams/templates/single.html
+++ b/wp-themes/ansel-adams/templates/single.html
@@ -1,0 +1,83 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"3rem","bottom":"1rem"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:3rem;padding-bottom:1rem">
+		<!-- wp:post-title {"level":1,"style":{"typography":{"fontSize":"var(--wp--preset--font-size--xx-large)"}}} /-->
+
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.5rem"},"typography":{"fontSize":"var(--wp--preset--font-size--small)"}}} -->
+		<div class="wp-block-group" style="font-size:var(--wp--preset--font-size--small)">
+			<!-- wp:post-date /-->
+
+			<!-- wp:paragraph -->
+			<p>&mdash;</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:post-author {"showAvatar":false} /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:post-featured-image {"align":"wide","style":{"border":{"radius":"0"}}} /-->
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"2rem","bottom":"2rem"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:2rem;padding-bottom:2rem">
+		<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:separator {"style":{"color":{"text":"var(--wp--preset--color--zone-viii)"}},"className":"is-style-wide"} -->
+	<hr class="wp-block-separator has-text-color is-style-wide" style="color:var(--wp--preset--color--zone-viii)"/>
+	<!-- /wp:separator -->
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"1rem","bottom":"2rem"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:1rem;padding-bottom:2rem">
+		<!-- wp:post-terms {"term":"category","style":{"typography":{"fontSize":"var(--wp--preset--font-size--small)","textTransform":"uppercase","letterSpacing":"0.08em"}}} /-->
+		<!-- wp:post-terms {"term":"post_tag","style":{"typography":{"fontSize":"var(--wp--preset--font-size--small)"}}} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"1rem","bottom":"3rem"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:1rem;padding-bottom:3rem">
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+		<div class="wp-block-group">
+			<!-- wp:post-navigation-link {"type":"previous","label":"Previous"} /-->
+			<!-- wp:post-navigation-link {"label":"Next"} /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:comments -->
+	<div class="wp-block-comments">
+		<!-- wp:comments-title /-->
+		<!-- wp:comment-template -->
+			<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"},"style":{"spacing":{"blockGap":"1rem"}}} -->
+			<div class="wp-block-group">
+				<!-- wp:avatar {"size":40} /-->
+				<!-- wp:group {"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group">
+					<!-- wp:comment-author-name /-->
+					<!-- wp:comment-date /-->
+					<!-- wp:comment-content /-->
+					<!-- wp:comment-reply-link /-->
+					<!-- wp:comment-edit-link /-->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:group -->
+		<!-- /wp:comment-template -->
+		<!-- wp:comments-pagination -->
+			<!-- wp:comments-pagination-previous /-->
+			<!-- wp:comments-pagination-numbers /-->
+			<!-- wp:comments-pagination-next /-->
+		<!-- /wp:comments-pagination -->
+		<!-- wp:post-comments-form /-->
+	</div>
+	<!-- /wp:comments -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/ansel-adams/theme.json
+++ b/wp-themes/ansel-adams/theme.json
@@ -1,0 +1,324 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"settings": {
+		"appearanceTools": true,
+		"layout": {
+			"contentSize": "720px",
+			"wideSize": "1200px"
+		},
+		"color": {
+			"palette": [
+				{
+					"slug": "pure-black",
+					"color": "#000000",
+					"name": "Pure Black"
+				},
+				{
+					"slug": "zone-ii",
+					"color": "#1A1A1A",
+					"name": "Zone II"
+				},
+				{
+					"slug": "zone-iv",
+					"color": "#404040",
+					"name": "Zone IV"
+				},
+				{
+					"slug": "zone-vi",
+					"color": "#808080",
+					"name": "Zone VI"
+				},
+				{
+					"slug": "zone-viii",
+					"color": "#C0C0C0",
+					"name": "Zone VIII"
+				},
+				{
+					"slug": "pure-white",
+					"color": "#FFFFFF",
+					"name": "Pure White"
+				},
+				{
+					"slug": "warm-tone",
+					"color": "#F5F0EB",
+					"name": "Warm Tone"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "'Playfair Display', serif",
+					"slug": "playfair-display",
+					"name": "Playfair Display",
+					"fontFace": [
+						{
+							"fontFamily": "Playfair Display",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/playfairdisplay/v37/nuFvD-vYSZviVYUb_rj3ij__anPXJzDwcbmjWBN2PKd3vUDQZNLo_U2r.woff2"
+							]
+						},
+						{
+							"fontFamily": "Playfair Display",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/playfairdisplay/v37/nuFvD-vYSZviVYUb_rj3ij__anPXJzDwcbmjWBN2PKdFukDQZNLo_U2r.woff2"
+							]
+						},
+						{
+							"fontFamily": "Playfair Display",
+							"fontWeight": "400",
+							"fontStyle": "italic",
+							"src": [
+								"https://fonts.gstatic.com/s/playfairdisplay/v37/nuFRD-vYSZviVYUb_rj3ij__anPXDTnCjmHKM4nYO7KN_qiTbtbK-F2rA0s.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "'Source Serif Pro', serif",
+					"slug": "source-serif-pro",
+					"name": "Source Serif Pro",
+					"fontFace": [
+						{
+							"fontFamily": "Source Serif Pro",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/sourceserifpro/v15/neIQzD-0qpwxpaWvJW_CGxGQo9LJttl1cfjy.woff2"
+							]
+						},
+						{
+							"fontFamily": "Source Serif Pro",
+							"fontWeight": "600",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/sourceserifpro/v15/neIXzD-0qpwxpaWvJW_CGxGQo9TFxnOI6EJN.woff2"
+							]
+						},
+						{
+							"fontFamily": "Source Serif Pro",
+							"fontWeight": "400",
+							"fontStyle": "italic",
+							"src": [
+								"https://fonts.gstatic.com/s/sourceserifpro/v15/neIWzD-0qpwxpaWvJW_CGxGQo9LBt0pU93gV.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+					"slug": "system-sans",
+					"name": "System Sans"
+				}
+			],
+			"fontSizes": [
+				{
+					"slug": "small",
+					"size": "0.875rem",
+					"name": "Small"
+				},
+				{
+					"slug": "medium",
+					"size": "1rem",
+					"name": "Medium"
+				},
+				{
+					"slug": "large",
+					"size": "1.5rem",
+					"name": "Large"
+				},
+				{
+					"slug": "x-large",
+					"size": "2.25rem",
+					"name": "Extra Large"
+				},
+				{
+					"slug": "xx-large",
+					"size": "3.5rem",
+					"name": "Huge"
+				}
+			]
+		},
+		"spacing": {
+			"units": [
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw",
+				"%"
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--warm-tone)",
+			"text": "var(--wp--preset--color--zone-ii)"
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--source-serif-pro)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"lineHeight": "1.75"
+		},
+		"spacing": {
+			"blockGap": "1.5rem",
+			"padding": {
+				"top": "0",
+				"right": "1.5rem",
+				"bottom": "0",
+				"left": "1.5rem"
+			}
+		},
+		"elements": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
+					"fontWeight": "700",
+					"lineHeight": "1.2"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--pure-black)"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--xx-large)"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--pure-black)"
+				},
+				"typography": {
+					"textDecoration": "underline"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--zone-iv)"
+					},
+					"typography": {
+						"textDecoration": "none"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--pure-black)",
+					"text": "var(--wp--preset--color--pure-white)"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"letterSpacing": "0.1em",
+					"textTransform": "uppercase"
+				},
+				"border": {
+					"radius": "0"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--zone-iv)",
+						"text": "var(--wp--preset--color--pure-white)"
+					}
+				}
+			},
+			"caption": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--system-sans)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontStyle": "italic"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--zone-iv)"
+				}
+			}
+		},
+		"blocks": {
+			"core/separator": {
+				"color": {
+					"text": "var(--wp--preset--color--zone-viii)"
+				},
+				"border": {
+					"width": "1px"
+				}
+			},
+			"core/quote": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
+					"fontStyle": "italic",
+					"fontSize": "var(--wp--preset--font-size--large)"
+				},
+				"border": {
+					"left": {
+						"color": "var(--wp--preset--color--pure-black)",
+						"width": "3px",
+						"style": "solid"
+					}
+				},
+				"spacing": {
+					"padding": {
+						"left": "1.5rem"
+					}
+				}
+			},
+			"core/image": {
+				"border": {
+					"radius": "0"
+				}
+			},
+			"core/post-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
+					"fontWeight": "700"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
+					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontWeight": "700",
+					"letterSpacing": "0.05em",
+					"textTransform": "uppercase"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--pure-black)"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--system-sans)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"letterSpacing": "0.08em",
+					"textTransform": "uppercase"
+				}
+			}
+		}
+	},
+	"templateParts": [
+		{
+			"name": "header",
+			"title": "Header",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"title": "Footer",
+			"area": "footer"
+		}
+	]
+}

--- a/wp-themes/basquiat/README.md
+++ b/wp-themes/basquiat/README.md
@@ -1,0 +1,54 @@
+# Basquiat - WordPress Block Theme
+
+A WordPress block theme inspired by the raw, expressive energy of Jean-Michel Basquiat's neo-expressionist art.
+
+## About
+
+This theme channels the spirit of 1980s New York street art through bold primary colors, gritty hand-drawn typography, and an unapologetically urban aesthetic. It is designed for creators, writers, and artists who want their digital presence to feel as alive and confrontational as a canvas in a SoHo gallery.
+
+## Design Notes
+
+### Color Palette
+
+The palette draws directly from colors frequently found in Basquiat's work:
+
+- **Raw Yellow (#FFD700)** -- the dominant warmth seen in his crown motifs and background fields
+- **Crown Gold (#DAA520)** -- a deeper gold evoking the three-pointed crowns
+- **Electric Blue (#0066FF)** -- the vivid blues that punctuate his compositions
+- **Fire Red (#FF2400)** -- aggressive reds used for emphasis and anatomy
+- **Bone White (#F5F5DC)** -- the off-white of raw canvas and exposed surfaces
+- **Charcoal Black (#1A1A1A)** -- dense black line work and text fragments
+- **Graffiti Green (#00CC66)** -- the greens appearing in his later, more complex works
+
+### Typography
+
+- **Permanent Marker** for headings -- captures the raw, hand-lettered quality of Basquiat's text fragments and word lists
+- **Caveat** as an alternate heading font -- a more fluid handwritten style
+- **Space Mono** for body text -- the monospaced rhythm echoes typewriter text and the mechanical lettering Basquiat sometimes incorporated
+
+### Style Variation: Crown
+
+The "Crown" variation pushes the palette darker and more intense, using deeper golds, darker blues, and richer reds. Headings switch to the Caveat font family for a looser, more gestural feel. This variation is suited for sites that want a moodier, more nocturnal atmosphere.
+
+## Features
+
+- Full site editing support
+- Responsive layout with content and wide size constraints
+- Blog index template with query loop
+- Single post template with navigation
+- Hero pattern for bold landing sections
+- Style variation for alternate aesthetics
+- Google Fonts loaded via theme.json font faces
+
+## Requirements
+
+- WordPress 6.4 or later
+- PHP 7.4 or later
+
+## Homage Disclaimer
+
+This theme is an independent creative work paying homage to the artistic style and cultural impact of Jean-Michel Basquiat (1960-1988). It is not affiliated with, endorsed by, or connected to the Estate of Jean-Michel Basquiat or any rights holders. No copyrighted artwork is reproduced in this theme. The color choices, typographic direction, and design language are original interpretations inspired by the broader neo-expressionist movement and street art culture of the 1980s.
+
+## License
+
+GNU General Public License v2 or later. See [LICENSE](http://www.gnu.org/licenses/gpl-2.0.html).

--- a/wp-themes/basquiat/parts/footer.html
+++ b/wp-themes/basquiat/parts/footer.html
@@ -1,0 +1,14 @@
+<!-- wp:group {"tagName":"footer","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"top":{"color":"var:preset|color|crown-gold","width":"2px","style":"solid"}}},"backgroundColor":"charcoal-black","layout":{"type":"constrained"}} -->
+<footer class="wp-block-group has-charcoal-black-background-color has-background">
+	<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":"var:preset|font-size|small"},"color":{"text":"var:preset|color|crown-gold"}}} -->
+		<p>SAMO lives. Powered by WordPress.</p>
+		<!-- /wp:paragraph -->
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":"var:preset|font-size|small"},"color":{"text":"var:preset|color|bone-white"}}} -->
+		<p>Basquiat Theme &copy; 2026</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+</footer>
+<!-- /wp:group -->

--- a/wp-themes/basquiat/parts/header.html
+++ b/wp-themes/basquiat/parts/header.html
@@ -1,0 +1,10 @@
+<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}},"border":{"bottom":{"color":"var:preset|color|fire-red","width":"3px","style":"solid"}}},"backgroundColor":"charcoal-black","layout":{"type":"constrained"}} -->
+<header class="wp-block-group has-charcoal-black-background-color has-background">
+	<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group">
+		<!-- wp:site-title {"isLink":true} /-->
+		<!-- wp:navigation {"overlayMenu":"mobile","layout":{"type":"flex","justifyContent":"right"}} /-->
+	</div>
+	<!-- /wp:group -->
+</header>
+<!-- /wp:group -->

--- a/wp-themes/basquiat/patterns/hero.php
+++ b/wp-themes/basquiat/patterns/hero.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Title: Hero
+ * Slug: basquiat/hero
+ * Categories: featured
+ * Description: A bold hero section inspired by Basquiat's raw expressionist energy
+ */
+?>
+
+<!-- wp:cover {"overlayColor":"charcoal-black","minHeight":80,"minHeightUnit":"vh","isDark":true,"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-cover alignfull is-dark" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--40);min-height:80vh">
+	<span aria-hidden="true" class="wp-block-cover__background has-charcoal-black-background-color has-background-dim-100 has-background-dim"></span>
+	<div class="wp-block-cover__inner-container">
+		<!-- wp:group {"layout":{"type":"constrained","contentSize":"900px"}} -->
+		<div class="wp-block-group">
+			<!-- wp:heading {"textAlign":"left","level":1,"style":{"typography":{"fontSize":"clamp(3rem, 8vw, 6rem)","letterSpacing":"-0.02em","lineHeight":"1.1"},"color":{"text":"var:preset|color|raw-yellow)"}}} -->
+			<h1 class="wp-block-heading has-text-align-left" style="color:var(--wp--preset--color--raw-yellow);font-size:clamp(3rem, 8vw, 6rem);letter-spacing:-0.02em;line-height:1.1"><?php echo esc_html__( 'The Crown Belongs to the Fearless', 'basquiat' ); ?></h1>
+			<!-- /wp:heading -->
+
+			<!-- wp:paragraph {"style":{"typography":{"fontSize":"var:preset|font-size|large","lineHeight":"1.6"},"color":{"text":"var:preset|color|bone-white)"},"spacing":{"margin":{"top":"var:preset|spacing|30"}}}} -->
+			<p style="color:var(--wp--preset--color--bone-white);font-size:var(--wp--preset--font-size--large);line-height:1.6;margin-top:var(--wp--preset--spacing--30)"><?php echo esc_html__( 'Art is how we decorate space. Words are how we decorate time. This is where both collide.', 'basquiat' ); ?></p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:separator {"style":{"color":{"background":"var:preset|color|fire-red)"},"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"className":"is-style-wide"} -->
+			<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background is-style-wide" style="background-color:var(--wp--preset--color--fire-red);margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40)"/>
+			<!-- /wp:separator -->
+
+			<!-- wp:buttons -->
+			<div class="wp-block-buttons">
+				<!-- wp:button {"backgroundColor":"fire-red","textColor":"bone-white","style":{"typography":{"fontFamily":"var:preset|font-family|permanent-marker)","textTransform":"uppercase","letterSpacing":"0.1em"},"border":{"width":"3px","color":"var:preset|color|raw-yellow)"},"spacing":{"padding":{"top":"1rem","bottom":"1rem","left":"2.5rem","right":"2.5rem"}}}} -->
+				<div class="wp-block-button"><a class="wp-block-button__link has-bone-white-color has-fire-red-background-color has-text-color has-background wp-element-button" style="border-color:var(--wp--preset--color--raw-yellow);border-width:3px;padding-top:1rem;padding-right:2.5rem;padding-bottom:1rem;padding-left:2.5rem;font-family:var(--wp--preset--font-family--permanent-marker);letter-spacing:0.1em;text-transform:uppercase"><?php echo esc_html__( 'Enter the Gallery', 'basquiat' ); ?></a></div>
+				<!-- /wp:button -->
+
+				<!-- wp:button {"backgroundColor":"charcoal-black","textColor":"raw-yellow","style":{"border":{"width":"3px","color":"var:preset|color|raw-yellow)"},"spacing":{"padding":{"top":"1rem","bottom":"1rem","left":"2.5rem","right":"2.5rem"}},"typography":{"fontFamily":"var:preset|font-family|permanent-marker)","textTransform":"uppercase","letterSpacing":"0.1em"}},"className":"is-style-outline"} -->
+				<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-raw-yellow-color has-charcoal-black-background-color has-text-color has-background wp-element-button" style="border-color:var(--wp--preset--color--raw-yellow);border-width:3px;padding-top:1rem;padding-right:2.5rem;padding-bottom:1rem;padding-left:2.5rem;font-family:var(--wp--preset--font-family--permanent-marker);letter-spacing:0.1em;text-transform:uppercase"><?php echo esc_html__( 'View the Work', 'basquiat' ); ?></a></div>
+				<!-- /wp:button -->
+			</div>
+			<!-- /wp:buttons -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+</div>
+<!-- /wp:cover -->

--- a/wp-themes/basquiat/style.css
+++ b/wp-themes/basquiat/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Basquiat
+Theme URI: #
+Author: Artist Themes Collection
+Author URI: #
+Description: A WordPress block theme inspired by the raw, expressive energy of Jean-Michel Basquiat's neo-expressionist art. Features bold primary colors, gritty typography, and an urban aesthetic that channels the spirit of 1980s New York street art.
+Version: 1.0.0
+Requires at least: 6.4
+Tested up to: 6.7
+Requires PHP: 7.4
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: basquiat
+Tags: block-patterns, full-site-editing, wide-blocks, custom-colors, custom-fonts
+*/

--- a/wp-themes/basquiat/styles/crown.json
+++ b/wp-themes/basquiat/styles/crown.json
@@ -1,0 +1,187 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"title": "Crown",
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "raw-yellow",
+					"color": "#FFB800",
+					"name": "Raw Yellow"
+				},
+				{
+					"slug": "crown-gold",
+					"color": "#B8860B",
+					"name": "Crown Gold"
+				},
+				{
+					"slug": "electric-blue",
+					"color": "#003399",
+					"name": "Electric Blue"
+				},
+				{
+					"slug": "fire-red",
+					"color": "#CC1100",
+					"name": "Fire Red"
+				},
+				{
+					"slug": "bone-white",
+					"color": "#E8E0D0",
+					"name": "Bone White"
+				},
+				{
+					"slug": "charcoal-black",
+					"color": "#0D0D0D",
+					"name": "Charcoal Black"
+				},
+				{
+					"slug": "graffiti-green",
+					"color": "#008844",
+					"name": "Graffiti Green"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "'Caveat', cursive",
+					"slug": "caveat",
+					"name": "Caveat",
+					"fontFace": [
+						{
+							"fontFamily": "Caveat",
+							"fontWeight": "400 700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/caveat/v18/WnznHAc5bAfYB2QRah7pcpNvOx-pjcB9SIKjYBxPigs.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "'Permanent Marker', cursive",
+					"slug": "permanent-marker",
+					"name": "Permanent Marker",
+					"fontFace": [
+						{
+							"fontFamily": "Permanent Marker",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/permanentmarker/v16/Fh4uPib9Iyv2ucM6pGQMWimMp004HaqIfrT5nlk.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "'Space Mono', monospace",
+					"slug": "space-mono",
+					"name": "Space Mono",
+					"fontFace": [
+						{
+							"fontFamily": "Space Mono",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/spacemono/v13/i7dPIFZifjKcF5UAWdDRYEF8RXi4EwQ.woff2"
+							]
+						},
+						{
+							"fontFamily": "Space Mono",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/spacemono/v13/i7dMIFZifjKcF5UAWdDRaPpZYFKQHwyVd3U.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+					"slug": "system-sans",
+					"name": "System Sans"
+				}
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "#0D0D0D",
+			"text": "#E8E0D0"
+		},
+		"elements": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--caveat)",
+					"fontWeight": "700"
+				},
+				"color": {
+					"text": "#FFB800"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "#003399"
+				},
+				":hover": {
+					"color": {
+						"text": "#CC1100"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "#CC1100",
+					"text": "#E8E0D0"
+				},
+				"border": {
+					"color": "#FFB800",
+					"width": "3px",
+					"style": "solid",
+					"radius": "0"
+				},
+				":hover": {
+					"color": {
+						"background": "#FFB800",
+						"text": "#0D0D0D"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/site-title": {
+				"color": {
+					"text": "#FFB800"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--caveat)",
+					"fontWeight": "700"
+				}
+			},
+			"core/quote": {
+				"color": {
+					"text": "#B8860B"
+				},
+				"border": {
+					"left": {
+						"color": "#CC1100",
+						"width": "4px",
+						"style": "solid"
+					}
+				}
+			},
+			"core/code": {
+				"color": {
+					"background": "#050505",
+					"text": "#008844"
+				},
+				"border": {
+					"color": "#008844",
+					"width": "2px",
+					"style": "solid"
+				}
+			}
+		}
+	}
+}

--- a/wp-themes/basquiat/templates/index.html
+++ b/wp-themes/basquiat/templates/index.html
@@ -1,0 +1,44 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|40"}}}} -->
+	<h1 class="wp-block-heading">The Street Speaks</h1>
+	<!-- /wp:heading -->
+
+	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","inherit":true}} -->
+	<div class="wp-block-query">
+		<!-- wp:post-template {"layout":{"type":"default"}} -->
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"margin":{"bottom":"var:preset|spacing|40"}},"border":{"bottom":{"color":"var:preset|color|crown-gold","width":"2px","style":"solid"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group">
+				<!-- wp:post-title {"isLink":true} /-->
+
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}}} -->
+				<div class="wp-block-group">
+					<!-- wp:post-date {"style":{"typography":{"fontSize":"var:preset|font-size|small"},"color":{"text":"var:preset|color|crown-gold"}}} /-->
+					<!-- wp:post-author-name {"style":{"typography":{"fontSize":"var:preset|font-size|small"},"color":{"text":"var:preset|color|electric-blue"}}} /-->
+				</div>
+				<!-- /wp:group -->
+
+				<!-- wp:post-excerpt {"moreText":"Read More \u2192","excerptLength":30} /-->
+			</div>
+			<!-- /wp:group -->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+			<!-- wp:paragraph -->
+			<p>No posts found. The canvas is blank — start creating.</p>
+			<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
+	</div>
+	<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/basquiat/templates/single.html
+++ b/wp-themes/basquiat/templates/single.html
@@ -1,0 +1,42 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group">
+		<!-- wp:post-title {"level":1} /-->
+
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"},"style":{"spacing":{"blockGap":"var:preset|spacing|20","margin":{"bottom":"var:preset|spacing|40"}}}} -->
+		<div class="wp-block-group">
+			<!-- wp:post-date {"style":{"typography":{"fontSize":"var:preset|font-size|small"},"color":{"text":"var:preset|color|crown-gold"}}} /-->
+			<!-- wp:post-author-name {"style":{"typography":{"fontSize":"var:preset|font-size|small"},"color":{"text":"var:preset|color|electric-blue"}}} /-->
+			<!-- wp:post-terms {"term":"category","style":{"typography":{"fontSize":"var:preset|font-size|small"},"color":{"text":"var:preset|color|graffiti-green"}}} /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:post-featured-image {"align":"wide","style":{"border":{"width":"3px","color":"var:preset|color|crown-gold","style":"solid"}}} /-->
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group">
+		<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"border":{"top":{"color":"var:preset|color|crown-gold","width":"2px","style":"solid"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group">
+		<!-- wp:post-terms {"term":"tag","style":{"typography":{"fontSize":"var:preset|font-size|small"},"color":{"text":"var:preset|color|fire-red"}}} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}},"border":{"top":{"color":"var:preset|color|electric-blue","width":"1px","style":"solid"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group">
+		<!-- wp:post-navigation-link {"type":"previous","label":"Previous"} /-->
+		<!-- wp:post-navigation-link {"label":"Next"} /-->
+	</div>
+	<!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/basquiat/theme.json
+++ b/wp-themes/basquiat/theme.json
@@ -1,0 +1,304 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"settings": {
+		"appearanceTools": true,
+		"color": {
+			"palette": [
+				{
+					"slug": "raw-yellow",
+					"color": "#FFD700",
+					"name": "Raw Yellow"
+				},
+				{
+					"slug": "crown-gold",
+					"color": "#DAA520",
+					"name": "Crown Gold"
+				},
+				{
+					"slug": "electric-blue",
+					"color": "#0066FF",
+					"name": "Electric Blue"
+				},
+				{
+					"slug": "fire-red",
+					"color": "#FF2400",
+					"name": "Fire Red"
+				},
+				{
+					"slug": "bone-white",
+					"color": "#F5F5DC",
+					"name": "Bone White"
+				},
+				{
+					"slug": "charcoal-black",
+					"color": "#1A1A1A",
+					"name": "Charcoal Black"
+				},
+				{
+					"slug": "graffiti-green",
+					"color": "#00CC66",
+					"name": "Graffiti Green"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "'Permanent Marker', cursive",
+					"slug": "permanent-marker",
+					"name": "Permanent Marker",
+					"fontFace": [
+						{
+							"fontFamily": "Permanent Marker",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/permanentmarker/v16/Fh4uPib9Iyv2ucM6pGQMWimMp004HaqIfrT5nlk.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "'Caveat', cursive",
+					"slug": "caveat",
+					"name": "Caveat",
+					"fontFace": [
+						{
+							"fontFamily": "Caveat",
+							"fontWeight": "400 700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/caveat/v18/WnznHAc5bAfYB2QRah7pcpNvOx-pjcB9SIKjYBxPigs.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "'Space Mono', monospace",
+					"slug": "space-mono",
+					"name": "Space Mono",
+					"fontFace": [
+						{
+							"fontFamily": "Space Mono",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/spacemono/v13/i7dPIFZifjKcF5UAWdDRYEF8RXi4EwQ.woff2"
+							]
+						},
+						{
+							"fontFamily": "Space Mono",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/spacemono/v13/i7dMIFZifjKcF5UAWdDRaPpZYFKQHwyVd3U.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+					"slug": "system-sans",
+					"name": "System Sans"
+				}
+			],
+			"fontSizes": [
+				{
+					"slug": "small",
+					"size": "0.875rem",
+					"name": "Small"
+				},
+				{
+					"slug": "medium",
+					"size": "1.125rem",
+					"name": "Medium"
+				},
+				{
+					"slug": "large",
+					"size": "1.75rem",
+					"name": "Large"
+				},
+				{
+					"slug": "x-large",
+					"size": "2.5rem",
+					"name": "Extra Large"
+				},
+				{
+					"slug": "xx-large",
+					"size": "4rem",
+					"name": "Huge"
+				}
+			]
+		},
+		"layout": {
+			"contentSize": "720px",
+			"wideSize": "1200px"
+		},
+		"spacing": {
+			"units": [
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw",
+				"%"
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--charcoal-black)",
+			"text": "var(--wp--preset--color--bone-white)"
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--space-mono)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"lineHeight": "1.7"
+		},
+		"spacing": {
+			"padding": {
+				"top": "0",
+				"right": "var(--wp--preset--spacing--30, 1.25rem)",
+				"bottom": "0",
+				"left": "var(--wp--preset--spacing--30, 1.25rem)"
+			}
+		},
+		"elements": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--permanent-marker)",
+					"fontWeight": "400",
+					"lineHeight": "1.2",
+					"textTransform": "uppercase"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--raw-yellow)"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--xx-large)"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--electric-blue)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--fire-red)"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--fire-red)",
+					"text": "var(--wp--preset--color--bone-white)"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--permanent-marker)",
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"textTransform": "uppercase",
+					"letterSpacing": "0.05em"
+				},
+				"border": {
+					"radius": "0",
+					"width": "3px",
+					"color": "var(--wp--preset--color--raw-yellow)",
+					"style": "solid"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--raw-yellow)",
+						"text": "var(--wp--preset--color--charcoal-black)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/post-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--permanent-marker)",
+					"fontSize": "var(--wp--preset--font-size--xx-large)",
+					"textTransform": "uppercase"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--raw-yellow)"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--permanent-marker)",
+					"fontSize": "var(--wp--preset--font-size--x-large)",
+					"textTransform": "uppercase"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--raw-yellow)"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--space-mono)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"textTransform": "uppercase"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--bone-white)"
+				}
+			},
+			"core/quote": {
+				"border": {
+					"left": {
+						"color": "var(--wp--preset--color--fire-red)",
+						"width": "4px",
+						"style": "solid"
+					}
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--caveat)",
+					"fontSize": "var(--wp--preset--font-size--large)"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--crown-gold)"
+				}
+			},
+			"core/code": {
+				"color": {
+					"background": "#111111",
+					"text": "var(--wp--preset--color--graffiti-green)"
+				},
+				"border": {
+					"width": "2px",
+					"color": "var(--wp--preset--color--graffiti-green)",
+					"style": "solid",
+					"radius": "0"
+				}
+			}
+		}
+	},
+	"templateParts": [
+		{
+			"name": "header",
+			"title": "Header",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"title": "Footer",
+			"area": "footer"
+		}
+	],
+	"customTemplates": [],
+	"patterns": []
+}

--- a/wp-themes/bjork/README.md
+++ b/wp-themes/bjork/README.md
@@ -1,0 +1,50 @@
+# Bjork - WordPress Block Theme
+
+A WordPress block theme inspired by the avant-garde musical and visual universe of Bjork.
+
+## Design Notes
+
+This theme draws from the otherworldly aesthetic that defines Bjork's visual and sonic identity. The design language reflects the tension between organic forms and digital technology, a theme that runs through her entire discography.
+
+### Color Palette
+
+The default palette evokes the Icelandic landscape and Bjork's surreal visual world:
+
+- **Glacial Blue** (#B3E5FC) -- Inspired by Icelandic glaciers and the cold luminosity of her "Homogenic" era
+- **Volcanic Black** (#1A1A2E) -- The dark volcanic rock of Iceland, grounding the palette
+- **Aurora Green** (#00E676) -- The Northern Lights, representing the supernatural and ephemeral
+- **Electric Violet** (#AA00FF) -- The vibrant energy of her live performances and "Post" era
+- **Coral Pink** (#FF6B6B) -- Organic warmth amid the digital, reminiscent of her more tender works
+- **Arctic White** (#F0F4F8) -- Clean and crisp, like freshly fallen snow
+- **Deep Ocean** (#0D1B2A) -- The deep waters surrounding Iceland, used as the primary background
+
+### Typography
+
+- **Headings**: Space Grotesk -- A futuristic grotesque that balances geometric precision with organic character
+- **Body**: DM Sans -- Clean and highly readable, providing contrast to the expressive headings
+
+### Style Variation: Biophilia
+
+Named after Bjork's groundbreaking multimedia album, the Biophilia variation shifts the palette toward nature-technology fusion with deep greens, metallics, and earth tones. This variation reflects the album's exploration of the intersection between musicology, nature, and technology.
+
+## Theme Features
+
+- Full Site Editing support
+- Responsive design
+- Custom color palette with 7 colors
+- Style variation (Biophilia)
+- Block patterns (Hero section)
+- Custom typography with web fonts
+
+## Requirements
+
+- WordPress 6.4 or later
+- PHP 7.4 or later
+
+## License
+
+GNU General Public License v2 or later. See LICENSE for details.
+
+## Disclaimer
+
+This theme is an independent creative work inspired by the artistry and visual language of Bjork. It is not affiliated with, endorsed by, or officially connected to Bjork, One Little Independent Records, or any associated entities. All artistic references are used purely as creative inspiration and homage. All trademarks and copyrights belong to their respective owners.

--- a/wp-themes/bjork/parts/footer.html
+++ b/wp-themes/bjork/parts/footer.html
@@ -1,0 +1,11 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"2rem","bottom":"2rem","right":"2rem","left":"2rem"}},"border":{"top":{"color":"#AA00FF","width":"2px","style":"solid"}}},"backgroundColor":"volcanic-black","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-volcanic-black-background-color has-background" style="border-top-color:#AA00FF;border-top-style:solid;border-top-width:2px;padding-top:2rem;padding-right:2rem;padding-bottom:2rem;padding-left:2rem">
+	<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+		<p class="has-text-align-center has-small-font-size">Designed with otherworldly inspiration. Powered by WordPress.</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/bjork/parts/header.html
+++ b/wp-themes/bjork/parts/header.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"1.5rem","bottom":"1.5rem","right":"2rem","left":"2rem"}},"border":{"bottom":{"color":"#AA00FF","width":"2px","style":"solid"}}},"backgroundColor":"volcanic-black","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group has-volcanic-black-background-color has-background" style="border-bottom-color:#AA00FF;border-bottom-style:solid;border-bottom-width:2px;padding-top:1.5rem;padding-right:2rem;padding-bottom:1.5rem;padding-left:2rem">
+	<!-- wp:site-title {"level":0} /-->
+	<!-- wp:navigation {"overlayMenu":"mobile","layout":{"type":"flex","justifyContent":"right"}} /-->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/bjork/patterns/hero.php
+++ b/wp-themes/bjork/patterns/hero.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Title: Hero
+ * Slug: bjork/hero
+ * Categories: featured
+ * Description: An otherworldly hero section inspired by Björk's avant-garde aesthetic
+ */
+?>
+<!-- wp:cover {"dimRatio":80,"overlayColor":"deep-ocean","minHeight":80,"minHeightUnit":"vh","isDark":true,"align":"full","layout":{"type":"constrained"}} -->
+<div class="wp-block-cover alignfull is-dark" style="min-height:80vh">
+	<span aria-hidden="true" class="wp-block-cover__background has-deep-ocean-background-color has-background-dim-80 has-background-dim"></span>
+	<div class="wp-block-cover__inner-container">
+		<!-- wp:group {"style":{"spacing":{"blockGap":"1.5rem","padding":{"top":"4rem","bottom":"4rem"}}},"layout":{"type":"constrained","contentSize":"800px"}} -->
+		<div class="wp-block-group" style="padding-top:4rem;padding-bottom:4rem">
+			<!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"letterSpacing":"0.05em"}},"textColor":"glacial-blue","fontSize":"xx-large"} -->
+			<h1 class="wp-block-heading has-text-align-center has-glacial-blue-color has-text-color has-xx-large-font-size" style="letter-spacing:0.05em"><?php echo esc_html__( 'Where Nature Meets the Digital Unknown', 'bjork' ); ?></h1>
+			<!-- /wp:heading -->
+
+			<!-- wp:paragraph {"align":"center","textColor":"arctic-white","fontSize":"large"} -->
+			<p class="has-text-align-center has-arctic-white-color has-text-color has-large-font-size"><?php echo esc_html__( 'An exploration of sound, vision, and the spaces between worlds. Step into the avant-garde.', 'bjork' ); ?></p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"margin":{"top":"2rem"}}}} -->
+			<div class="wp-block-buttons" style="margin-top:2rem">
+				<!-- wp:button {"backgroundColor":"electric-violet","textColor":"arctic-white","style":{"border":{"radius":"2rem"},"spacing":{"padding":{"top":"0.8rem","bottom":"0.8rem","left":"2.5rem","right":"2.5rem"}}}} -->
+				<div class="wp-block-button"><a class="wp-block-button__link has-arctic-white-color has-electric-violet-background-color has-text-color has-background wp-element-button" style="border-radius:2rem;padding-top:0.8rem;padding-right:2.5rem;padding-bottom:0.8rem;padding-left:2.5rem"><?php echo esc_html__( 'Explore', 'bjork' ); ?></a></div>
+				<!-- /wp:button -->
+
+				<!-- wp:button {"textColor":"aurora-green","className":"is-style-outline","style":{"border":{"radius":"2rem"},"spacing":{"padding":{"top":"0.8rem","bottom":"0.8rem","left":"2.5rem","right":"2.5rem"}}}} -->
+				<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-aurora-green-color has-text-color wp-element-button" style="border-radius:2rem;padding-top:0.8rem;padding-right:2.5rem;padding-bottom:0.8rem;padding-left:2.5rem"><?php echo esc_html__( 'Listen', 'bjork' ); ?></a></div>
+				<!-- /wp:button -->
+			</div>
+			<!-- /wp:buttons -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+</div>
+<!-- /wp:cover -->

--- a/wp-themes/bjork/style.css
+++ b/wp-themes/bjork/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Björk
+Theme URI: #
+Author: Artist Themes Collection
+Author URI: #
+Description: A WordPress block theme inspired by the avant-garde musical and visual universe of Björk. Features otherworldly color palettes, futuristic typography, and organic-digital hybrid aesthetics drawn from her iconic album artwork and performances.
+Version: 1.0.0
+Requires at least: 6.4
+Tested up to: 6.7
+Requires PHP: 7.4
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: bjork
+Tags: block-patterns, full-site-editing, wide-blocks, custom-colors, custom-fonts
+*/

--- a/wp-themes/bjork/styles/biophilia.json
+++ b/wp-themes/bjork/styles/biophilia.json
@@ -1,0 +1,153 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"title": "Biophilia",
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "moss-green",
+					"color": "#2E7D32",
+					"name": "Moss Green"
+				},
+				{
+					"slug": "brushed-silver",
+					"color": "#B0BEC5",
+					"name": "Brushed Silver"
+				},
+				{
+					"slug": "copper-metallic",
+					"color": "#BF6A30",
+					"name": "Copper Metallic"
+				},
+				{
+					"slug": "forest-canopy",
+					"color": "#1B3A2D",
+					"name": "Forest Canopy"
+				},
+				{
+					"slug": "lichen-gold",
+					"color": "#C8B560",
+					"name": "Lichen Gold"
+				},
+				{
+					"slug": "mineral-white",
+					"color": "#ECEFF1",
+					"name": "Mineral White"
+				},
+				{
+					"slug": "basalt-dark",
+					"color": "#121A14",
+					"name": "Basalt Dark"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "'Space Grotesk', sans-serif",
+					"slug": "space-grotesk",
+					"name": "Space Grotesk",
+					"fontFace": [
+						{
+							"fontFamily": "Space Grotesk",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/spacegrotesk/v16/V8mDoQDjQSkFtoMM3T6r8E7mPbF4Cw.woff2"
+							]
+						},
+						{
+							"fontFamily": "Space Grotesk",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/spacegrotesk/v16/V8mDoQDjQSkFtoMM3T6r8E7mPbF4Cw.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "'DM Sans', sans-serif",
+					"slug": "dm-sans",
+					"name": "DM Sans",
+					"fontFace": [
+						{
+							"fontFamily": "DM Sans",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/dmsans/v15/rP2tp2ywxg089UriI5-g4vlH9VoD8A.woff2"
+							]
+						},
+						{
+							"fontFamily": "DM Sans",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/dmsans/v15/rP2tp2ywxg089UriI5-g4vlH9VoD8A.woff2"
+							]
+						}
+					]
+				}
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--basalt-dark)",
+			"text": "var(--wp--preset--color--mineral-white)"
+		},
+		"elements": {
+			"heading": {
+				"color": {
+					"text": "var(--wp--preset--color--lichen-gold)"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--space-grotesk)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--moss-green)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--copper-metallic)"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--moss-green)",
+					"text": "var(--wp--preset--color--mineral-white)"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--copper-metallic)",
+						"text": "var(--wp--preset--color--mineral-white)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/site-title": {
+				"color": {
+					"text": "var(--wp--preset--color--mineral-white)"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--mineral-white)"
+						},
+						":hover": {
+							"color": {
+								"text": "var(--wp--preset--color--lichen-gold)"
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/wp-themes/bjork/templates/index.html
+++ b/wp-themes/bjork/templates/index.html
@@ -1,0 +1,47 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+	<div class="wp-block-query">
+		<!-- wp:post-template {"layout":{"type":"default"}} -->
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"2rem","bottom":"2rem"},"blockGap":"1rem"}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-top:2rem;padding-bottom:2rem">
+				<!-- wp:post-title {"isLink":true} /-->
+
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.5rem"}},"fontSize":"small"} -->
+				<div class="wp-block-group has-small-font-size">
+					<!-- wp:post-date /-->
+					<!-- wp:paragraph -->
+					<p>·</p>
+					<!-- /wp:paragraph -->
+					<!-- wp:post-author {"showAvatar":false} /-->
+				</div>
+				<!-- /wp:group -->
+
+				<!-- wp:post-excerpt {"moreText":"Continue reading","excerptLength":40} /-->
+
+				<!-- wp:separator {"style":{"color":{"background":"#AA00FF"}},"className":"is-style-wide"} -->
+				<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background is-style-wide" style="background-color:#AA00FF;color:#AA00FF"/>
+				<!-- /wp:separator -->
+			</div>
+			<!-- /wp:group -->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"margin":{"top":"2rem"}}}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center">No posts found.</p>
+			<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
+	</div>
+	<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/bjork/templates/single.html
+++ b/wp-themes/bjork/templates/single.html
@@ -1,0 +1,77 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"3rem","bottom":"1rem"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:3rem;padding-bottom:1rem">
+		<!-- wp:post-title {"level":1} /-->
+
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.5rem"}},"fontSize":"small"} -->
+		<div class="wp-block-group has-small-font-size">
+			<!-- wp:post-date /-->
+			<!-- wp:paragraph -->
+			<p>·</p>
+			<!-- /wp:paragraph -->
+			<!-- wp:post-author {"showAvatar":false} /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:post-featured-image {"align":"wide","style":{"border":{"radius":"4px"}}} /-->
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"2rem","bottom":"2rem"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:2rem;padding-bottom:2rem">
+		<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:separator {"style":{"color":{"background":"#AA00FF"}},"className":"is-style-wide"} -->
+	<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background is-style-wide" style="background-color:#AA00FF;color:#AA00FF"/>
+	<!-- /wp:separator -->
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"2rem","bottom":"2rem"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:2rem;padding-bottom:2rem">
+		<!-- wp:post-terms {"term":"category","prefix":"Categories: "} /-->
+		<!-- wp:post-terms {"term":"post_tag","prefix":"Tags: "} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"1rem","bottom":"2rem"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group" style="padding-top:1rem;padding-bottom:2rem">
+		<!-- wp:post-navigation-link {"type":"previous","label":"Previous"} /-->
+		<!-- wp:post-navigation-link {"label":"Next"} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:comments -->
+	<div class="wp-block-comments">
+		<!-- wp:comments-title /-->
+		<!-- wp:comment-template -->
+			<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"},"style":{"spacing":{"blockGap":"1rem"}}} -->
+			<div class="wp-block-group">
+				<!-- wp:avatar {"size":40} /-->
+				<!-- wp:group {"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group">
+					<!-- wp:comment-author-name /-->
+					<!-- wp:comment-date /-->
+					<!-- wp:comment-content /-->
+					<!-- wp:comment-reply-link /-->
+					<!-- wp:comment-edit-link /-->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:group -->
+		<!-- /wp:comment-template -->
+		<!-- wp:comments-pagination -->
+			<!-- wp:comments-pagination-previous /-->
+			<!-- wp:comments-pagination-numbers /-->
+			<!-- wp:comments-pagination-next /-->
+		<!-- /wp:comments-pagination -->
+		<!-- wp:post-comments-form /-->
+	</div>
+	<!-- /wp:comments -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/bjork/theme.json
+++ b/wp-themes/bjork/theme.json
@@ -1,0 +1,289 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"settings": {
+		"appearanceTools": true,
+		"color": {
+			"palette": [
+				{
+					"slug": "glacial-blue",
+					"color": "#B3E5FC",
+					"name": "Glacial Blue"
+				},
+				{
+					"slug": "volcanic-black",
+					"color": "#1A1A2E",
+					"name": "Volcanic Black"
+				},
+				{
+					"slug": "aurora-green",
+					"color": "#00E676",
+					"name": "Aurora Green"
+				},
+				{
+					"slug": "electric-violet",
+					"color": "#AA00FF",
+					"name": "Electric Violet"
+				},
+				{
+					"slug": "coral-pink",
+					"color": "#FF6B6B",
+					"name": "Coral Pink"
+				},
+				{
+					"slug": "arctic-white",
+					"color": "#F0F4F8",
+					"name": "Arctic White"
+				},
+				{
+					"slug": "deep-ocean",
+					"color": "#0D1B2A",
+					"name": "Deep Ocean"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "'Space Grotesk', sans-serif",
+					"slug": "space-grotesk",
+					"name": "Space Grotesk",
+					"fontFace": [
+						{
+							"fontFamily": "Space Grotesk",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/spacegrotesk/v16/V8mDoQDjQSkFtoMM3T6r8E7mPbF4Cw.woff2"
+							]
+						},
+						{
+							"fontFamily": "Space Grotesk",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/spacegrotesk/v16/V8mDoQDjQSkFtoMM3T6r8E7mPbF4Cw.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "'DM Sans', sans-serif",
+					"slug": "dm-sans",
+					"name": "DM Sans",
+					"fontFace": [
+						{
+							"fontFamily": "DM Sans",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/dmsans/v15/rP2tp2ywxg089UriI5-g4vlH9VoD8A.woff2"
+							]
+						},
+						{
+							"fontFamily": "DM Sans",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/dmsans/v15/rP2tp2ywxg089UriI5-g4vlH9VoD8A.woff2"
+							]
+						}
+					]
+				}
+			],
+			"fontSizes": [
+				{
+					"slug": "small",
+					"size": "0.875rem",
+					"name": "Small"
+				},
+				{
+					"slug": "medium",
+					"size": "1rem",
+					"name": "Medium"
+				},
+				{
+					"slug": "large",
+					"size": "1.75rem",
+					"name": "Large"
+				},
+				{
+					"slug": "x-large",
+					"size": "2.5rem",
+					"name": "Extra Large"
+				},
+				{
+					"slug": "xx-large",
+					"size": "4rem",
+					"name": "Huge"
+				}
+			]
+		},
+		"layout": {
+			"contentSize": "720px",
+			"wideSize": "1200px"
+		},
+		"spacing": {
+			"units": [
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw",
+				"%"
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--deep-ocean)",
+			"text": "var(--wp--preset--color--arctic-white)"
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--dm-sans)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"lineHeight": "1.7"
+		},
+		"spacing": {
+			"blockGap": "1.5rem",
+			"padding": {
+				"top": "0",
+				"right": "1.5rem",
+				"bottom": "0",
+				"left": "1.5rem"
+			}
+		},
+		"elements": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--space-grotesk)",
+					"fontWeight": "700",
+					"lineHeight": "1.2"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--glacial-blue)"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--xx-large)"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--aurora-green)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--electric-violet)"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--electric-violet)",
+					"text": "var(--wp--preset--color--arctic-white)"
+				},
+				"border": {
+					"radius": "2rem"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--space-grotesk)",
+					"fontWeight": "700",
+					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--aurora-green)",
+						"text": "var(--wp--preset--color--deep-ocean)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--space-grotesk)",
+					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontWeight": "700",
+					"textTransform": "uppercase",
+					"letterSpacing": "0.15em"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--arctic-white)"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--arctic-white)"
+						},
+						":hover": {
+							"color": {
+								"text": "var(--wp--preset--color--aurora-green)"
+							}
+						}
+					}
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--space-grotesk)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"textTransform": "uppercase",
+					"letterSpacing": "0.1em"
+				}
+			},
+			"core/post-title": {
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--glacial-blue)"
+						},
+						":hover": {
+							"color": {
+								"text": "var(--wp--preset--color--electric-violet)"
+							}
+						}
+					}
+				}
+			},
+			"core/quote": {
+				"border": {
+					"left": {
+						"color": "var(--wp--preset--color--electric-violet)",
+						"width": "3px",
+						"style": "solid"
+					}
+				},
+				"typography": {
+					"fontStyle": "italic"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--glacial-blue)"
+				}
+			}
+		}
+	},
+	"templateParts": [
+		{
+			"name": "header",
+			"title": "Header",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"title": "Footer",
+			"area": "footer"
+		}
+	]
+}

--- a/wp-themes/gaudi/README.md
+++ b/wp-themes/gaudi/README.md
@@ -1,0 +1,30 @@
+# Gaudí - WordPress Block Theme
+
+A WordPress block theme inspired by the architectural vision of Antoni Gaudí (1852-1926), the Catalan architect whose work defined the boundaries of Art Nouveau and Modernisme.
+
+## Design Notes
+
+This theme draws upon the visual language of Gaudí's most celebrated works -- the mosaic trencadís tiles of Park Güell, the soaring organic forms of the Sagrada Família, and the undulating facades of Casa Batlló and Casa Milà. The color palette reflects the rich, earthy tones and vivid blues found in Gaudí's ceramic mosaics, while the typography choices evoke the ornamental elegance of the Art Nouveau movement.
+
+This is a stylized homage to Gaudí's aesthetic sensibility, not a literal reproduction of any specific work. The theme interprets his design philosophy -- that straight lines belong to man and curved lines belong to God -- through the medium of modern web typography and layout.
+
+## Style Variations
+
+- **Default**: Mosaic-inspired palette with cobalt blues, golden ambers, and terracotta.
+- **Sagrada**: A more subdued, reverent palette inspired by the interior light of the Sagrada Família basilica, with stained glass rose tones and sanctuary stone neutrals.
+
+## Features
+
+- Full site editing support
+- Responsive layouts with constrained and wide content sizes
+- Custom block patterns including a hero section
+- Art Nouveau-inspired typography with Playfair Display and Lora
+- Gaudí-inspired color palette based on trencadís mosaics
+
+## Artist Attribution
+
+Antoni Gaudí i Cornet (1852-1926) was a Spanish architect from Catalonia. Seven of his works are UNESCO World Heritage Sites. His most famous work, the Sagrada Família, remains under construction and is expected to be completed in the coming years. Gaudí's unique style was influenced by nature, religion, and Catalan culture, resulting in architecture that defies conventional categorization.
+
+## License
+
+GNU General Public License v2 or later. See LICENSE for details.

--- a/wp-themes/gaudi/parts/footer.html
+++ b/wp-themes/gaudi/parts/footer.html
@@ -1,0 +1,19 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"top":{"color":"var:preset|color|sandstone","width":"2px"}},"color":{"background":"var:preset|color|deep-charcoal","text":"var:preset|color|cream-white"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-text-color has-background" style="border-top-color:var(--wp--preset--color--sandstone);border-top-width:2px;background-color:var(--wp--preset--color--deep-charcoal);color:var(--wp--preset--color--cream-white);padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)">
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"center"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph {"fontSize":"small"} -->
+		<p class="has-small-font-size">Designed with the spirit of Antoni Gaud&iacute; &mdash; where nature meets architecture.</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
+	<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20)">
+		<!-- wp:paragraph {"fontSize":"small"} -->
+		<p class="has-small-font-size">&copy; 2026 &mdash; Powered by WordPress</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/gaudi/parts/header.html
+++ b/wp-themes/gaudi/parts/header.html
@@ -1,0 +1,10 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"bottom":{"color":"var:preset|color|sandstone","width":"2px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="border-bottom-color:var(--wp--preset--color--sandstone);border-bottom-width:2px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
+	<div class="wp-block-group">
+		<!-- wp:site-title /-->
+		<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"right"}} /-->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/gaudi/patterns/hero.php
+++ b/wp-themes/gaudi/patterns/hero.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Title: Hero
+ * Slug: gaudi/hero
+ * Categories: featured
+ * Description: A hero section inspired by Gaudí's organic architectural forms
+ */
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"color":{"background":"var:preset|color|cobalt-blue","text":"var:preset|color|cream-white"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-text-color has-background" style="background-color:var(--wp--preset--color--cobalt-blue);color:var(--wp--preset--color--cream-white);padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--30)">
+	<!-- wp:heading {"textAlign":"center","level":2,"fontSize":"xx-large"} -->
+	<h2 class="wp-block-heading has-text-align-center has-xx-large-font-size"><?php echo esc_html__( 'Where Nature Meets Architecture', 'gaudi' ); ?></h2>
+	<!-- /wp:heading -->
+
+	<!-- wp:paragraph {"align":"center","fontSize":"large"} -->
+	<p class="has-text-align-center has-large-font-size"><?php echo esc_html__( 'Inspired by the organic forms, flowing curves, and mosaic brilliance of Antoni Gaudí.', 'gaudi' ); ?></p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:separator {"className":"is-style-wide","style":{"color":{"background":"var:preset|color|golden-amber"}}} -->
+	<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background is-style-wide" style="background-color:var(--wp--preset--color--golden-amber);color:var(--wp--preset--color--golden-amber)"/>
+	<!-- /wp:separator -->
+
+	<!-- wp:columns {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
+	<div class="wp-block-columns" style="margin-top:var(--wp--preset--spacing--40)">
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:heading {"textAlign":"center","level":3,"style":{"color":{"text":"var:preset|color|golden-amber"}}} -->
+			<h3 class="wp-block-heading has-text-align-center has-text-color" style="color:var(--wp--preset--color--golden-amber)"><?php echo esc_html__( 'Organic Forms', 'gaudi' ); ?></h3>
+			<!-- /wp:heading -->
+
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center"><?php echo esc_html__( 'Every line curves with purpose, echoing the shapes found in the natural world that Gaudí revered throughout his life.', 'gaudi' ); ?></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:heading {"textAlign":"center","level":3,"style":{"color":{"text":"var:preset|color|golden-amber"}}} -->
+			<h3 class="wp-block-heading has-text-align-center has-text-color" style="color:var(--wp--preset--color--golden-amber)"><?php echo esc_html__( 'Mosaic Brilliance', 'gaudi' ); ?></h3>
+			<!-- /wp:heading -->
+
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center"><?php echo esc_html__( 'Color and texture interweave in trencadís patterns, turning broken fragments into cohesive works of art and beauty.', 'gaudi' ); ?></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:heading {"textAlign":"center","level":3,"style":{"color":{"text":"var:preset|color|golden-amber"}}} -->
+			<h3 class="wp-block-heading has-text-align-center has-text-color" style="color:var(--wp--preset--color--golden-amber)"><?php echo esc_html__( 'Sacred Geometry', 'gaudi' ); ?></h3>
+			<!-- /wp:heading -->
+
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center"><?php echo esc_html__( 'Mathematics and spirituality converge in structures that reach skyward, blending engineering precision with divine inspiration.', 'gaudi' ); ?></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+
+	<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
+	<div class="wp-block-buttons" style="margin-top:var(--wp--preset--spacing--40)">
+		<!-- wp:button {"style":{"color":{"background":"var:preset|color|golden-amber","text":"var:preset|color|deep-charcoal"}}} -->
+		<div class="wp-block-button"><a class="wp-block-button__link has-text-color has-background wp-element-button" style="background-color:var(--wp--preset--color--golden-amber);color:var(--wp--preset--color--deep-charcoal)"><?php echo esc_html__( 'Explore the Vision', 'gaudi' ); ?></a></div>
+		<!-- /wp:button -->
+	</div>
+	<!-- /wp:buttons -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/gaudi/style.css
+++ b/wp-themes/gaudi/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Gaudí
+Theme URI: #
+Author: Artist Themes Collection
+Author URI: #
+Description: A WordPress block theme inspired by the organic, flowing architectural forms of Antoni Gaudí. Features mosaic-like color palettes, curvilinear design sensibilities, and nature-inspired typography reminiscent of Park Güell and the Sagrada Família.
+Version: 1.0.0
+Requires at least: 6.4
+Tested up to: 6.7
+Requires PHP: 7.4
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: gaudi
+Tags: block-patterns, full-site-editing, wide-blocks, custom-colors, custom-fonts
+*/

--- a/wp-themes/gaudi/styles/sagrada.json
+++ b/wp-themes/gaudi/styles/sagrada.json
@@ -1,0 +1,146 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"title": "Sagrada",
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "nave-gold",
+					"color": "#B8860B",
+					"name": "Nave Gold"
+				},
+				{
+					"slug": "stained-glass-rose",
+					"color": "#8B2252",
+					"name": "Stained Glass Rose"
+				},
+				{
+					"slug": "sanctuary-stone",
+					"color": "#D2C6A5",
+					"name": "Sanctuary Stone"
+				},
+				{
+					"slug": "spire-grey",
+					"color": "#6B6B6B",
+					"name": "Spire Grey"
+				},
+				{
+					"slug": "altar-white",
+					"color": "#F5F0EB",
+					"name": "Altar White"
+				},
+				{
+					"slug": "crypt-green",
+					"color": "#3B5E3B",
+					"name": "Crypt Green"
+				},
+				{
+					"slug": "nativity-blue",
+					"color": "#2A4D7F",
+					"name": "Nativity Blue"
+				},
+				{
+					"slug": "passion-charcoal",
+					"color": "#1E1E1E",
+					"name": "Passion Charcoal"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "'Cormorant Garamond', Garamond, serif",
+					"slug": "cormorant-garamond",
+					"name": "Cormorant Garamond",
+					"fontFace": [
+						{
+							"fontFamily": "Cormorant Garamond",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/cormorantgaramond/v16/co3bmX5slCNuHLi8bLeY9MK7whWMhyjYrEtFmSu5.woff2"
+							]
+						},
+						{
+							"fontFamily": "Cormorant Garamond",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/cormorantgaramond/v16/co3YmX5slCNuHLi8bLeY9MK7whWMhyjQAllvuQWJ5heb.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "'Source Serif 4', 'Times New Roman', serif",
+					"slug": "source-serif",
+					"name": "Source Serif 4",
+					"fontFace": [
+						{
+							"fontFamily": "Source Serif 4",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/sourceserif4/v8/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf64.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+					"slug": "system-sans",
+					"name": "System Sans"
+				}
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--altar-white)",
+			"text": "var(--wp--preset--color--passion-charcoal)"
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--source-serif)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"lineHeight": "1.75"
+		},
+		"elements": {
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--nativity-blue)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--stained-glass-rose)"
+					}
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--cormorant-garamond)",
+					"fontWeight": "700",
+					"lineHeight": "1.15"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--passion-charcoal)"
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--nativity-blue)",
+					"text": "var(--wp--preset--color--altar-white)"
+				},
+				"border": {
+					"radius": "2px"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--stained-glass-rose)",
+						"text": "var(--wp--preset--color--altar-white)"
+					}
+				}
+			}
+		}
+	}
+}

--- a/wp-themes/gaudi/templates/index.html
+++ b/wp-themes/gaudi/templates/index.html
@@ -1,0 +1,47 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+	<div class="wp-block-query">
+		<!-- wp:post-template {"layout":{"type":"default"}} -->
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+				<!-- wp:post-title {"isLink":true} /-->
+
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.5em"}}} -->
+				<div class="wp-block-group">
+					<!-- wp:post-date /-->
+					<!-- wp:paragraph -->
+					<p>·</p>
+					<!-- /wp:paragraph -->
+					<!-- wp:post-author {"showAvatar":false} /-->
+				</div>
+				<!-- /wp:group -->
+
+				<!-- wp:post-excerpt {"moreText":"Continue reading","excerptLength":40} /-->
+
+				<!-- wp:separator {"className":"is-style-wide"} -->
+				<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
+				<!-- /wp:separator -->
+			</div>
+			<!-- /wp:group -->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center">No posts found.</p>
+			<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
+	</div>
+	<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/gaudi/templates/single.html
+++ b/wp-themes/gaudi/templates/single.html
@@ -1,0 +1,74 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
+		<!-- wp:post-title {"level":1} /-->
+
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.5em","margin":{"bottom":"var:preset|spacing|30"}}}} -->
+		<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--30)">
+			<!-- wp:post-date /-->
+			<!-- wp:paragraph -->
+			<p>·</p>
+			<!-- /wp:paragraph -->
+			<!-- wp:post-author {"showAvatar":false} /-->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:post-featured-image {"align":"wide"} /-->
+
+		<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+
+		<!-- wp:group {"layout":{"type":"constrained"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
+		<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--40)">
+			<!-- wp:post-terms {"term":"category","prefix":"Categories: "} /-->
+			<!-- wp:post-terms {"term":"post_tag","prefix":"Tags: "} /-->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:separator {"className":"is-style-wide"} -->
+		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
+		<!-- /wp:separator -->
+
+		<!-- wp:group {"layout":{"type":"constrained"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
+		<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--40)">
+			<!-- wp:comments -->
+			<div class="wp-block-comments">
+				<!-- wp:comments-title /-->
+				<!-- wp:comment-template -->
+					<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
+					<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--30)">
+						<!-- wp:avatar {"size":48} /-->
+						<!-- wp:group {"layout":{"type":"constrained"}} -->
+						<div class="wp-block-group">
+							<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.5em"}}} -->
+							<div class="wp-block-group">
+								<!-- wp:comment-author-name /-->
+								<!-- wp:comment-date /-->
+							</div>
+							<!-- /wp:group -->
+							<!-- wp:comment-content /-->
+							<!-- wp:comment-reply-link /-->
+							<!-- wp:comment-edit-link /-->
+						</div>
+						<!-- /wp:group -->
+					</div>
+					<!-- /wp:group -->
+				<!-- /wp:comment-template -->
+				<!-- wp:comments-pagination -->
+					<!-- wp:comments-pagination-previous /-->
+					<!-- wp:comments-pagination-numbers /-->
+					<!-- wp:comments-pagination-next /-->
+				<!-- /wp:comments-pagination -->
+				<!-- wp:post-comments-form /-->
+			</div>
+			<!-- /wp:comments -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/gaudi/theme.json
+++ b/wp-themes/gaudi/theme.json
@@ -1,0 +1,294 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"settings": {
+		"appearanceTools": true,
+		"layout": {
+			"contentSize": "720px",
+			"wideSize": "1200px"
+		},
+		"color": {
+			"palette": [
+				{
+					"slug": "cobalt-blue",
+					"color": "#1B3A8C",
+					"name": "Cobalt Blue"
+				},
+				{
+					"slug": "golden-amber",
+					"color": "#D4A017",
+					"name": "Golden Amber"
+				},
+				{
+					"slug": "forest-green",
+					"color": "#2E6F40",
+					"name": "Forest Green"
+				},
+				{
+					"slug": "terracotta",
+					"color": "#C2572A",
+					"name": "Terracotta"
+				},
+				{
+					"slug": "cream-white",
+					"color": "#FAF3E0",
+					"name": "Cream White"
+				},
+				{
+					"slug": "mosaic-teal",
+					"color": "#1A7A6D",
+					"name": "Mosaic Teal"
+				},
+				{
+					"slug": "sandstone",
+					"color": "#C4A77D",
+					"name": "Sandstone"
+				},
+				{
+					"slug": "deep-charcoal",
+					"color": "#2C2C2C",
+					"name": "Deep Charcoal"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "'Playfair Display', Georgia, serif",
+					"slug": "playfair-display",
+					"name": "Playfair Display",
+					"fontFace": [
+						{
+							"fontFamily": "Playfair Display",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/playfairdisplay/v37/nuFvD-vYSZviVYUb_rj3ij__anPXJzDwcbmjWBN2PKd3vXDXbtM.woff2"
+							]
+						},
+						{
+							"fontFamily": "Playfair Display",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/playfairdisplay/v37/nuFvD-vYSZviVYUb_rj3ij__anPXJzDwcbmjWBN2PKdFu3DXbtM.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "'Lora', 'Times New Roman', serif",
+					"slug": "lora",
+					"name": "Lora",
+					"fontFace": [
+						{
+							"fontFamily": "Lora",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/lora/v35/0QI6MX1D_JOuGQbT0gvTJPa787weuyJGmKxemMeZ.woff2"
+							]
+						},
+						{
+							"fontFamily": "Lora",
+							"fontWeight": "400",
+							"fontStyle": "italic",
+							"src": [
+								"https://fonts.gstatic.com/s/lora/v35/0QI8MX1D_JOuMw_hLdO6T2wV9KnW-MoFkqh8ndeZzU.woff2"
+							]
+						},
+						{
+							"fontFamily": "Lora",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/lora/v35/0QI6MX1D_JOuGQbT0gvTJPa787z5vCJGmKxemMeZ.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+					"slug": "system-sans",
+					"name": "System Sans"
+				}
+			],
+			"fontSizes": [
+				{
+					"slug": "small",
+					"size": "0.875rem",
+					"name": "Small"
+				},
+				{
+					"slug": "medium",
+					"size": "1rem",
+					"name": "Medium"
+				},
+				{
+					"slug": "large",
+					"size": "1.5rem",
+					"name": "Large"
+				},
+				{
+					"slug": "x-large",
+					"size": "2.25rem",
+					"name": "Extra Large"
+				},
+				{
+					"slug": "xx-large",
+					"size": "3.5rem",
+					"name": "Huge"
+				}
+			]
+		},
+		"spacing": {
+			"units": [
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw",
+				"%"
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--cream-white)",
+			"text": "var(--wp--preset--color--deep-charcoal)"
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--lora)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"lineHeight": "1.7"
+		},
+		"elements": {
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--cobalt-blue)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--terracotta)"
+					}
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
+					"fontWeight": "700",
+					"lineHeight": "1.2"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--deep-charcoal)"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--xx-large)"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--cobalt-blue)",
+					"text": "var(--wp--preset--color--cream-white)"
+				},
+				"border": {
+					"radius": "4px"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--terracotta)",
+						"text": "var(--wp--preset--color--cream-white)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--playfair-display)",
+					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontWeight": "700"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--deep-charcoal)"
+						},
+						":hover": {
+							"color": {
+								"text": "var(--wp--preset--color--cobalt-blue)"
+							}
+						},
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--lora)",
+					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--deep-charcoal)"
+						},
+						":hover": {
+							"color": {
+								"text": "var(--wp--preset--color--terracotta)"
+							}
+						},
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				}
+			},
+			"core/post-title": {
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--deep-charcoal)"
+						},
+						":hover": {
+							"color": {
+								"text": "var(--wp--preset--color--cobalt-blue)"
+							}
+						},
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				}
+			}
+		}
+	},
+	"templateParts": [
+		{
+			"name": "header",
+			"title": "Header",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"title": "Footer",
+			"area": "footer"
+		}
+	],
+	"customTemplates": [],
+	"patterns": []
+}

--- a/wp-themes/giacometti/README.md
+++ b/wp-themes/giacometti/README.md
@@ -1,0 +1,34 @@
+# Giacometti — A WordPress Block Theme
+
+A WordPress block theme inspired by the sculptural work of Alberto Giacometti (1901--1966).
+
+## Design Notes
+
+This theme draws from the visual language of Giacometti's mature sculpture: the elongated human figures, the rough textured surfaces of bronze castings, and the austere studio environments in which he worked.
+
+Key design decisions:
+
+- **Narrow content width (620px):** Echoes the tall, compressed vertical forms of works like *Walking Man* and *Tall Figure*. The reading column is deliberately slender, creating generous whitespace on either side.
+- **Bronze and stone palette:** The six-color palette references the materials of sculpture itself -- cast bronze, raw plaster, studio charcoal, and the warm stone of Parisian ateliers.
+- **Light-weight typography:** Josefin Sans at weight 300 for headings produces the thin, stretched letterforms that rhyme with Giacometti's attenuated figures. IBM Plex Serif provides a grounded, readable body text.
+- **Uppercase headings with wide letter-spacing:** Suggests the inscriptions found on sculpture pedestals and exhibition plaques.
+- **Spare layout:** Minimal ornamentation. The theme relies on proportion, whitespace, and restrained color rather than decorative elements.
+
+## Style Variation
+
+**Bronze** — A darker, moodier variation that inverts the default palette. Dark charcoal background with bronze and warm-stone text, evoking the interior of a foundry or a dimly lit gallery.
+
+## Attribution
+
+This theme is an artistic homage and is not affiliated with, endorsed by, or connected to the Alberto Giacometti estate, the Fondation Giacometti, or any rights holders. All references to the artist and his work are made purely for the purpose of artistic inspiration and design commentary.
+
+The typefaces used (Josefin Sans and IBM Plex Serif) are open-source fonts available through Google Fonts.
+
+## Requirements
+
+- WordPress 6.4 or later
+- PHP 7.4 or later
+
+## License
+
+GNU General Public License v2 or later. See [LICENSE](http://www.gnu.org/licenses/gpl-2.0.html).

--- a/wp-themes/giacometti/parts/footer.html
+++ b/wp-themes/giacometti/parts/footer.html
@@ -1,0 +1,11 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"2rem","bottom":"2rem"}},"border":{"top":{"color":"var(--wp--preset--color--studio-gray)","width":"1px","style":"solid"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--studio-gray);border-top-style:solid;border-top-width:1px;padding-top:2rem;padding-bottom:2rem">
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"center"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph {"style":{"typography":{"fontFamily":"var(--wp--preset--font-family--josefin-sans)","fontSize":"var(--wp--preset--font-size--small)","letterSpacing":"0.04em","textTransform":"uppercase","fontWeight":"300"}},"textColor":"studio-gray"} -->
+		<p class="has-studio-gray-color has-text-color" style="font-family:var(--wp--preset--font-family--josefin-sans);font-size:var(--wp--preset--font-size--small);font-weight:300;letter-spacing:0.04em;text-transform:uppercase">Giacometti Theme &mdash; An artist-inspired WordPress theme</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/giacometti/parts/header.html
+++ b/wp-themes/giacometti/parts/header.html
@@ -1,0 +1,11 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"1.5rem","bottom":"1.5rem"}},"border":{"bottom":{"color":"var(--wp--preset--color--studio-gray)","width":"1px","style":"solid"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="border-bottom-color:var(--wp--preset--color--studio-gray);border-bottom-style:solid;border-bottom-width:1px;padding-top:1.5rem;padding-bottom:1.5rem">
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
+	<div class="wp-block-group">
+		<!-- wp:site-title {"style":{"typography":{"fontFamily":"var(--wp--preset--font-family--josefin-sans)","fontWeight":"300","letterSpacing":"0.1em","textTransform":"uppercase","fontSize":"var(--wp--preset--font-size--large)"},"elements":{"link":{"color":{"text":"var(--wp--preset--color--dark-bronze)"}}}}} /-->
+
+		<!-- wp:navigation {"overlayMenu":"mobile","style":{"typography":{"fontFamily":"var(--wp--preset--font-family--josefin-sans)","fontWeight":"300","letterSpacing":"0.04em","textTransform":"uppercase","fontSize":"var(--wp--preset--font-size--small)"}}} /-->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/giacometti/patterns/hero.php
+++ b/wp-themes/giacometti/patterns/hero.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Title: Hero
+ * Slug: giacometti/hero
+ * Categories: featured
+ * Description: A minimalist hero section inspired by Giacometti's elongated sculptural forms
+ */
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"8rem","bottom":"8rem"}},"color":{"background":"var(--wp--preset--color--charcoal)"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="background-color:var(--wp--preset--color--charcoal);padding-top:8rem;padding-bottom:8rem">
+	<!-- wp:group {"layout":{"type":"constrained","contentSize":"620px"}} -->
+	<div class="wp-block-group">
+		<!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"var(--wp--preset--font-size--xx-large)","fontWeight":"300","letterSpacing":"0.08em"}},"textColor":"plaster-white"} -->
+		<h1 class="wp-block-heading has-plaster-white-color has-text-color" style="font-size:var(--wp--preset--font-size--xx-large);font-weight:300;letter-spacing:0.08em"><?php echo esc_html__( 'The Figure Stands Alone', 'giacometti' ); ?></h1>
+		<!-- /wp:heading -->
+
+		<!-- wp:separator {"style":{"color":{"text":"var(--wp--preset--color--bronze)"}},"className":"is-style-wide"} -->
+		<hr class="wp-block-separator has-text-color is-style-wide" style="color:var(--wp--preset--color--bronze)"/>
+		<!-- /wp:separator -->
+
+		<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.9"}},"textColor":"warm-stone"} -->
+		<p class="has-warm-stone-color has-text-color" style="line-height:1.9"><?php echo esc_html__( 'Stripped to its essence, the form reaches upward. In the silence of the studio, between shadow and plaster dust, every surface becomes a meditation on presence and absence.', 'giacometti' ); ?></p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:buttons {"style":{"spacing":{"margin":{"top":"2rem"}}}} -->
+		<div class="wp-block-buttons" style="margin-top:2rem">
+			<!-- wp:button {"backgroundColor":"bronze","textColor":"plaster-white","style":{"typography":{"fontFamily":"var(--wp--preset--font-family--josefin-sans)","letterSpacing":"0.08em","textTransform":"uppercase","fontWeight":"300","fontSize":"var(--wp--preset--font-size--small)"},"border":{"radius":"0"},"spacing":{"padding":{"top":"0.8rem","bottom":"0.8rem","left":"2rem","right":"2rem"}}}} -->
+			<div class="wp-block-button" style="font-family:var(--wp--preset--font-family--josefin-sans);font-size:var(--wp--preset--font-size--small);font-weight:300;letter-spacing:0.08em;text-transform:uppercase"><a class="wp-block-button__link has-bronze-background-color has-plaster-white-color has-text-color has-background wp-element-button" style="border-radius:0;padding-top:0.8rem;padding-right:2rem;padding-bottom:0.8rem;padding-left:2rem"><?php echo esc_html__( 'Explore', 'giacometti' ); ?></a></div>
+			<!-- /wp:button -->
+		</div>
+		<!-- /wp:buttons -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/giacometti/style.css
+++ b/wp-themes/giacometti/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Giacometti
+Theme URI: #
+Author: Artist Themes Collection
+Author URI: #
+Description: A WordPress block theme inspired by Alberto Giacometti's elongated sculptures and existentialist aesthetic. Features a restrained palette of bronze and stone tones, tall vertical rhythms, and spare typography that echoes the solitary human figures of his work.
+Version: 1.0.0
+Requires at least: 6.4
+Tested up to: 6.7
+Requires PHP: 7.4
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: giacometti
+Tags: block-patterns, full-site-editing, wide-blocks, custom-colors, custom-fonts
+*/

--- a/wp-themes/giacometti/styles/bronze.json
+++ b/wp-themes/giacometti/styles/bronze.json
@@ -1,0 +1,146 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"title": "Bronze",
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "bronze",
+					"color": "#8B5E3C",
+					"name": "Bronze"
+				},
+				{
+					"slug": "dark-bronze",
+					"color": "#2E1A05",
+					"name": "Dark Bronze"
+				},
+				{
+					"slug": "studio-gray",
+					"color": "#6B6B6B",
+					"name": "Studio Gray"
+				},
+				{
+					"slug": "plaster-white",
+					"color": "#E8E0D4",
+					"name": "Plaster White"
+				},
+				{
+					"slug": "charcoal",
+					"color": "#1A1A1A",
+					"name": "Charcoal"
+				},
+				{
+					"slug": "warm-stone",
+					"color": "#BFA97A",
+					"name": "Warm Stone"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "\"Josefin Sans\", sans-serif",
+					"name": "Josefin Sans",
+					"slug": "josefin-sans",
+					"fontFace": [
+						{
+							"fontFamily": "Josefin Sans",
+							"fontWeight": "300",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/josefinsans/v32/Qw3PZQNVED7rKGKxtqIqX5E-AVSJrOCfjY46_DjQbMZhKSbpUVzEEQ.woff2"
+							]
+						},
+						{
+							"fontFamily": "Josefin Sans",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/josefinsans/v32/Qw3PZQNVED7rKGKxtqIqX5E-AVSJrOCfjY46_DjQbMZhKSbpUVzEEQ.woff2"
+							]
+						},
+						{
+							"fontFamily": "Josefin Sans",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/josefinsans/v32/Qw3PZQNVED7rKGKxtqIqX5E-AVSJrOCfjY46_DjQbMZhKSbpUVzEEQ.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "\"IBM Plex Serif\", serif",
+					"name": "IBM Plex Serif",
+					"slug": "ibm-plex-serif",
+					"fontFace": [
+						{
+							"fontFamily": "IBM Plex Serif",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/ibmplexserif/v19/jizDREVNn1dOx-zrZ2X3pZvkTiUQ6nnBig.woff2"
+							]
+						},
+						{
+							"fontFamily": "IBM Plex Serif",
+							"fontWeight": "400",
+							"fontStyle": "italic",
+							"src": [
+								"https://fonts.gstatic.com/s/ibmplexserif/v19/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zUTiA.woff2"
+							]
+						},
+						{
+							"fontFamily": "IBM Plex Serif",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/ibmplexserif/v19/jizAREVNn1dOx-zrZ2X3pZvkTi2k_iI5q1vjitOh.woff2"
+							]
+						}
+					]
+				}
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--charcoal)",
+			"text": "var(--wp--preset--color--plaster-white)"
+		},
+		"elements": {
+			"heading": {
+				"color": {
+					"text": "var(--wp--preset--color--bronze)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--warm-stone)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--bronze)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/separator": {
+				"color": {
+					"text": "var(--wp--preset--color--studio-gray)"
+				}
+			},
+			"core/quote": {
+				"border": {
+					"left": {
+						"color": "var(--wp--preset--color--bronze)",
+						"width": "2px",
+						"style": "solid"
+					}
+				}
+			}
+		}
+	}
+}

--- a/wp-themes/giacometti/templates/index.html
+++ b/wp-themes/giacometti/templates/index.html
@@ -1,0 +1,47 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+	<div class="wp-block-query">
+		<!-- wp:post-template {"layout":{"type":"default"}} -->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"0.75rem","padding":{"top":"2rem","bottom":"2rem"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-top:2rem;padding-bottom:2rem">
+				<!-- wp:post-title {"isLink":true,"style":{"typography":{"fontSize":"var(--wp--preset--font-size--x-large)"}}} /-->
+
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.5rem"},"typography":{"fontSize":"var(--wp--preset--font-size--small)"}}} -->
+				<div class="wp-block-group" style="font-size:var(--wp--preset--font-size--small)">
+					<!-- wp:post-date /-->
+					<!-- wp:paragraph -->
+					<p>&middot;</p>
+					<!-- /wp:paragraph -->
+					<!-- wp:post-author {"showAvatar":false} /-->
+				</div>
+				<!-- /wp:group -->
+
+				<!-- wp:post-excerpt {"moreText":"Continue reading","excerptLength":30} /-->
+
+				<!-- wp:separator {"style":{"color":{"text":"var(--wp--preset--color--studio-gray)"}},"className":"is-style-wide"} -->
+				<hr class="wp-block-separator has-text-color is-style-wide" style="color:var(--wp--preset--color--studio-gray)"/>
+				<!-- /wp:separator -->
+			</div>
+			<!-- /wp:group -->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"padding":{"top":"2rem"}}}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center">No posts found.</p>
+			<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
+	</div>
+	<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/giacometti/templates/single.html
+++ b/wp-themes/giacometti/templates/single.html
@@ -1,0 +1,31 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"style":{"spacing":{"padding":{"top":"3rem","bottom":"3rem"}}}} -->
+<main class="wp-block-group" style="padding-top:3rem;padding-bottom:3rem">
+	<!-- wp:post-title {"level":1} /-->
+
+	<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.5rem","margin":{"bottom":"2rem"}},"typography":{"fontSize":"var(--wp--preset--font-size--small)"}}} -->
+	<div class="wp-block-group" style="font-size:var(--wp--preset--font-size--small);margin-bottom:2rem">
+		<!-- wp:post-date /-->
+		<!-- wp:paragraph -->
+		<p>&middot;</p>
+		<!-- /wp:paragraph -->
+		<!-- wp:post-author {"showAvatar":false} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:post-featured-image {"align":"wide","style":{"spacing":{"margin":{"bottom":"2rem"}}}} /-->
+
+	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+
+	<!-- wp:separator {"style":{"spacing":{"margin":{"top":"3rem","bottom":"2rem"}},"color":{"text":"var(--wp--preset--color--studio-gray)"}},"className":"is-style-wide"} -->
+	<hr class="wp-block-separator has-text-color is-style-wide" style="color:var(--wp--preset--color--studio-gray);margin-top:3rem;margin-bottom:2rem"/>
+	<!-- /wp:separator -->
+
+	<!-- wp:post-terms {"term":"category","style":{"typography":{"fontSize":"var(--wp--preset--font-size--small)"}}} /-->
+
+	<!-- wp:post-comments-form /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/giacometti/theme.json
+++ b/wp-themes/giacometti/theme.json
@@ -1,0 +1,248 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"settings": {
+		"appearanceTools": true,
+		"color": {
+			"palette": [
+				{
+					"slug": "bronze",
+					"color": "#CD7F32",
+					"name": "Bronze"
+				},
+				{
+					"slug": "dark-bronze",
+					"color": "#4A2C0A",
+					"name": "Dark Bronze"
+				},
+				{
+					"slug": "studio-gray",
+					"color": "#A8A8A8",
+					"name": "Studio Gray"
+				},
+				{
+					"slug": "plaster-white",
+					"color": "#F0EDE8",
+					"name": "Plaster White"
+				},
+				{
+					"slug": "charcoal",
+					"color": "#2C2C2C",
+					"name": "Charcoal"
+				},
+				{
+					"slug": "warm-stone",
+					"color": "#D4C5A9",
+					"name": "Warm Stone"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "\"Josefin Sans\", sans-serif",
+					"name": "Josefin Sans",
+					"slug": "josefin-sans",
+					"fontFace": [
+						{
+							"fontFamily": "Josefin Sans",
+							"fontWeight": "300",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/josefinsans/v32/Qw3PZQNVED7rKGKxtqIqX5E-AVSJrOCfjY46_DjQbMZhKSbpUVzEEQ.woff2"
+							]
+						},
+						{
+							"fontFamily": "Josefin Sans",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/josefinsans/v32/Qw3PZQNVED7rKGKxtqIqX5E-AVSJrOCfjY46_DjQbMZhKSbpUVzEEQ.woff2"
+							]
+						},
+						{
+							"fontFamily": "Josefin Sans",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/josefinsans/v32/Qw3PZQNVED7rKGKxtqIqX5E-AVSJrOCfjY46_DjQbMZhKSbpUVzEEQ.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "\"IBM Plex Serif\", serif",
+					"name": "IBM Plex Serif",
+					"slug": "ibm-plex-serif",
+					"fontFace": [
+						{
+							"fontFamily": "IBM Plex Serif",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/ibmplexserif/v19/jizDREVNn1dOx-zrZ2X3pZvkTiUQ6nnBig.woff2"
+							]
+						},
+						{
+							"fontFamily": "IBM Plex Serif",
+							"fontWeight": "400",
+							"fontStyle": "italic",
+							"src": [
+								"https://fonts.gstatic.com/s/ibmplexserif/v19/jizBREVNn1dOx-zrZ2X3pZvkTiUa6zUTiA.woff2"
+							]
+						},
+						{
+							"fontFamily": "IBM Plex Serif",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/ibmplexserif/v19/jizAREVNn1dOx-zrZ2X3pZvkTi2k_iI5q1vjitOh.woff2"
+							]
+						}
+					]
+				}
+			],
+			"fontSizes": [
+				{
+					"slug": "small",
+					"size": "0.875rem",
+					"name": "Small"
+				},
+				{
+					"slug": "medium",
+					"size": "1rem",
+					"name": "Medium"
+				},
+				{
+					"slug": "large",
+					"size": "1.5rem",
+					"name": "Large"
+				},
+				{
+					"slug": "x-large",
+					"size": "2.25rem",
+					"name": "Extra Large"
+				},
+				{
+					"slug": "xx-large",
+					"size": "3.5rem",
+					"name": "Huge"
+				}
+			]
+		},
+		"layout": {
+			"contentSize": "620px",
+			"wideSize": "1100px"
+		},
+		"spacing": {
+			"units": [
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw",
+				"%"
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--plaster-white)",
+			"text": "var(--wp--preset--color--charcoal)"
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--ibm-plex-serif)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"lineHeight": "1.7"
+		},
+		"spacing": {
+			"blockGap": "1.5rem",
+			"padding": {
+				"top": "0",
+				"right": "1.5rem",
+				"bottom": "0",
+				"left": "1.5rem"
+			}
+		},
+		"elements": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--josefin-sans)",
+					"fontWeight": "300",
+					"lineHeight": "1.2",
+					"letterSpacing": "0.04em",
+					"textTransform": "uppercase"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--dark-bronze)"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--xx-large)"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--bronze)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--dark-bronze)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/separator": {
+				"color": {
+					"text": "var(--wp--preset--color--studio-gray)"
+				},
+				"border": {
+					"width": "1px"
+				}
+			},
+			"core/quote": {
+				"border": {
+					"left": {
+						"color": "var(--wp--preset--color--bronze)",
+						"width": "2px",
+						"style": "solid"
+					}
+				},
+				"typography": {
+					"fontStyle": "italic"
+				},
+				"spacing": {
+					"padding": {
+						"left": "1.5rem"
+					}
+				}
+			}
+		}
+	},
+	"templateParts": [
+		{
+			"name": "header",
+			"title": "Header",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"title": "Footer",
+			"area": "footer"
+		}
+	],
+	"customTemplates": [],
+	"patterns": []
+}

--- a/wp-themes/hitchcock/README.md
+++ b/wp-themes/hitchcock/README.md
@@ -1,0 +1,36 @@
+# Hitchcock
+
+A WordPress block theme inspired by the visual language of Alfred Hitchcock's cinema.
+
+## Design Notes
+
+This theme draws from the aesthetic vocabulary of classic thriller and film noir cinematography:
+
+- **Color palette**: High-contrast noir palette featuring deep blacks, dramatic blood reds, and cool silver grays that evoke the chiaroscuro lighting of mid-century suspense films.
+- **Typography**: Bold, uppercase headings (Anton) paired with clean body text (Inter) to create the tension between dramatic impact and readability found in classic film title sequences.
+- **Layout**: Constrained content width with wide alignment support, mirroring the deliberate framing and composition of suspenseful cinema.
+
+## Style Variations
+
+- **Vertigo**: An alternative palette inspired by the spiraling, disorienting visuals of psychological thrillers, featuring deep greens, golds, and teal accents with Playfair Display serif headings.
+
+## Features
+
+- Full Site Editing support
+- Dark background with high-contrast typography
+- Hero pattern for dramatic landing sections
+- Responsive navigation with noir-styled mobile overlay
+- Custom color palette with six film-noir-inspired colors
+
+## Requirements
+
+- WordPress 6.4 or later
+- PHP 7.4 or later
+
+## Homage Disclaimer
+
+This theme is an artistic homage to the visual style of classic suspense cinema. It is not affiliated with, endorsed by, or connected to the estate of Alfred Hitchcock or any related entities. All design choices are original interpretations inspired by the broader genre of film noir and thriller cinematography.
+
+## License
+
+GNU General Public License v2 or later. See [LICENSE](http://www.gnu.org/licenses/gpl-2.0.html).

--- a/wp-themes/hitchcock/parts/footer.html
+++ b/wp-themes/hitchcock/parts/footer.html
@@ -1,0 +1,19 @@
+<!-- wp:group {"tagName":"footer","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"top":{"color":"var:preset|color|deep-shadow","width":"1px","style":"solid"}}},"backgroundColor":"jet-black","layout":{"type":"constrained"}} -->
+<footer class="wp-block-group has-jet-black-background-color has-background" style="border-top-color:var(--wp--preset--color--deep-shadow);border-top-style:solid;border-top-width:1px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30)">
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"center"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"var:preset|font-size|small","textTransform":"uppercase","letterSpacing":"0.1em"}},"textColor":"smoke-gray"} -->
+		<p class="has-text-align-center has-smoke-gray-color has-text-color" style="font-size:var(--wp--preset--font-size--small);text-transform:uppercase;letter-spacing:0.1em">Designed with suspense in mind</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
+	<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20)">
+		<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"var:preset|font-size|small"}},"textColor":"smoke-gray"} -->
+		<p class="has-text-align-center has-smoke-gray-color has-text-color" style="font-size:var(--wp--preset--font-size--small)">Proudly powered by <a href="https://wordpress.org">WordPress</a></p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+</footer>
+<!-- /wp:group -->

--- a/wp-themes/hitchcock/parts/header.html
+++ b/wp-themes/hitchcock/parts/header.html
@@ -1,0 +1,11 @@
+<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"border":{"bottom":{"color":"var:preset|color|blood-red","width":"2px","style":"solid"}}},"backgroundColor":"deep-shadow","layout":{"type":"constrained"}} -->
+<header class="wp-block-group has-deep-shadow-background-color has-background" style="border-bottom-color:var(--wp--preset--color--blood-red);border-bottom-style:solid;border-bottom-width:2px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
+	<div class="wp-block-group">
+		<!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"var:preset|color|spotlight-white"},":hover":{"color":{"text":"var:preset|color|blood-red"}}}},"typography":{"textTransform":"uppercase","letterSpacing":"0.15em","fontSize":"var:preset|font-size|large","fontStyle":"normal","fontWeight":"400"}},"fontFamily":"anton"} /-->
+
+		<!-- wp:navigation {"overlayTextColor":"spotlight-white","overlayBackgroundColor":"jet-black","style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.1em","fontSize":"var:preset|font-size|small"},"elements":{"link":{"color":{"text":"var:preset|color|silver-screen"},":hover":{"color":{"text":"var:preset|color|blood-red"}}}}},"fontFamily":"inter","layout":{"type":"flex","justifyContent":"right"}} /-->
+	</div>
+	<!-- /wp:group -->
+</header>
+<!-- /wp:group -->

--- a/wp-themes/hitchcock/patterns/hero.php
+++ b/wp-themes/hitchcock/patterns/hero.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Title: Hero
+ * Slug: hitchcock/hero
+ * Categories: featured
+ * Description: A dramatic hero section inspired by Hitchcock's cinematic suspense
+ */
+?>
+
+<!-- wp:cover {"dimRatio":80,"overlayColor":"jet-black","isUserOverlayColor":true,"minHeight":85,"minHeightUnit":"vh","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}}} -->
+<div class="wp-block-cover alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--30);min-height:85vh">
+	<span aria-hidden="true" class="wp-block-cover__background has-jet-black-background-color has-background-dim-80 has-background-dim"></span>
+	<div class="wp-block-cover__inner-container">
+		<!-- wp:group {"layout":{"type":"constrained","contentSize":"800px"}} -->
+		<div class="wp-block-group">
+			<!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontSize":"clamp(2.5rem, 6vw, 5rem)","letterSpacing":"0.08em","lineHeight":"1.1"}},"textColor":"spotlight-white"} -->
+			<h1 class="wp-block-heading has-text-align-center has-spotlight-white-color has-text-color" style="font-size:clamp(2.5rem, 6vw, 5rem);letter-spacing:0.08em;line-height:1.1"><?php echo esc_html__( 'There Is No Terror in the Bang, Only in the Anticipation of It', 'hitchcock' ); ?></h1>
+			<!-- /wp:heading -->
+
+			<!-- wp:separator {"backgroundColor":"blood-red","style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
+			<hr class="wp-block-separator has-text-color has-blood-red-color has-alpha-channel-opacity has-blood-red-background-color has-background" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30)"/>
+			<!-- /wp:separator -->
+
+			<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"var:preset|font-size|large","lineHeight":"1.6","letterSpacing":"0.02em"}},"textColor":"silver-screen"} -->
+			<p class="has-text-align-center has-silver-screen-color has-text-color" style="font-size:var(--wp--preset--font-size--large);line-height:1.6;letter-spacing:0.02em"><?php echo esc_html__( 'A cinematic experience crafted with dramatic contrast, bold typography, and the unmistakable tension of noir storytelling.', 'hitchcock' ); ?></p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
+			<div class="wp-block-buttons" style="margin-top:var(--wp--preset--spacing--40)">
+				<!-- wp:button {"backgroundColor":"blood-red","textColor":"spotlight-white","style":{"typography":{"letterSpacing":"0.15em","textTransform":"uppercase"},"spacing":{"padding":{"top":"1rem","bottom":"1rem","left":"2.5rem","right":"2.5rem"}},"border":{"radius":"0px"}},"fontFamily":"anton"} -->
+				<div class="wp-block-button" style="font-family:var(--wp--preset--font-family--anton)"><a class="wp-block-button__link has-spotlight-white-color has-blood-red-background-color has-text-color has-background wp-element-button" style="border-radius:0px;padding-top:1rem;padding-right:2.5rem;padding-bottom:1rem;padding-left:2.5rem;letter-spacing:0.15em;text-transform:uppercase"><?php echo esc_html__( 'Enter the Scene', 'hitchcock' ); ?></a></div>
+				<!-- /wp:button -->
+			</div>
+			<!-- /wp:buttons -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+</div>
+<!-- /wp:cover -->

--- a/wp-themes/hitchcock/style.css
+++ b/wp-themes/hitchcock/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Hitchcock
+Theme URI: #
+Author: Artist Themes Collection
+Author URI: #
+Description: A WordPress block theme inspired by the suspenseful visual style of Alfred Hitchcock's cinema. Features dramatic contrast, noir-influenced palettes, and bold typography that evokes the tension and sophistication of classic thriller films.
+Version: 1.0.0
+Requires at least: 6.4
+Tested up to: 6.7
+Requires PHP: 7.4
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: hitchcock
+Tags: block-patterns, full-site-editing, wide-blocks, custom-colors, custom-fonts
+*/

--- a/wp-themes/hitchcock/styles/vertigo.json
+++ b/wp-themes/hitchcock/styles/vertigo.json
@@ -1,0 +1,130 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"title": "Vertigo",
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "jet-black",
+					"color": "#0D1117",
+					"name": "Obsidian"
+				},
+				{
+					"slug": "blood-red",
+					"color": "#FFD700",
+					"name": "Vertigo Gold"
+				},
+				{
+					"slug": "smoke-gray",
+					"color": "#26A69A",
+					"name": "Vertiginous Teal"
+				},
+				{
+					"slug": "silver-screen",
+					"color": "#B2DFDB",
+					"name": "Pale Mist"
+				},
+				{
+					"slug": "spotlight-white",
+					"color": "#E0F2F1",
+					"name": "Spiral Light"
+				},
+				{
+					"slug": "deep-shadow",
+					"color": "#004D40",
+					"name": "Deep Green"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "Playfair Display, serif",
+					"slug": "anton",
+					"name": "Playfair Display",
+					"fontFace": [
+						{
+							"fontFamily": "Playfair Display",
+							"fontWeight": "400 700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/playfairdisplay/v37/nuFvD-vYSZviVYUb_rj3ij__anPXJzDwcbmjWBN2PKd3vXDXbtM.woff2"
+							]
+						},
+						{
+							"fontFamily": "Playfair Display",
+							"fontWeight": "400 700",
+							"fontStyle": "italic",
+							"src": [
+								"https://fonts.gstatic.com/s/playfairdisplay/v37/nuFRD-vYSZviVYUb_rj3ij__anPXDTnCjmHKM4nYO7KN_qiTbtbK.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "Inter, sans-serif",
+					"slug": "inter",
+					"name": "Inter",
+					"fontFace": [
+						{
+							"fontFamily": "Inter",
+							"fontWeight": "300 700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/inter/v18/UcCo3FwrK3iLTcviYwY.woff2"
+							]
+						}
+					]
+				}
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--deep-shadow)",
+			"text": "var(--wp--preset--color--silver-screen)"
+		},
+		"elements": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--anton)",
+					"fontWeight": "700",
+					"fontStyle": "italic"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--blood-red)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--blood-red)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--spotlight-white)"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--blood-red)",
+					"text": "var(--wp--preset--color--deep-shadow)"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--spotlight-white)",
+						"text": "var(--wp--preset--color--deep-shadow)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/separator": {
+				"color": {
+					"text": "var(--wp--preset--color--smoke-gray)"
+				}
+			}
+		}
+	}
+}

--- a/wp-themes/hitchcock/templates/index.html
+++ b/wp-themes/hitchcock/templates/index.html
@@ -1,0 +1,44 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","inherit":true}} -->
+	<div class="wp-block-query">
+		<!-- wp:post-template {"layout":{"type":"default"}} -->
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
+				<!-- wp:post-title {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|spotlight-white"},":hover":{"color":{"text":"var:preset|color|blood-red"}}}}}} /-->
+
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"1rem"},"typography":{"fontSize":"var:preset|font-size|small"}},"textColor":"smoke-gray"} -->
+				<div class="wp-block-group has-smoke-gray-color has-text-color" style="font-size:var(--wp--preset--font-size--small)">
+					<!-- wp:post-date /-->
+					<!-- wp:post-author {"showAvatar":false} /-->
+				</div>
+				<!-- /wp:group -->
+
+				<!-- wp:post-excerpt {"moreText":"Continue reading","excerptLength":35} /-->
+
+				<!-- wp:separator {"backgroundColor":"smoke-gray","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
+				<hr class="wp-block-separator has-text-color has-smoke-gray-color has-alpha-channel-opacity has-smoke-gray-background-color has-background" style="margin-top:var(--wp--preset--spacing--40)"/>
+				<!-- /wp:separator -->
+			</div>
+			<!-- /wp:group -->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"},"style":{"typography":{"fontSize":"var:preset|font-size|small"}}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+			<!-- wp:paragraph {"align":"center","textColor":"smoke-gray"} -->
+			<p class="has-text-align-center has-smoke-gray-color has-text-color">No posts found.</p>
+			<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
+	</div>
+	<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/hitchcock/templates/single.html
+++ b/wp-themes/hitchcock/templates/single.html
@@ -1,0 +1,73 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--30)">
+		<!-- wp:post-title {"level":1,"textAlign":"center"} /-->
+
+		<!-- wp:group {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"blockGap":"1rem","margin":{"top":"var:preset|spacing|20"}},"typography":{"fontSize":"var:preset|font-size|small"}},"textColor":"smoke-gray"} -->
+		<div class="wp-block-group has-smoke-gray-color has-text-color" style="font-size:var(--wp--preset--font-size--small);margin-top:var(--wp--preset--spacing--20)">
+			<!-- wp:post-date /-->
+			<!-- wp:post-author {"showAvatar":false} /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:post-featured-image {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)">
+		<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:separator {"backgroundColor":"smoke-gray"} -->
+	<hr class="wp-block-separator has-text-color has-smoke-gray-color has-alpha-channel-opacity has-smoke-gray-background-color has-background"/>
+	<!-- /wp:separator -->
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+		<!-- wp:post-terms {"term":"category","textColor":"blood-red","style":{"typography":{"fontSize":"var:preset|font-size|small"}}} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--40)">
+		<!-- wp:post-navigation-link {"type":"previous","label":"Previous"} /-->
+		<!-- wp:post-navigation-link {"label":"Next"} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:comments -->
+	<div class="wp-block-comments">
+		<!-- wp:comments-title /-->
+		<!-- wp:comment-template -->
+			<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
+			<div class="wp-block-group">
+				<!-- wp:avatar {"size":40} /-->
+				<!-- wp:group {"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group">
+					<!-- wp:comment-author-name /-->
+					<!-- wp:comment-date {"style":{"typography":{"fontSize":"var:preset|font-size|small"}},"textColor":"smoke-gray"} /-->
+					<!-- wp:comment-content /-->
+					<!-- wp:comment-reply-link {"style":{"typography":{"fontSize":"var:preset|font-size|small"}}} /-->
+					<!-- wp:comment-edit-link {"style":{"typography":{"fontSize":"var:preset|font-size|small"}}} /-->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:group -->
+		<!-- /wp:comment-template -->
+		<!-- wp:comments-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+			<!-- wp:comments-pagination-previous /-->
+			<!-- wp:comments-pagination-numbers /-->
+			<!-- wp:comments-pagination-next /-->
+		<!-- /wp:comments-pagination -->
+		<!-- wp:post-comments-form /-->
+	</div>
+	<!-- /wp:comments -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/hitchcock/theme.json
+++ b/wp-themes/hitchcock/theme.json
@@ -1,0 +1,220 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"settings": {
+		"appearanceTools": true,
+		"color": {
+			"palette": [
+				{
+					"slug": "jet-black",
+					"color": "#0A0A0A",
+					"name": "Jet Black"
+				},
+				{
+					"slug": "blood-red",
+					"color": "#8B0000",
+					"name": "Blood Red"
+				},
+				{
+					"slug": "smoke-gray",
+					"color": "#708090",
+					"name": "Smoke Gray"
+				},
+				{
+					"slug": "silver-screen",
+					"color": "#C0C0C0",
+					"name": "Silver Screen"
+				},
+				{
+					"slug": "spotlight-white",
+					"color": "#FAFAFA",
+					"name": "Spotlight White"
+				},
+				{
+					"slug": "deep-shadow",
+					"color": "#1C1C1C",
+					"name": "Deep Shadow"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "Anton, sans-serif",
+					"slug": "anton",
+					"name": "Anton",
+					"fontFace": [
+						{
+							"fontFamily": "Anton",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/anton/v25/1Ptgg87GROyAm3K9-C8.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "Inter, sans-serif",
+					"slug": "inter",
+					"name": "Inter",
+					"fontFace": [
+						{
+							"fontFamily": "Inter",
+							"fontWeight": "300 700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/inter/v18/UcCo3FwrK3iLTcviYwY.woff2"
+							]
+						}
+					]
+				}
+			],
+			"fontSizes": [
+				{
+					"slug": "small",
+					"size": "0.875rem",
+					"name": "Small"
+				},
+				{
+					"slug": "medium",
+					"size": "1rem",
+					"name": "Medium"
+				},
+				{
+					"slug": "large",
+					"size": "1.5rem",
+					"name": "Large"
+				},
+				{
+					"slug": "x-large",
+					"size": "2.25rem",
+					"name": "Extra Large"
+				},
+				{
+					"slug": "xx-large",
+					"size": "3.5rem",
+					"name": "Huge"
+				}
+			]
+		},
+		"layout": {
+			"contentSize": "720px",
+			"wideSize": "1200px"
+		},
+		"spacing": {
+			"units": [
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw",
+				"%"
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--jet-black)",
+			"text": "var(--wp--preset--color--silver-screen)"
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--inter)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"lineHeight": "1.7"
+		},
+		"elements": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--anton)",
+					"fontWeight": "400",
+					"lineHeight": "1.15",
+					"textTransform": "uppercase",
+					"letterSpacing": "0.03em"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--spotlight-white)"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--xx-large)"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--blood-red)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--spotlight-white)"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--blood-red)",
+					"text": "var(--wp--preset--color--spotlight-white)"
+				},
+				"border": {
+					"radius": "0"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--anton)",
+					"textTransform": "uppercase",
+					"letterSpacing": "0.1em",
+					"fontSize": "var(--wp--preset--font-size--small)"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--spotlight-white)",
+						"text": "var(--wp--preset--color--jet-black)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/separator": {
+				"color": {
+					"text": "var(--wp--preset--color--smoke-gray)"
+				}
+			},
+			"core/quote": {
+				"border": {
+					"left": {
+						"color": "var(--wp--preset--color--blood-red)",
+						"width": "4px",
+						"style": "solid"
+					}
+				},
+				"typography": {
+					"fontStyle": "italic"
+				}
+			}
+		}
+	},
+	"templateParts": [
+		{
+			"name": "header",
+			"title": "Header",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"title": "Footer",
+			"area": "footer"
+		}
+	],
+	"customTemplates": [],
+	"patterns": []
+}

--- a/wp-themes/hundertwasser/README.md
+++ b/wp-themes/hundertwasser/README.md
@@ -1,0 +1,36 @@
+# Hundertwasser - WordPress Block Theme
+
+A WordPress block theme inspired by the vibrant, nature-loving art and architecture of **Friedensreich Hundertwasser** (1928-2000).
+
+## Design Notes
+
+This theme draws from Hundertwasser's philosophy and aesthetic principles:
+
+- **Bold, organic color palette** - Vivid reds, blues, yellows, greens, and purples inspired by Hundertwasser's paintings and the facades of the Hundertwasserhaus in Vienna.
+- **Playful typography** - Rounded, friendly heading fonts paired with readable body text echo the whimsical spirit of Hundertwasser's architectural lettering.
+- **Rounded forms** - Border-radius treatments on buttons and cards reject the rigid grid in favor of softer, more natural shapes.
+- **Nature-forward philosophy** - The "Spiral" style variation shifts toward earthy, natural tones reflecting Hundertwasser's deep environmentalism and belief that architecture should serve both people and nature.
+
+## Features
+
+- Full Site Editing support
+- Custom color palette with 8 Hundertwasser-inspired colors
+- Two font families: Fredoka (headings) and Nunito (body)
+- Hero pattern for featured content
+- "Spiral" style variation with earthy/nature palette and serif body text
+- Responsive layout with content and wide size options
+
+## Style Variations
+
+### Spiral
+A more subdued, nature-focused variation that replaces the vivid palette with earthy tones (sienna, olive green, goldenrod, dark slate) and swaps the body font for Lora, a serif typeface. Named after Hundertwasser's famous spiral motifs.
+
+## Attribution
+
+This theme is an artistic homage to the work of Friedensreich Hundertwasser. It is not affiliated with, endorsed by, or connected to the Hundertwasser Foundation or any official Hundertwasser entity. All design choices are original interpretations inspired by publicly known aspects of Hundertwasser's artistic style and philosophy.
+
+Hundertwasser's name and artistic legacy are referenced here solely for purposes of artistic tribute and design inspiration.
+
+## License
+
+GNU General Public License v2 or later - see LICENSE for details.

--- a/wp-themes/hundertwasser/parts/footer.html
+++ b/wp-themes/hundertwasser/parts/footer.html
@@ -1,0 +1,19 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","right":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"backgroundColor":"forest-green","textColor":"cream","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-cream-color has-forest-green-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"center"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+		<p class="has-text-align-center has-small-font-size">Designed with love for nature, color, and the irregular beauty of life.</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"center"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
+		<p class="has-text-align-center has-small-font-size">Powered by <a href="https://wordpress.org">WordPress</a></p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/hundertwasser/parts/header.html
+++ b/wp-themes/hundertwasser/parts/header.html
@@ -1,0 +1,10 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","right":"var:preset|spacing|30","left":"var:preset|spacing|30"}}},"backgroundColor":"cobalt-blue","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-cobalt-blue-background-color has-background" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
+	<div class="wp-block-group">
+		<!-- wp:site-title {"isLink":true} /-->
+		<!-- wp:navigation {"overlayBackgroundColor":"cobalt-blue","overlayTextColor":"cream","layout":{"type":"flex","justifyContent":"right"}} /-->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/hundertwasser/patterns/hero.php
+++ b/wp-themes/hundertwasser/patterns/hero.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Title: Hero
+ * Slug: hundertwasser/hero
+ * Categories: featured
+ * Description: A colorful hero section inspired by Hundertwasser's vibrant artistic vision
+ */
+?>
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","right":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"backgroundColor":"cobalt-blue","textColor":"cream","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-cream-color has-cobalt-blue-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+	<!-- wp:heading {"textAlign":"center","level":1,"textColor":"sunflower-yellow","fontSize":"xx-large"} -->
+	<h1 class="wp-block-heading has-text-align-center has-sunflower-yellow-color has-text-color has-xx-large-font-size"><?php echo esc_html__( 'The Straight Line Is Godless', 'hundertwasser' ); ?></h1>
+	<!-- /wp:heading -->
+
+	<!-- wp:paragraph {"align":"center","textColor":"cream","fontSize":"large"} -->
+	<p class="has-text-align-center has-cream-color has-text-color has-large-font-size"><?php echo esc_html__( 'Inspired by the art and architecture of Friedensreich Hundertwasser, this space celebrates organic forms, vivid color, and harmony with nature.', 'hundertwasser' ); ?></p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:spacer {"height":"24px"} -->
+	<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+
+	<!-- wp:columns {"align":"wide"} -->
+	<div class="wp-block-columns alignwide">
+		<!-- wp:column {"style":{"border":{"radius":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"backgroundColor":"bright-red"} -->
+		<div class="wp-block-column has-bright-red-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+			<!-- wp:heading {"textAlign":"center","level":3,"textColor":"cream"} -->
+			<h3 class="wp-block-heading has-text-align-center has-cream-color has-text-color"><?php echo esc_html__( 'Color', 'hundertwasser' ); ?></h3>
+			<!-- /wp:heading -->
+
+			<!-- wp:paragraph {"align":"center","textColor":"cream"} -->
+			<p class="has-text-align-center has-cream-color has-text-color"><?php echo esc_html__( 'Bold, joyful palettes drawn from nature and imagination.', 'hundertwasser' ); ?></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"style":{"border":{"radius":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"backgroundColor":"forest-green"} -->
+		<div class="wp-block-column has-forest-green-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+			<!-- wp:heading {"textAlign":"center","level":3,"textColor":"cream"} -->
+			<h3 class="wp-block-heading has-text-align-center has-cream-color has-text-color"><?php echo esc_html__( 'Nature', 'hundertwasser' ); ?></h3>
+			<!-- /wp:heading -->
+
+			<!-- wp:paragraph {"align":"center","textColor":"cream"} -->
+			<p class="has-text-align-center has-cream-color has-text-color"><?php echo esc_html__( 'Trees on rooftops, spirals in the soil, life growing everywhere.', 'hundertwasser' ); ?></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"style":{"border":{"radius":"16px"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"backgroundColor":"deep-purple"} -->
+		<div class="wp-block-column has-deep-purple-background-color has-background" style="border-radius:16px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+			<!-- wp:heading {"textAlign":"center","level":3,"textColor":"sunflower-yellow"} -->
+			<h3 class="wp-block-heading has-text-align-center has-sunflower-yellow-color has-text-color"><?php echo esc_html__( 'Organic Form', 'hundertwasser' ); ?></h3>
+			<!-- /wp:heading -->
+
+			<!-- wp:paragraph {"align":"center","textColor":"cream"} -->
+			<p class="has-text-align-center has-cream-color has-text-color"><?php echo esc_html__( 'No straight lines, only the flowing curves of the living world.', 'hundertwasser' ); ?></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+
+	<!-- wp:spacer {"height":"24px"} -->
+	<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+
+	<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+	<div class="wp-block-buttons">
+		<!-- wp:button {"backgroundColor":"sunflower-yellow","textColor":"cobalt-blue","style":{"border":{"radius":"24px"}},"fontSize":"medium"} -->
+		<div class="wp-block-button has-custom-font-size has-medium-font-size"><a class="wp-block-button__link has-cobalt-blue-color has-sunflower-yellow-background-color has-text-color has-background wp-element-button" style="border-radius:24px"><?php echo esc_html__( 'Explore the Beauty', 'hundertwasser' ); ?></a></div>
+		<!-- /wp:button -->
+	</div>
+	<!-- /wp:buttons -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/hundertwasser/style.css
+++ b/wp-themes/hundertwasser/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Hundertwasser
+Theme URI: #
+Author: Artist Themes Collection
+Author URI: #
+Description: A WordPress block theme inspired by the vibrant, irregular, nature-loving art and architecture of Friedensreich Hundertwasser. Features bold organic colors, rejection of straight lines in spirit, and whimsical patterns echoing the Hundertwasserhaus.
+Version: 1.0.0
+Requires at least: 6.4
+Tested up to: 6.7
+Requires PHP: 7.4
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: hundertwasser
+Tags: block-patterns, full-site-editing, wide-blocks, custom-colors, custom-fonts
+*/

--- a/wp-themes/hundertwasser/styles/spiral.json
+++ b/wp-themes/hundertwasser/styles/spiral.json
@@ -1,0 +1,158 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"title": "Spiral",
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "bright-red",
+					"color": "#A0522D",
+					"name": "Sienna"
+				},
+				{
+					"slug": "cobalt-blue",
+					"color": "#2F4F4F",
+					"name": "Dark Slate"
+				},
+				{
+					"slug": "sunflower-yellow",
+					"color": "#DAA520",
+					"name": "Goldenrod"
+				},
+				{
+					"slug": "forest-green",
+					"color": "#556B2F",
+					"name": "Olive Green"
+				},
+				{
+					"slug": "deep-purple",
+					"color": "#4A3728",
+					"name": "Dark Earth"
+				},
+				{
+					"slug": "warm-orange",
+					"color": "#CD853F",
+					"name": "Peru"
+				},
+				{
+					"slug": "earth-brown",
+					"color": "#6B4423",
+					"name": "Russet"
+				},
+				{
+					"slug": "cream",
+					"color": "#F5F0E1",
+					"name": "Parchment"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "'Fredoka', sans-serif",
+					"slug": "fredoka",
+					"name": "Fredoka",
+					"fontFace": [
+						{
+							"fontFamily": "Fredoka",
+							"fontWeight": "400 700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/fredoka/v14/X7nP4b87HvSqjb_WIi2yDCRwoQ_k7367.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "'Lora', serif",
+					"slug": "lora",
+					"name": "Lora",
+					"fontFace": [
+						{
+							"fontFamily": "Lora",
+							"fontWeight": "400 700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/lora/v35/0QI6MX1D_JOuGQbT0gvTJPa787weuyJGmKxemMeZ.woff2"
+							]
+						},
+						{
+							"fontFamily": "Lora",
+							"fontWeight": "400 700",
+							"fontStyle": "italic",
+							"src": [
+								"https://fonts.gstatic.com/s/lora/v35/0QI8MX1D_JOuMw_hLdO6T2wV9KnW-MoFkqh8ndeZzU.woff2"
+							]
+						}
+					]
+				}
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--cream)",
+			"text": "var(--wp--preset--color--cobalt-blue)"
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--lora)",
+			"lineHeight": "1.75"
+		},
+		"elements": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--fredoka)",
+					"fontWeight": "700"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--deep-purple)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--warm-orange)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--bright-red)"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--forest-green)",
+					"text": "var(--wp--preset--color--cream)"
+				},
+				"border": {
+					"radius": "8px"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--deep-purple)",
+						"text": "var(--wp--preset--color--sunflower-yellow)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/site-title": {
+				"color": {
+					"text": "var(--wp--preset--color--sunflower-yellow)"
+				}
+			},
+			"core/quote": {
+				"border": {
+					"left": {
+						"color": "var(--wp--preset--color--forest-green)",
+						"width": "4px",
+						"style": "solid"
+					}
+				},
+				"color": {
+					"text": "var(--wp--preset--color--earth-brown)"
+				}
+			}
+		}
+	}
+}

--- a/wp-themes/hundertwasser/templates/index.html
+++ b/wp-themes/hundertwasser/templates/index.html
@@ -1,0 +1,33 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+	<div class="wp-block-query">
+		<!-- wp:post-template -->
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+				<!-- wp:post-title {"isLink":true} /-->
+				<!-- wp:post-date /-->
+				<!-- wp:post-excerpt {"moreText":"Continue reading"} /-->
+			</div>
+			<!-- /wp:group -->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+			<!-- wp:paragraph -->
+			<p>No posts were found.</p>
+			<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
+	</div>
+	<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/hundertwasser/templates/single.html
+++ b/wp-themes/hundertwasser/templates/single.html
@@ -1,0 +1,66 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
+		<!-- wp:post-title {"level":1} /-->
+
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"},"style":{"spacing":{"blockGap":"16px"}}} -->
+		<div class="wp-block-group">
+			<!-- wp:post-date /-->
+			<!-- wp:post-author-name /-->
+			<!-- wp:post-terms {"term":"category"} /-->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:post-featured-image {"align":"wide"} /-->
+
+		<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+
+		<!-- wp:separator {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"backgroundColor":"warm-orange"} -->
+		<hr class="wp-block-separator has-text-color has-warm-orange-color has-alpha-channel-opacity has-warm-orange-background-color has-background" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40)"/>
+		<!-- /wp:separator -->
+
+		<!-- wp:post-terms {"term":"tag","separator":" | "} /-->
+
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+		<div class="wp-block-group">
+			<!-- wp:post-navigation-link {"type":"previous","label":"Previous Post"} /-->
+			<!-- wp:post-navigation-link {"label":"Next Post"} /-->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:comments -->
+		<div class="wp-block-comments">
+			<!-- wp:comments-title /-->
+			<!-- wp:comment-template -->
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
+				<div class="wp-block-group">
+					<!-- wp:avatar {"size":40} /-->
+					<!-- wp:group -->
+					<div class="wp-block-group">
+						<!-- wp:comment-author-name /-->
+						<!-- wp:comment-date /-->
+						<!-- wp:comment-content /-->
+						<!-- wp:comment-reply-link /-->
+						<!-- wp:comment-edit-link /-->
+					</div>
+					<!-- /wp:group -->
+				</div>
+				<!-- /wp:group -->
+			<!-- /wp:comment-template -->
+			<!-- wp:comments-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+				<!-- wp:comments-pagination-previous /-->
+				<!-- wp:comments-pagination-numbers /-->
+				<!-- wp:comments-pagination-next /-->
+			<!-- /wp:comments-pagination -->
+			<!-- wp:post-comments-form /-->
+		</div>
+		<!-- /wp:comments -->
+	</div>
+	<!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/hundertwasser/theme.json
+++ b/wp-themes/hundertwasser/theme.json
@@ -1,0 +1,254 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"settings": {
+		"appearanceTools": true,
+		"color": {
+			"palette": [
+				{
+					"slug": "bright-red",
+					"color": "#E63946",
+					"name": "Bright Red"
+				},
+				{
+					"slug": "cobalt-blue",
+					"color": "#1D3557",
+					"name": "Cobalt Blue"
+				},
+				{
+					"slug": "sunflower-yellow",
+					"color": "#F4D35E",
+					"name": "Sunflower Yellow"
+				},
+				{
+					"slug": "forest-green",
+					"color": "#2D6A4F",
+					"name": "Forest Green"
+				},
+				{
+					"slug": "deep-purple",
+					"color": "#5C2D91",
+					"name": "Deep Purple"
+				},
+				{
+					"slug": "warm-orange",
+					"color": "#E76F51",
+					"name": "Warm Orange"
+				},
+				{
+					"slug": "earth-brown",
+					"color": "#8B5E3C",
+					"name": "Earth Brown"
+				},
+				{
+					"slug": "cream",
+					"color": "#FFF8E7",
+					"name": "Cream"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "'Fredoka', sans-serif",
+					"slug": "fredoka",
+					"name": "Fredoka",
+					"fontFace": [
+						{
+							"fontFamily": "Fredoka",
+							"fontWeight": "400 700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/fredoka/v14/X7nP4b87HvSqjb_WIi2yDCRwoQ_k7367.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "'Nunito', sans-serif",
+					"slug": "nunito",
+					"name": "Nunito",
+					"fontFace": [
+						{
+							"fontFamily": "Nunito",
+							"fontWeight": "300 700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/nunito/v26/XRXI3I6Li01BKofiOc5wtlZ2di8HDIkhdTQ3j6zbXWjgeg.woff2"
+							]
+						},
+						{
+							"fontFamily": "Nunito",
+							"fontWeight": "300 700",
+							"fontStyle": "italic",
+							"src": [
+								"https://fonts.gstatic.com/s/nunito/v26/XRXK3I6Li01BKofIMPyPbj8d7IEAGXNiLXA3iqzbXWjSRDc.woff2"
+							]
+						}
+					]
+				}
+			],
+			"fontSizes": [
+				{
+					"slug": "small",
+					"size": "0.875rem",
+					"name": "Small"
+				},
+				{
+					"slug": "medium",
+					"size": "1rem",
+					"name": "Medium"
+				},
+				{
+					"slug": "large",
+					"size": "1.5rem",
+					"name": "Large"
+				},
+				{
+					"slug": "x-large",
+					"size": "2.25rem",
+					"name": "Extra Large"
+				},
+				{
+					"slug": "xx-large",
+					"size": "3.5rem",
+					"name": "Huge"
+				}
+			]
+		},
+		"layout": {
+			"contentSize": "720px",
+			"wideSize": "1100px"
+		},
+		"spacing": {
+			"units": [
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw",
+				"%"
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--cream)",
+			"text": "var(--wp--preset--color--cobalt-blue)"
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--nunito)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"lineHeight": "1.7"
+		},
+		"elements": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--fredoka)",
+					"fontWeight": "700",
+					"lineHeight": "1.2"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--deep-purple)"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--xx-large)"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--bright-red)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--warm-orange)"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--bright-red)",
+					"text": "var(--wp--preset--color--cream)"
+				},
+				"border": {
+					"radius": "24px"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--deep-purple)",
+						"text": "var(--wp--preset--color--sunflower-yellow)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--fredoka)",
+					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontWeight": "700"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--sunflower-yellow)"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--nunito)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "600"
+				}
+			},
+			"core/post-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--fredoka)",
+					"fontWeight": "700"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--cobalt-blue)"
+				}
+			},
+			"core/quote": {
+				"border": {
+					"left": {
+						"color": "var(--wp--preset--color--warm-orange)",
+						"width": "4px",
+						"style": "solid"
+					}
+				},
+				"color": {
+					"text": "var(--wp--preset--color--earth-brown)"
+				},
+				"typography": {
+					"fontStyle": "italic"
+				}
+			}
+		}
+	},
+	"templateParts": [
+		{
+			"name": "header",
+			"title": "Header",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"title": "Footer",
+			"area": "footer"
+		}
+	],
+	"customTemplates": [],
+	"patterns": []
+}

--- a/wp-themes/kusama/README.md
+++ b/wp-themes/kusama/README.md
@@ -1,0 +1,53 @@
+# Kusama - A WordPress Block Theme
+
+A WordPress block theme inspired by the immersive installation art of Yayoi Kusama.
+
+## About
+
+This theme channels the visual language of Yayoi Kusama's iconic infinity rooms, polka-dot installations, and pumpkin sculptures into a bold, high-contrast WordPress block theme. It is designed for creatives, artists, and anyone who wants their site to feel like stepping into an art installation.
+
+## Design Notes
+
+- **Color palette** draws from Kusama's signature motifs: polka-dot red, pumpkin yellow, infinity-room black, mirror silver, hot pink, and cosmic purple.
+- **Typography** pairs Archivo Black (headings) with Work Sans (body) for a bold, contemporary feel that echoes the artist's unflinching visual confidence.
+- **Layout** uses generous spacing and full-width cover sections to create a sense of immersion.
+- **Style variation** ("Infinity") shifts the palette toward darker, more psychedelic tones -- purples and golds on deep midnight backgrounds -- evoking the disorienting beauty of Kusama's mirrored rooms.
+
+## Features
+
+- Full Site Editing support with customizable templates and template parts
+- Hero pattern inspired by Kusama's infinity installations
+- "Infinity" style variation with a darker, psychedelic palette
+- High-contrast, accessible color combinations
+- Responsive grid-based blog index
+
+## Structure
+
+```
+kusama/
+  style.css          - Theme metadata
+  theme.json         - Global settings and styles
+  templates/
+    index.html       - Blog index template
+    single.html      - Single post template
+  parts/
+    header.html      - Site header with title and navigation
+    footer.html      - Site footer with credits
+  patterns/
+    hero.php         - Immersive hero section pattern
+  styles/
+    infinity.json    - Dark psychedelic style variation
+```
+
+## Requirements
+
+- WordPress 6.4 or later
+- PHP 7.4 or later
+
+## Homage Disclaimer
+
+This theme is an artistic homage to the work of Yayoi Kusama and is not affiliated with, endorsed by, or connected to Yayoi Kusama, her studio, or any associated entities. All design choices are original interpretations inspired by the public visual language of Kusama's art. No copyrighted artwork is reproduced in this theme.
+
+## License
+
+GNU General Public License v2 or later. See [LICENSE](http://www.gnu.org/licenses/gpl-2.0.html).

--- a/wp-themes/kusama/parts/footer.html
+++ b/wp-themes/kusama/parts/footer.html
@@ -1,0 +1,11 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"color":{"background":"var:preset|color|infinity-black"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-background" style="background-color:var(--wp--preset--color--infinity-black);padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30)">
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"center"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|polka-red"}}}},"textColor":"mirror-silver","fontSize":"small"} -->
+		<p class="has-text-align-center has-mirror-silver-color has-text-color has-link-color has-small-font-size">&copy; 2026 &mdash; Powered by <a href="https://wordpress.org">WordPress</a>. A theme inspired by the infinite vision of Yayoi Kusama.</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/kusama/parts/header.html
+++ b/wp-themes/kusama/parts/header.html
@@ -1,0 +1,10 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"color":{"background":"var:preset|color|infinity-black"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-background" style="background-color:var(--wp--preset--color--infinity-black);padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30)">
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
+	<div class="wp-block-group">
+		<!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"var:preset|color|polka-red"}}}},"textColor":"polka-red"} /-->
+		<!-- wp:navigation {"overlayTextColor":"void-white","overlayBackgroundColor":"infinity-black","style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.08em","fontWeight":"600"},"elements":{"link":{"color":{"text":"var:preset|color|mirror-silver"},":hover":{"color":{"text":"var:preset|color|pumpkin-yellow"}}}}},"fontSize":"small"} /-->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/kusama/patterns/hero.php
+++ b/wp-themes/kusama/patterns/hero.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Title: Hero
+ * Slug: kusama/hero
+ * Categories: featured
+ * Description: An immersive hero section inspired by Kusama's infinity installations
+ */
+?>
+<!-- wp:cover {"overlayColor":"infinity-black","minHeight":85,"minHeightUnit":"vh","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}}} -->
+<div class="wp-block-cover alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);min-height:85vh">
+	<span aria-hidden="true" class="wp-block-cover__background has-infinity-black-background-color has-background-dim-100 has-background-dim"></span>
+	<div class="wp-block-cover__inner-container">
+		<!-- wp:group {"layout":{"type":"constrained","contentSize":"800px"}} -->
+		<div class="wp-block-group">
+			<!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"letterSpacing":"0.05em"}},"textColor":"polka-red","fontSize":"xx-large"} -->
+			<h1 class="wp-block-heading has-text-align-center has-polka-red-color has-text-color has-xx-large-font-size" style="letter-spacing:0.05em"><?php echo esc_html__( 'Infinity Begins Here', 'kusama' ); ?></h1>
+			<!-- /wp:heading -->
+
+			<!-- wp:paragraph {"align":"center","textColor":"mirror-silver","fontSize":"large"} -->
+			<p class="has-text-align-center has-mirror-silver-color has-text-color has-large-font-size"><?php echo esc_html__( 'Lose yourself in a world of endless dots, boundless color, and infinite possibility. Every surface is a canvas. Every moment, a reflection.', 'kusama' ); ?></p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:spacer {"height":"2rem"} -->
+			<div style="height:2rem" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+
+			<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"blockGap":"1rem"}}} -->
+			<div class="wp-block-buttons">
+				<!-- wp:button {"backgroundColor":"polka-red","textColor":"void-white","style":{"border":{"radius":"50px"},"spacing":{"padding":{"top":"0.9rem","bottom":"0.9rem","left":"2.5rem","right":"2.5rem"}}}} -->
+				<div class="wp-block-button"><a class="wp-block-button__link has-void-white-color has-polka-red-background-color has-text-color has-background wp-element-button" style="border-radius:50px;padding-top:0.9rem;padding-right:2.5rem;padding-bottom:0.9rem;padding-left:2.5rem"><?php echo esc_html__( 'Enter the Room', 'kusama' ); ?></a></div>
+				<!-- /wp:button -->
+
+				<!-- wp:button {"backgroundColor":"pumpkin-yellow","textColor":"infinity-black","style":{"border":{"radius":"50px"},"spacing":{"padding":{"top":"0.9rem","bottom":"0.9rem","left":"2.5rem","right":"2.5rem"}}}} -->
+				<div class="wp-block-button"><a class="wp-block-button__link has-infinity-black-color has-pumpkin-yellow-background-color has-text-color has-background wp-element-button" style="border-radius:50px;padding-top:0.9rem;padding-right:2.5rem;padding-bottom:0.9rem;padding-left:2.5rem"><?php echo esc_html__( 'Explore the Dots', 'kusama' ); ?></a></div>
+				<!-- /wp:button -->
+			</div>
+			<!-- /wp:buttons -->
+
+			<!-- wp:spacer {"height":"3rem"} -->
+			<div style="height:3rem" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+
+			<!-- wp:separator {"backgroundColor":"polka-red","className":"is-style-dots"} -->
+			<hr class="wp-block-separator has-text-color has-polka-red-color has-alpha-channel-opacity has-polka-red-background-color has-background is-style-dots"/>
+			<!-- /wp:separator -->
+
+			<!-- wp:spacer {"height":"2rem"} -->
+			<div style="height:2rem" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+
+			<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"2rem"}}}} -->
+			<div class="wp-block-columns">
+				<!-- wp:column -->
+				<div class="wp-block-column">
+					<!-- wp:heading {"textAlign":"center","level":3,"textColor":"pumpkin-yellow"} -->
+					<h3 class="wp-block-heading has-text-align-center has-pumpkin-yellow-color has-text-color"><?php echo esc_html__( 'Obsession', 'kusama' ); ?></h3>
+					<!-- /wp:heading -->
+
+					<!-- wp:paragraph {"align":"center","textColor":"mirror-silver","fontSize":"small"} -->
+					<p class="has-text-align-center has-mirror-silver-color has-text-color has-small-font-size"><?php echo esc_html__( 'Repetition as meditation. The dot is the universe, endlessly multiplied.', 'kusama' ); ?></p>
+					<!-- /wp:paragraph -->
+				</div>
+				<!-- /wp:column -->
+
+				<!-- wp:column -->
+				<div class="wp-block-column">
+					<!-- wp:heading {"textAlign":"center","level":3,"textColor":"hot-pink"} -->
+					<h3 class="wp-block-heading has-text-align-center has-hot-pink-color has-text-color"><?php echo esc_html__( 'Infinity', 'kusama' ); ?></h3>
+					<!-- /wp:heading -->
+
+					<!-- wp:paragraph {"align":"center","textColor":"mirror-silver","fontSize":"small"} -->
+					<p class="has-text-align-center has-mirror-silver-color has-text-color has-small-font-size"><?php echo esc_html__( 'Step inside and dissolve the boundary between self and cosmos.', 'kusama' ); ?></p>
+					<!-- /wp:paragraph -->
+				</div>
+				<!-- /wp:column -->
+
+				<!-- wp:column -->
+				<div class="wp-block-column">
+					<!-- wp:heading {"textAlign":"center","level":3,"textColor":"polka-red"} -->
+					<h3 class="wp-block-heading has-text-align-center has-polka-red-color has-text-color"><?php echo esc_html__( 'Immersion', 'kusama' ); ?></h3>
+					<!-- /wp:heading -->
+
+					<!-- wp:paragraph {"align":"center","textColor":"mirror-silver","fontSize":"small"} -->
+					<p class="has-text-align-center has-mirror-silver-color has-text-color has-small-font-size"><?php echo esc_html__( 'Art is not what you see, but what you feel when surrounded by it.', 'kusama' ); ?></p>
+					<!-- /wp:paragraph -->
+				</div>
+				<!-- /wp:column -->
+			</div>
+			<!-- /wp:columns -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+</div>
+<!-- /wp:cover -->

--- a/wp-themes/kusama/style.css
+++ b/wp-themes/kusama/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Kusama
+Theme URI: #
+Author: Artist Themes Collection
+Author URI: #
+Description: A WordPress block theme inspired by Yayoi Kusama's mesmerizing infinity rooms and polka-dot obsession. Features bold contrasting colors, repetitive patterns in spirit, and an immersive visual experience that channels the artist's iconic installations.
+Version: 1.0.0
+Requires at least: 6.4
+Tested up to: 6.7
+Requires PHP: 7.4
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: kusama
+Tags: block-patterns, full-site-editing, wide-blocks, custom-colors, custom-fonts
+*/

--- a/wp-themes/kusama/styles/infinity.json
+++ b/wp-themes/kusama/styles/infinity.json
@@ -1,0 +1,95 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"title": "Infinity",
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "polka-red",
+					"color": "#CC0029",
+					"name": "Deep Red"
+				},
+				{
+					"slug": "pumpkin-yellow",
+					"color": "#FFD700",
+					"name": "Gold Yellow"
+				},
+				{
+					"slug": "infinity-black",
+					"color": "#000000",
+					"name": "Absolute Black"
+				},
+				{
+					"slug": "mirror-silver",
+					"color": "#1A1A2E",
+					"name": "Night Blue"
+				},
+				{
+					"slug": "hot-pink",
+					"color": "#E040FB",
+					"name": "Neon Pink"
+				},
+				{
+					"slug": "void-white",
+					"color": "#0D0D0D",
+					"name": "Void Black"
+				},
+				{
+					"slug": "cosmic-purple",
+					"color": "#7B1FA2",
+					"name": "Psychedelic Purple"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "'Archivo Black', sans-serif",
+					"slug": "archivo-black",
+					"name": "Archivo Black"
+				},
+				{
+					"fontFamily": "'Work Sans', sans-serif",
+					"slug": "work-sans",
+					"name": "Work Sans"
+				}
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--infinity-black)",
+			"text": "var(--wp--preset--color--pumpkin-yellow)"
+		},
+		"elements": {
+			"heading": {
+				"color": {
+					"text": "var(--wp--preset--color--hot-pink)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--pumpkin-yellow)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--hot-pink)"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--cosmic-purple)",
+					"text": "var(--wp--preset--color--pumpkin-yellow)"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--hot-pink)",
+						"text": "var(--wp--preset--color--infinity-black)"
+					}
+				}
+			}
+		}
+	}
+}

--- a/wp-themes/kusama/templates/index.html
+++ b/wp-themes/kusama/templates/index.html
@@ -1,0 +1,39 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:query-title {"type":"archive","textAlign":"center"} /-->
+
+	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","inherit":true}} -->
+	<div class="wp-block-query">
+		<!-- wp:post-template {"layout":{"type":"grid","columnCount":2}} -->
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+				<!-- wp:post-featured-image {"isLink":true,"aspectRatio":"16/9"} /-->
+
+				<!-- wp:post-title {"isLink":true,"fontSize":"large"} /-->
+
+				<!-- wp:post-date {"fontSize":"small"} /-->
+
+				<!-- wp:post-excerpt {"moreText":"Continue reading","excerptLength":25} /-->
+			</div>
+			<!-- /wp:group -->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center">No posts found. The infinity room is empty for now.</p>
+			<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
+	</div>
+	<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/kusama/templates/single.html
+++ b/wp-themes/kusama/templates/single.html
@@ -1,0 +1,66 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--30)">
+		<!-- wp:post-title {"textAlign":"center"} /-->
+
+		<!-- wp:group {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"blockGap":"1rem"}}} -->
+		<div class="wp-block-group">
+			<!-- wp:post-date {"fontSize":"small"} /-->
+			<!-- wp:post-terms {"term":"category","fontSize":"small"} /-->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:post-featured-image {"align":"wide"} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+
+	<!-- wp:separator {"backgroundColor":"polka-red","className":"is-style-wide"} -->
+	<hr class="wp-block-separator has-text-color has-polka-red-color has-alpha-channel-opacity has-polka-red-background-color has-background is-style-wide"/>
+	<!-- /wp:separator -->
+
+	<!-- wp:group {"layout":{"type":"constrained"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
+	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+		<!-- wp:post-terms {"term":"tag","separator":" / ","fontSize":"small"} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"layout":{"type":"constrained"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|50"}}}} -->
+	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--50)">
+		<!-- wp:comments -->
+		<div class="wp-block-comments">
+			<!-- wp:comments-title /-->
+			<!-- wp:comment-template -->
+				<!-- wp:group {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
+				<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--30)">
+					<!-- wp:avatar {"size":48} /-->
+					<!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
+					<div class="wp-block-group">
+						<!-- wp:comment-author-name /-->
+						<!-- wp:comment-date {"fontSize":"small"} /-->
+						<!-- wp:comment-content /-->
+						<!-- wp:comment-reply-link {"fontSize":"small"} /-->
+						<!-- wp:comment-edit-link {"fontSize":"small"} /-->
+					</div>
+					<!-- /wp:group -->
+				</div>
+				<!-- /wp:group -->
+			<!-- /wp:comment-template -->
+			<!-- wp:comments-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+				<!-- wp:comments-pagination-previous /-->
+				<!-- wp:comments-pagination-numbers /-->
+				<!-- wp:comments-pagination-next /-->
+			<!-- /wp:comments-pagination -->
+			<!-- wp:post-comments-form /-->
+		</div>
+		<!-- /wp:comments -->
+	</div>
+	<!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/kusama/theme.json
+++ b/wp-themes/kusama/theme.json
@@ -1,0 +1,261 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"settings": {
+		"appearanceTools": true,
+		"color": {
+			"palette": [
+				{
+					"slug": "polka-red",
+					"color": "#FF0033",
+					"name": "Polka Red"
+				},
+				{
+					"slug": "pumpkin-yellow",
+					"color": "#FFB800",
+					"name": "Pumpkin Yellow"
+				},
+				{
+					"slug": "infinity-black",
+					"color": "#0D0D0D",
+					"name": "Infinity Black"
+				},
+				{
+					"slug": "mirror-silver",
+					"color": "#E8E8E8",
+					"name": "Mirror Silver"
+				},
+				{
+					"slug": "hot-pink",
+					"color": "#FF69B4",
+					"name": "Hot Pink"
+				},
+				{
+					"slug": "void-white",
+					"color": "#FFFFFF",
+					"name": "Void White"
+				},
+				{
+					"slug": "cosmic-purple",
+					"color": "#4B0082",
+					"name": "Cosmic Purple"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "'Archivo Black', sans-serif",
+					"slug": "archivo-black",
+					"name": "Archivo Black",
+					"fontFace": [
+						{
+							"fontFamily": "Archivo Black",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/archivoblack/v21/HTxqL89-EiGe0NM.wgNql4ux5Q.css"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "'Work Sans', sans-serif",
+					"slug": "work-sans",
+					"name": "Work Sans",
+					"fontFace": [
+						{
+							"fontFamily": "Work Sans",
+							"fontWeight": "300 700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/worksans/v19/QGY_z_wNahGAdqQ43RhVcIgY.woff2"
+							]
+						},
+						{
+							"fontFamily": "Work Sans",
+							"fontWeight": "300 700",
+							"fontStyle": "italic",
+							"src": [
+								"https://fonts.gstatic.com/s/worksans/v19/QGY2z_wNahGAdqQ43Rh_eZDkv_RS.woff2"
+							]
+						}
+					]
+				}
+			],
+			"fontSizes": [
+				{
+					"slug": "small",
+					"size": "0.875rem",
+					"name": "Small"
+				},
+				{
+					"slug": "medium",
+					"size": "1.125rem",
+					"name": "Medium"
+				},
+				{
+					"slug": "large",
+					"size": "1.75rem",
+					"name": "Large"
+				},
+				{
+					"slug": "x-large",
+					"size": "2.5rem",
+					"name": "Extra Large"
+				},
+				{
+					"slug": "xx-large",
+					"size": "4rem",
+					"name": "Huge"
+				}
+			]
+		},
+		"layout": {
+			"contentSize": "720px",
+			"wideSize": "1200px"
+		},
+		"spacing": {
+			"units": [
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw",
+				"%"
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--void-white)",
+			"text": "var(--wp--preset--color--infinity-black)"
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--work-sans)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"lineHeight": "1.7"
+		},
+		"spacing": {
+			"blockGap": "1.5rem"
+		},
+		"elements": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--archivo-black)",
+					"fontWeight": "400",
+					"lineHeight": "1.15",
+					"textTransform": "uppercase"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--infinity-black)"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--xx-large)"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--polka-red)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--hot-pink)"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--polka-red)",
+					"text": "var(--wp--preset--color--void-white)"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--archivo-black)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"textTransform": "uppercase",
+					"letterSpacing": "0.1em"
+				},
+				"border": {
+					"radius": "50px"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--infinity-black)",
+						"text": "var(--wp--preset--color--pumpkin-yellow)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/post-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--xx-large)"
+				}
+			},
+			"core/query-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)"
+				}
+			},
+			"core/site-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--archivo-black)",
+					"fontSize": "var(--wp--preset--font-size--large)",
+					"textTransform": "uppercase",
+					"letterSpacing": "0.05em"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--polka-red)"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--work-sans)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "600",
+					"textTransform": "uppercase",
+					"letterSpacing": "0.08em"
+				}
+			},
+			"core/quote": {
+				"border": {
+					"left": {
+						"color": "var(--wp--preset--color--polka-red)",
+						"width": "4px",
+						"style": "solid"
+					}
+				},
+				"typography": {
+					"fontStyle": "italic"
+				}
+			}
+		}
+	},
+	"templateParts": [
+		{
+			"name": "header",
+			"title": "Header",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"title": "Footer",
+			"area": "footer"
+		}
+	],
+	"patterns": [
+		"kusama/hero"
+	]
+}

--- a/wp-themes/rafael/README.md
+++ b/wp-themes/rafael/README.md
@@ -1,0 +1,42 @@
+# Rafael - A Renaissance-Inspired WordPress Block Theme
+
+## Artist Attribution
+
+This theme draws inspiration from the work of **Raffaello Sanzio da Urbino** (1483-1520), known simply as Raphael, one of the three great masters of the Italian High Renaissance alongside Leonardo da Vinci and Michelangelo.
+
+Raphael is celebrated for his clarity of form, ease of composition, and visual achievement of the Neoplatonic ideal of human grandeur. His most famous works include *The School of Athens*, *The Sistine Madonna*, and the *Transfiguration*.
+
+## Design Notes
+
+### Color Palette
+The default palette reflects the rich, warm tones found throughout Raphael's paintings:
+
+- **Rich Gold (#C5A55A)** -- Inspired by the gilded frames and golden light in Raphael's compositions
+- **Deep Burgundy (#6B1D2A)** -- Drawn from the luxurious drapery in his papal portraits
+- **Ultramarine Blue (#1B3A8C)** -- The precious lapis lazuli pigment used in the Madonna's robes
+- **Ivory (#FFFFF0)** -- Reflecting the luminous skin tones and marble surfaces of the Renaissance
+- **Warm Sienna (#A0522D)** -- The earthy warmth of Umbrian landscapes and architectural elements
+- **Olive Green (#556B2F)** -- The verdant backgrounds of his pastoral compositions
+
+### Typography
+- **Cormorant Garamond** for headings: A refined serif typeface that echoes the classical inscriptions and letterforms of the Renaissance
+- **Lora** for body text: A well-balanced contemporary serif that maintains readability while honoring classical proportions
+
+### Vatican Style Variation
+The included "Vatican" style variation offers a more muted, fresco-like palette reminiscent of Raphael's Stanze di Raffaello in the Vatican Palace, where time and atmosphere have softened the original pigments into a gentle patina.
+
+## Theme Structure
+
+- `theme.json` -- Global settings and styles
+- `templates/` -- Block templates for index and single post views
+- `parts/` -- Reusable template parts (header, footer)
+- `patterns/` -- Block patterns including a Renaissance-inspired hero section
+- `styles/` -- Style variations (Vatican)
+
+## Homage Disclaimer
+
+This WordPress theme is an artistic homage to the work of Raphael and the Italian Renaissance. It is not affiliated with, endorsed by, or connected to any museum, estate, or institution associated with Raphael's works. All design choices are original interpretations inspired by the aesthetic principles of Renaissance art. No copyrighted artwork is included in this theme.
+
+## License
+
+GNU General Public License v2 or later. See LICENSE for full text.

--- a/wp-themes/rafael/parts/footer.html
+++ b/wp-themes/rafael/parts/footer.html
@@ -1,0 +1,17 @@
+<!-- wp:group {"tagName":"footer","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}},"color":{"background":"var(--wp--preset--color--deep-burgundy)","text":"var(--wp--preset--color--ivory)"}},"layout":{"type":"constrained"}} -->
+<footer class="wp-block-group has-text-color has-background" style="background-color:var(--wp--preset--color--deep-burgundy);color:var(--wp--preset--color--ivory);padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
+
+	<!-- wp:separator {"style":{"color":{"background":"var(--wp--preset--color--rich-gold)"}},"className":"is-style-wide"} -->
+	<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background is-style-wide" style="background-color:var(--wp--preset--color--rich-gold);color:var(--wp--preset--color--rich-gold)"/>
+	<!-- /wp:separator -->
+
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"center"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph {"style":{"typography":{"fontFamily":"var(--wp--preset--font-family--cormorant-garamond)","fontSize":"var(--wp--preset--font-size--small)"},"elements":{"link":{"color":{"text":"var(--wp--preset--color--rich-gold)"}}}}} -->
+		<p style="font-family:var(--wp--preset--font-family--cormorant-garamond);font-size:var(--wp--preset--font-size--small)">Designed with Renaissance elegance &mdash; Powered by <a href="https://wordpress.org">WordPress</a></p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+
+</footer>
+<!-- /wp:group -->

--- a/wp-themes/rafael/parts/header.html
+++ b/wp-themes/rafael/parts/header.html
@@ -1,0 +1,15 @@
+<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}},"color":{"background":"var(--wp--preset--color--deep-burgundy)","text":"var(--wp--preset--color--ivory)"}},"layout":{"type":"constrained"}} -->
+<header class="wp-block-group has-text-color has-background" style="background-color:var(--wp--preset--color--deep-burgundy);color:var(--wp--preset--color--ivory);padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
+	<div class="wp-block-group">
+
+		<!-- wp:site-title {"style":{"typography":{"fontFamily":"var(--wp--preset--font-family--cormorant-garamond)","fontWeight":"700","textTransform":"uppercase","letterSpacing":"0.05em"},"elements":{"link":{"color":{"text":"var(--wp--preset--color--rich-gold)"}}}}} /-->
+
+		<!-- wp:navigation {"overlayTextColor":"ivory","overlayBackgroundColor":"deep-burgundy","style":{"typography":{"fontFamily":"var(--wp--preset--font-family--cormorant-garamond)","fontWeight":"600","textTransform":"uppercase","letterSpacing":"0.03em"}}} /-->
+
+	</div>
+	<!-- /wp:group -->
+
+</header>
+<!-- /wp:group -->

--- a/wp-themes/rafael/patterns/hero.php
+++ b/wp-themes/rafael/patterns/hero.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Title: Hero
+ * Slug: rafael/hero
+ * Categories: featured
+ * Description: A hero section inspired by Raphael's Renaissance compositions
+ */
+?>
+
+<!-- wp:cover {"dimRatio":70,"overlayColor":"deep-burgundy","minHeight":600,"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-cover alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);min-height:600px">
+	<span aria-hidden="true" class="wp-block-cover__background has-deep-burgundy-background-color has-background-dim-70 has-background-dim"></span>
+	<div class="wp-block-cover__inner-container">
+
+		<!-- wp:group {"layout":{"type":"constrained","contentSize":"720px"}} -->
+		<div class="wp-block-group">
+
+			<!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontFamily":"var(--wp--preset--font-family--cormorant-garamond)","fontSize":"var(--wp--preset--font-size--xx-large)","fontWeight":"700"},"color":{"text":"var(--wp--preset--color--rich-gold)"}}} -->
+			<h1 class="wp-block-heading has-text-align-center has-text-color" style="color:var(--wp--preset--color--rich-gold);font-family:var(--wp--preset--font-family--cormorant-garamond);font-size:var(--wp--preset--font-size--xx-large);font-weight:700"><?php echo esc_html__( 'The School of Athens', 'rafael' ); ?></h1>
+			<!-- /wp:heading -->
+
+			<!-- wp:separator {"style":{"color":{"background":"var(--wp--preset--color--rich-gold)"}},"className":"is-style-wide"} -->
+			<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background is-style-wide" style="background-color:var(--wp--preset--color--rich-gold);color:var(--wp--preset--color--rich-gold)"/>
+			<!-- /wp:separator -->
+
+			<!-- wp:paragraph {"align":"center","style":{"typography":{"fontFamily":"var(--wp--preset--font-family--lora)","fontSize":"var(--wp--preset--font-size--large)","lineHeight":"1.8"},"color":{"text":"var(--wp--preset--color--ivory)"}}} -->
+			<p class="has-text-align-center has-text-color" style="color:var(--wp--preset--color--ivory);font-family:var(--wp--preset--font-family--lora);font-size:var(--wp--preset--font-size--large);line-height:1.8"><?php echo esc_html__( 'Where harmony meets proportion, and the beauty of classical ideals finds new expression in the modern age.', 'rafael' ); ?></p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}}} -->
+			<div class="wp-block-buttons" style="margin-top:var(--wp--preset--spacing--30)">
+				<!-- wp:button {"backgroundColor":"rich-gold","textColor":"deep-burgundy","style":{"typography":{"fontFamily":"var(--wp--preset--font-family--cormorant-garamond)","fontWeight":"700","textTransform":"uppercase","letterSpacing":"0.08em"},"border":{"radius":"2px"}}} -->
+				<div class="wp-block-button"><a class="wp-block-button__link has-deep-burgundy-color has-rich-gold-background-color has-text-color has-background wp-element-button" style="border-radius:2px;font-family:var(--wp--preset--font-family--cormorant-garamond);font-weight:700;text-transform:uppercase;letter-spacing:0.08em"><?php echo esc_html__( 'Explore the Collection', 'rafael' ); ?></a></div>
+				<!-- /wp:button -->
+			</div>
+			<!-- /wp:buttons -->
+
+		</div>
+		<!-- /wp:group -->
+
+	</div>
+</div>
+<!-- /wp:cover -->

--- a/wp-themes/rafael/style.css
+++ b/wp-themes/rafael/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Rafael
+Theme URI: #
+Author: Artist Themes Collection
+Author URI: #
+Description: A WordPress block theme inspired by the harmonious compositions and classical beauty of Renaissance master Raphael. Features warm golden tones, balanced proportions, and elegant typography reminiscent of the Italian Renaissance.
+Version: 1.0.0
+Requires at least: 6.4
+Tested up to: 6.7
+Requires PHP: 7.4
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: rafael
+Tags: block-patterns, full-site-editing, wide-blocks, custom-colors, custom-fonts
+*/

--- a/wp-themes/rafael/styles/vatican.json
+++ b/wp-themes/rafael/styles/vatican.json
@@ -1,0 +1,142 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"title": "Vatican",
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "rich-gold",
+					"color": "#B8A88A",
+					"name": "Aged Gold"
+				},
+				{
+					"slug": "deep-burgundy",
+					"color": "#5C3A3A",
+					"name": "Faded Fresco Red"
+				},
+				{
+					"slug": "ultramarine-blue",
+					"color": "#6A7B8D",
+					"name": "Chapel Blue"
+				},
+				{
+					"slug": "ivory",
+					"color": "#F5F0E8",
+					"name": "Plaster White"
+				},
+				{
+					"slug": "warm-sienna",
+					"color": "#8B7355",
+					"name": "Fresco Ochre"
+				},
+				{
+					"slug": "olive-green",
+					"color": "#7A8B6F",
+					"name": "Patina Green"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "'EB Garamond', Garamond, 'Times New Roman', serif",
+					"slug": "cormorant-garamond",
+					"name": "EB Garamond",
+					"fontFace": [
+						{
+							"fontFamily": "EB Garamond",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/ebgaramond/v27/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-6_RUA4V-e6yHgQ.woff2"
+							]
+						},
+						{
+							"fontFamily": "EB Garamond",
+							"fontWeight": "600",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/ebgaramond/v27/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-2_dUA4V-e6yHgQ.woff2"
+							]
+						},
+						{
+							"fontFamily": "EB Garamond",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/ebgaramond/v27/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-4PdUA4V-e6yHgQ.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "'Crimson Text', 'Times New Roman', serif",
+					"slug": "lora",
+					"name": "Crimson Text",
+					"fontFace": [
+						{
+							"fontFamily": "Crimson Text",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/crimsontext/v19/wlp2gwHKFkZgtmSR3NB0oRJfajhRK_Z_.woff2"
+							]
+						},
+						{
+							"fontFamily": "Crimson Text",
+							"fontWeight": "400",
+							"fontStyle": "italic",
+							"src": [
+								"https://fonts.gstatic.com/s/crimsontext/v19/wlpogwHKFkZgtmSR3NB0oRJfajDODMhRaA.woff2"
+							]
+						},
+						{
+							"fontFamily": "Crimson Text",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/crimsontext/v19/wlppgwHKFkZgtmSR3NB0oRJXsCxGDNNQ9rJPfw.woff2"
+							]
+						}
+					]
+				}
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--ivory)",
+			"text": "#3D3229"
+		},
+		"elements": {
+			"heading": {
+				"color": {
+					"text": "var(--wp--preset--color--deep-burgundy)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--ultramarine-blue)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--warm-sienna)"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--deep-burgundy)",
+					"text": "var(--wp--preset--color--ivory)"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--warm-sienna)",
+						"text": "var(--wp--preset--color--ivory)"
+					}
+				}
+			}
+		}
+	}
+}

--- a/wp-themes/rafael/templates/index.html
+++ b/wp-themes/rafael/templates/index.html
@@ -1,0 +1,55 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+
+	<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","inherit":true}} -->
+	<div class="wp-block-query">
+
+		<!-- wp:post-template {"layout":{"type":"default"}} -->
+
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
+
+				<!-- wp:post-title {"isLink":true} /-->
+
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.5em"}}} -->
+				<div class="wp-block-group">
+					<!-- wp:post-date /-->
+					<!-- wp:paragraph -->
+					<p>&middot;</p>
+					<!-- /wp:paragraph -->
+					<!-- wp:post-author-name /-->
+				</div>
+				<!-- /wp:group -->
+
+				<!-- wp:post-excerpt {"moreText":"Continue reading","excerptLength":40} /-->
+
+				<!-- wp:separator {"className":"is-style-wide"} -->
+				<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
+				<!-- /wp:separator -->
+
+			</div>
+			<!-- /wp:group -->
+
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center">No posts found.</p>
+			<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
+
+	</div>
+	<!-- /wp:query -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/rafael/templates/single.html
+++ b/wp-themes/rafael/templates/single.html
@@ -1,0 +1,44 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
+
+		<!-- wp:post-title {"level":1} /-->
+
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"0.5em","margin":{"bottom":"var:preset|spacing|30"}}}} -->
+		<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--30)">
+			<!-- wp:post-date /-->
+			<!-- wp:paragraph -->
+			<p>&middot;</p>
+			<!-- /wp:paragraph -->
+			<!-- wp:post-author-name /-->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:post-featured-image {"align":"wide"} /-->
+
+		<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+
+		<!-- wp:separator {"className":"is-style-wide"} -->
+		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
+		<!-- /wp:separator -->
+
+		<!-- wp:group {"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group">
+			<!-- wp:post-terms {"term":"category","prefix":"Filed under: "} /-->
+			<!-- wp:post-terms {"term":"post_tag","prefix":"Tagged: "} /-->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:post-comments /-->
+
+	</div>
+	<!-- /wp:group -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/rafael/theme.json
+++ b/wp-themes/rafael/theme.json
@@ -1,0 +1,260 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"settings": {
+		"appearanceTools": true,
+		"color": {
+			"palette": [
+				{
+					"slug": "rich-gold",
+					"color": "#C5A55A",
+					"name": "Rich Gold"
+				},
+				{
+					"slug": "deep-burgundy",
+					"color": "#6B1D2A",
+					"name": "Deep Burgundy"
+				},
+				{
+					"slug": "ultramarine-blue",
+					"color": "#1B3A8C",
+					"name": "Ultramarine Blue"
+				},
+				{
+					"slug": "ivory",
+					"color": "#FFFFF0",
+					"name": "Ivory"
+				},
+				{
+					"slug": "warm-sienna",
+					"color": "#A0522D",
+					"name": "Warm Sienna"
+				},
+				{
+					"slug": "olive-green",
+					"color": "#556B2F",
+					"name": "Olive Green"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "'Cormorant Garamond', Garamond, 'Times New Roman', serif",
+					"slug": "cormorant-garamond",
+					"name": "Cormorant Garamond",
+					"fontFace": [
+						{
+							"fontFamily": "Cormorant Garamond",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/cormorantgaramond/v16/co3bmX5slCNuHLi8bLeY9MK7whWMhyjYrEtF.woff2"
+							]
+						},
+						{
+							"fontFamily": "Cormorant Garamond",
+							"fontWeight": "600",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/cormorantgaramond/v16/co3YmX5slCNuHLi8bLeY9MK7whWMhyjQEl5fsA.woff2"
+							]
+						},
+						{
+							"fontFamily": "Cormorant Garamond",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/cormorantgaramond/v16/co3YmX5slCNuHLi8bLeY9MK7whWMhyjQWl9fsA.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "Lora, 'Times New Roman', serif",
+					"slug": "lora",
+					"name": "Lora",
+					"fontFace": [
+						{
+							"fontFamily": "Lora",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/lora/v32/0QI6MX1D_JOuGQbT0gvTJPa787weuxJBkq0.woff2"
+							]
+						},
+						{
+							"fontFamily": "Lora",
+							"fontWeight": "400",
+							"fontStyle": "italic",
+							"src": [
+								"https://fonts.gstatic.com/s/lora/v32/0QI8MX1D_JOuMw_hLdO6T2wV9KnW-MoFoq92nA.woff2"
+							]
+						},
+						{
+							"fontFamily": "Lora",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/lora/v32/0QI6MX1D_JOuGQbT0gvTJPa787z5vBJBkq0.woff2"
+							]
+						}
+					]
+				}
+			],
+			"fontSizes": [
+				{
+					"slug": "small",
+					"size": "0.875rem",
+					"name": "Small"
+				},
+				{
+					"slug": "medium",
+					"size": "1rem",
+					"name": "Medium"
+				},
+				{
+					"slug": "large",
+					"size": "1.5rem",
+					"name": "Large"
+				},
+				{
+					"slug": "x-large",
+					"size": "2.25rem",
+					"name": "Extra Large"
+				},
+				{
+					"slug": "xx-large",
+					"size": "3.5rem",
+					"name": "Huge"
+				}
+			]
+		},
+		"layout": {
+			"contentSize": "720px",
+			"wideSize": "1100px"
+		},
+		"spacing": {
+			"units": [
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw",
+				"%"
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--ivory)",
+			"text": "#2C1810"
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--lora)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"lineHeight": "1.75"
+		},
+		"elements": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--cormorant-garamond)",
+					"fontWeight": "600",
+					"lineHeight": "1.3"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--deep-burgundy)"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--xx-large)"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--ultramarine-blue)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--deep-burgundy)"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--deep-burgundy)",
+					"text": "var(--wp--preset--color--ivory)"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--cormorant-garamond)",
+					"fontWeight": "600",
+					"fontSize": "var(--wp--preset--font-size--medium)",
+					"textTransform": "uppercase",
+					"letterSpacing": "0.05em"
+				},
+				"border": {
+					"radius": "2px"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--warm-sienna)",
+						"text": "var(--wp--preset--color--ivory)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/separator": {
+				"color": {
+					"text": "var(--wp--preset--color--rich-gold)"
+				},
+				"border": {
+					"color": "var(--wp--preset--color--rich-gold)",
+					"width": "2px"
+				}
+			},
+			"core/quote": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--cormorant-garamond)",
+					"fontStyle": "italic",
+					"fontSize": "var(--wp--preset--font-size--large)"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--warm-sienna)"
+				},
+				"border": {
+					"left": {
+						"color": "var(--wp--preset--color--rich-gold)",
+						"width": "3px",
+						"style": "solid"
+					}
+				}
+			}
+		}
+	},
+	"templateParts": [
+		{
+			"name": "header",
+			"title": "Header",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"title": "Footer",
+			"area": "footer"
+		}
+	],
+	"customTemplates": [],
+	"patterns": []
+}

--- a/wp-themes/run-tests.sh
+++ b/wp-themes/run-tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+php tests/run-all.php

--- a/wp-themes/tests/run-all.php
+++ b/wp-themes/tests/run-all.php
@@ -1,0 +1,350 @@
+<?php
+
+$root = dirname(__DIR__);
+$themes = [];
+$pass = 0;
+$fail = 0;
+$errors = [];
+
+$theme_dirs = array_filter(glob($root . '/*'), function ($path) {
+    return is_dir($path) && basename($path) !== 'tests' && file_exists($path . '/style.css');
+});
+
+sort($theme_dirs);
+
+foreach ($theme_dirs as $theme_dir) {
+    $slug = basename($theme_dir);
+    $themes[] = $slug;
+}
+
+if (count($themes) < 10) {
+    fwrite(STDERR, "ERROR: Expected 10 themes, found " . count($themes) . ": " . implode(', ', $themes) . "\n");
+    exit(1);
+}
+
+function assert_check(string $desc, bool $condition, string $detail = ''): void {
+    global $pass, $fail, $errors;
+    if ($condition) {
+        $pass++;
+    } else {
+        $fail++;
+        $msg = "FAIL: $desc";
+        if ($detail) $msg .= " — $detail";
+        $errors[] = $msg;
+        fwrite(STDERR, $msg . "\n");
+    }
+}
+
+function parse_style_css_headers(string $path): array {
+    $content = file_get_contents($path);
+    $headers = [];
+    if (preg_match_all('/^\s*([A-Za-z ]+?)\s*:\s*(.+)$/m', $content, $matches, PREG_SET_ORDER)) {
+        foreach ($matches as $m) {
+            $headers[trim($m[1])] = trim($m[2]);
+        }
+    }
+    return $headers;
+}
+
+function check_balanced_blocks(string $content, string $file_label): array {
+    $issues = [];
+    $stack = [];
+
+    // Match all block comments
+    preg_match_all('/<!-- (\/?)wp:([a-z0-9-]+(?:\/[a-z0-9-]+)?)\s*(.*?)(\/?)\s*-->/', $content, $matches, PREG_SET_ORDER);
+
+    foreach ($matches as $m) {
+        $is_closing = ($m[1] === '/');
+        $block_name = $m[2];
+        $is_self_closing = ($m[4] === '/');
+
+        if ($is_self_closing) {
+            continue;
+        }
+
+        if (!$is_closing) {
+            $stack[] = $block_name;
+        } else {
+            if (empty($stack)) {
+                $issues[] = "Unexpected closing for wp:$block_name with empty stack";
+            } else {
+                $top = array_pop($stack);
+                if ($top !== $block_name) {
+                    $issues[] = "Mismatched block: opened wp:$top but closed wp:$block_name";
+                }
+            }
+        }
+    }
+
+    foreach ($stack as $unclosed) {
+        $issues[] = "Unclosed block: wp:$unclosed";
+    }
+
+    return $issues;
+}
+
+function check_pattern_i18n(string $content, string $text_domain): array {
+    $issues = [];
+    // Find strings in block markup that look like human-readable text
+    // We check that text content inside HTML tags uses translation functions
+    // Strategy: find PHP echo/print statements with bare strings (not wrapped in __/esc_ functions)
+
+    // Check for bare strings that should be translated
+    // Look for PHP strings that contain alphabetic text but aren't in i18n wrappers
+    $lines = explode("\n", $content);
+    foreach ($lines as $line_num => $line) {
+        // Skip comment lines and the header block
+        if (preg_match('/^\s*\*/', $line)) continue;
+        if (preg_match('/^<\?php/', $line)) continue;
+        if (preg_match('/^\s*\?>/', $line)) continue;
+
+        // Check for echo/print with bare strings (not i18n-wrapped)
+        if (preg_match('/\becho\s+[\'"]([^\'"]*)[\'"]\s*;/', $line, $em)) {
+            $str = $em[1];
+            if (preg_match('/[a-zA-Z]{2,}/', $str) && !preg_match('/^(https?:|#|[a-z0-9-]+$|wp:|has-|is-|align)/', $str)) {
+                $issues[] = "Line " . ($line_num + 1) . ": bare echo string '$str' not wrapped in i18n function";
+            }
+        }
+    }
+
+    // Check that i18n functions use the correct text domain
+    if (preg_match_all("/(__|_e|esc_html__|esc_html_e|esc_attr__|esc_attr_e|_x|_ex|esc_html_x|_n)\s*\([^)]*?['\"]([a-z0-9-]+)['\"]\s*\)/", $content, $dm, PREG_SET_ORDER)) {
+        foreach ($dm as $d) {
+            $found_domain = $d[2];
+            // The last quoted string before the closing paren is the domain
+            // Re-parse to be more precise
+        }
+    }
+
+    // More targeted: find all i18n calls and verify the text domain
+    if (preg_match_all("/(__|_e|esc_html__|esc_html_e|esc_attr__|esc_attr_e|_x|_ex|esc_html_x|_n)\s*\(\s*'[^']*'\s*,\s*'([^']*)'\s*\)/", $content, $dm, PREG_SET_ORDER)) {
+        foreach ($dm as $d) {
+            if ($d[2] !== $text_domain) {
+                $issues[] = "Wrong text domain '{$d[2]}' (expected '$text_domain') in {$d[1]}() call";
+            }
+        }
+    }
+    if (preg_match_all('/(__|_e|esc_html__|esc_html_e|esc_attr__|esc_attr_e|_x|_ex|esc_html_x|_n)\s*\(\s*"[^"]*"\s*,\s*\'([^\']*)\'\s*\)/', $content, $dm, PREG_SET_ORDER)) {
+        foreach ($dm as $d) {
+            if ($d[2] !== $text_domain) {
+                $issues[] = "Wrong text domain '{$d[2]}' (expected '$text_domain') in {$d[1]}() call";
+            }
+        }
+    }
+
+    return $issues;
+}
+
+$required_headers = [
+    'Theme Name', 'Theme URI', 'Author', 'Author URI', 'Description',
+    'Version', 'Requires at least', 'Tested up to', 'Requires PHP',
+    'License', 'License URI', 'Text Domain', 'Tags'
+];
+
+$required_files = [
+    'style.css',
+    'theme.json',
+    'templates/index.html',
+    'parts/header.html',
+    'parts/footer.html',
+    'patterns/hero.php',
+];
+
+foreach ($themes as $slug) {
+    $dir = $root . '/' . $slug;
+    echo "Testing theme: $slug\n";
+
+    // 1. Required files exist
+    foreach ($required_files as $rf) {
+        assert_check(
+            "[$slug] File exists: $rf",
+            file_exists($dir . '/' . $rf)
+        );
+    }
+
+    // Check for at least one style variation
+    $style_variations = glob($dir . '/styles/*.json');
+    assert_check(
+        "[$slug] Has at least 1 style variation in styles/",
+        count($style_variations) >= 1,
+        "Found " . count($style_variations) . " style variations"
+    );
+
+    // 2. Parse style.css headers
+    $headers = parse_style_css_headers($dir . '/style.css');
+    foreach ($required_headers as $rh) {
+        assert_check(
+            "[$slug] style.css header '$rh' present and non-empty",
+            !empty($headers[$rh]),
+            "Value: " . ($headers[$rh] ?? '(missing)')
+        );
+    }
+
+    // 3. Text Domain matches slug
+    assert_check(
+        "[$slug] Text Domain matches directory name",
+        isset($headers['Text Domain']) && $headers['Text Domain'] === $slug,
+        "Text Domain: '" . ($headers['Text Domain'] ?? '(missing)') . "', slug: '$slug'"
+    );
+
+    // 4. theme.json validation
+    $theme_json_path = $dir . '/theme.json';
+    if (file_exists($theme_json_path)) {
+        $theme_json_raw = file_get_contents($theme_json_path);
+        $theme_json = json_decode($theme_json_raw, true);
+        assert_check(
+            "[$slug] theme.json is valid JSON",
+            $theme_json !== null,
+            json_last_error_msg()
+        );
+
+        if ($theme_json !== null) {
+            assert_check(
+                "[$slug] theme.json has \$schema",
+                !empty($theme_json['$schema'])
+            );
+            assert_check(
+                "[$slug] theme.json version is 3",
+                isset($theme_json['version']) && $theme_json['version'] === 3
+            );
+            assert_check(
+                "[$slug] theme.json has non-empty settings.color.palette",
+                !empty($theme_json['settings']['color']['palette'])
+            );
+            assert_check(
+                "[$slug] theme.json has non-empty settings.typography.fontFamilies",
+                !empty($theme_json['settings']['typography']['fontFamilies'])
+            );
+            assert_check(
+                "[$slug] theme.json has non-empty settings.typography.fontSizes",
+                !empty($theme_json['settings']['typography']['fontSizes'])
+            );
+            assert_check(
+                "[$slug] theme.json has settings.layout.contentSize",
+                !empty($theme_json['settings']['layout']['contentSize'])
+            );
+            assert_check(
+                "[$slug] theme.json has settings.layout.wideSize",
+                !empty($theme_json['settings']['layout']['wideSize'])
+            );
+            assert_check(
+                "[$slug] theme.json has styles key",
+                isset($theme_json['styles'])
+            );
+        }
+    }
+
+    // 5. Style variation JSON validation
+    foreach ($style_variations as $sv_path) {
+        $sv_name = basename($sv_path);
+        $sv_raw = file_get_contents($sv_path);
+        $sv_json = json_decode($sv_raw, true);
+        assert_check(
+            "[$slug] styles/$sv_name is valid JSON",
+            $sv_json !== null,
+            json_last_error_msg()
+        );
+        if ($sv_json !== null) {
+            assert_check(
+                "[$slug] styles/$sv_name has \$schema",
+                !empty($sv_json['$schema'])
+            );
+            assert_check(
+                "[$slug] styles/$sv_name version is 3",
+                isset($sv_json['version']) && $sv_json['version'] === 3
+            );
+            assert_check(
+                "[$slug] styles/$sv_name has non-empty settings.color.palette",
+                !empty($sv_json['settings']['color']['palette'])
+            );
+            assert_check(
+                "[$slug] styles/$sv_name has non-empty settings.typography.fontFamilies",
+                !empty($sv_json['settings']['typography']['fontFamilies'])
+            );
+        }
+    }
+
+    // 6. Template/part balanced block check
+    $html_files = array_merge(
+        glob($dir . '/templates/*.html') ?: [],
+        glob($dir . '/parts/*.html') ?: []
+    );
+    foreach ($html_files as $html_path) {
+        $rel = str_replace($dir . '/', '', $html_path);
+        $content = file_get_contents($html_path);
+        $issues = check_balanced_blocks($content, $rel);
+        assert_check(
+            "[$slug] $rel has balanced block markup",
+            empty($issues),
+            implode('; ', $issues)
+        );
+    }
+
+    // 7. Pattern PHP checks
+    $patterns = glob($dir . '/patterns/*.php') ?: [];
+    foreach ($patterns as $pattern_path) {
+        $pattern_name = basename($pattern_path);
+
+        // PHP lint
+        $lint_output = [];
+        $lint_code = 0;
+        exec('php -l ' . escapeshellarg($pattern_path) . ' 2>&1', $lint_output, $lint_code);
+        assert_check(
+            "[$slug] patterns/$pattern_name passes php -l",
+            $lint_code === 0,
+            implode("\n", $lint_output)
+        );
+
+        // Pattern header keys
+        $pattern_content = file_get_contents($pattern_path);
+        assert_check(
+            "[$slug] patterns/$pattern_name has Title header",
+            (bool)preg_match('/\*\s*Title\s*:/', $pattern_content)
+        );
+        assert_check(
+            "[$slug] patterns/$pattern_name has Slug header",
+            (bool)preg_match('/\*\s*Slug\s*:/', $pattern_content)
+        );
+
+        // Slug should match theme
+        if (preg_match('/\*\s*Slug\s*:\s*(\S+)/', $pattern_content, $sm)) {
+            assert_check(
+                "[$slug] patterns/$pattern_name Slug starts with theme slug",
+                strpos($sm[1], $slug . '/') === 0,
+                "Slug: {$sm[1]}"
+            );
+        }
+
+        // i18n check
+        $i18n_issues = check_pattern_i18n($pattern_content, $slug);
+        assert_check(
+            "[$slug] patterns/$pattern_name i18n strings use correct text domain",
+            empty($i18n_issues),
+            implode('; ', $i18n_issues)
+        );
+
+        // Balanced blocks in pattern
+        $block_issues = check_balanced_blocks($pattern_content, "patterns/$pattern_name");
+        assert_check(
+            "[$slug] patterns/$pattern_name has balanced block markup",
+            empty($block_issues),
+            implode('; ', $block_issues)
+        );
+    }
+}
+
+echo "\n" . str_repeat('=', 60) . "\n";
+
+$total = $pass + $fail;
+
+if ($fail > 0) {
+    echo "FAILED — $fail failures out of $total assertions across " . count($themes) . " themes\n\n";
+    echo "Failures:\n";
+    foreach ($errors as $e) {
+        echo "  $e\n";
+    }
+    exit(1);
+} else {
+    echo "ALL TESTS PASSED — " . count($themes) . " themes × " . intval($total / count($themes)) . " checks each = $total total assertions\n";
+    exit(0);
+}

--- a/wp-themes/wes-anderson/README.md
+++ b/wp-themes/wes-anderson/README.md
@@ -1,0 +1,42 @@
+# Wes Anderson - WordPress Block Theme
+
+A WordPress block theme inspired by the meticulously composed, pastel-rich visual world of filmmaker Wes Anderson.
+
+## Design Notes
+
+This theme draws from the recurring visual motifs across Anderson's filmography:
+
+- **Symmetrical Composition**: Layouts are centered and balanced, reflecting the director's signature framing technique where subjects are placed dead-center in the frame.
+- **Pastel Color Palette**: Blush pinks, powder blues, mustard yellows, and sage greens evoke the carefully art-directed worlds of his films.
+- **Retro-Modern Typography**: Jost (a Futura-like geometric sans-serif) for headings and Libre Franklin for body text mirror the typographic choices seen in Anderson's title cards and on-screen text.
+- **Deliberate Whitespace**: Generous spacing and a cream background create the sense of a curated, museum-like presentation.
+- **Ornamental Separators**: Thin rules and decorative dividers serve as visual chapter breaks, nodding to the storybook structure Anderson frequently employs.
+
+## Style Variation
+
+- **Grand Budapest**: Shifts the palette toward the deep reds, purples, and muted pinks of the Grand Budapest Hotel, evoking the faded opulence of Zubrowka's most distinguished establishment.
+
+## Requirements
+
+- WordPress 6.4 or later
+- PHP 7.4 or later
+
+## Installation
+
+1. Upload the `wes-anderson` folder to `/wp-content/themes/`.
+2. Activate the theme through the Appearance menu in WordPress.
+3. Open the Site Editor to customize templates and style variations.
+
+## Attribution
+
+- **Jost** typeface by Owen Earl, licensed under the SIL Open Font License.
+- **Libre Franklin** typeface by Impallari Type, licensed under the SIL Open Font License.
+- Fonts served via Google Fonts.
+
+## Disclaimer
+
+This theme is an artistic homage to the visual style of Wes Anderson's films. It is not affiliated with, endorsed by, or connected to Wes Anderson, American Empirical Pictures, or any associated production companies. All film titles and related trademarks belong to their respective owners.
+
+## License
+
+GNU General Public License v2 or later. See [LICENSE](http://www.gnu.org/licenses/gpl-2.0.html).

--- a/wp-themes/wes-anderson/parts/footer.html
+++ b/wp-themes/wes-anderson/parts/footer.html
@@ -1,0 +1,15 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"2.5rem","bottom":"2.5rem"}},"border":{"top":{"color":"var(--wp--preset--color--mustard-yellow)","width":"2px","style":"solid"}}},"backgroundColor":"cream","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-cream-background-color has-background" style="border-top-color:var(--wp--preset--color--mustard-yellow);border-top-style:solid;border-top-width:2px;padding-top:2.5rem;padding-bottom:2.5rem">
+	<!-- wp:separator {"backgroundColor":"blush-pink","style":{"spacing":{"margin":{"bottom":"1.5rem"}}}} -->
+	<hr class="wp-block-separator has-text-color has-blush-pink-color has-alpha-channel-opacity has-blush-pink-background-color has-background" style="margin-bottom:1.5rem"/>
+	<!-- /wp:separator -->
+
+	<!-- wp:paragraph {"align":"center","style":{"typography":{"fontFamily":"var(--wp--preset--font-family--jost)","fontSize":"var(--wp--preset--font-size--small)","letterSpacing":"0.1em","textTransform":"uppercase"}}} -->
+	<p class="has-text-align-center" style="font-family:var(--wp--preset--font-family--jost);font-size:var(--wp--preset--font-size--small);letter-spacing:0.1em;text-transform:uppercase">A production of meticulous craft and deliberate whimsy.</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"var(--wp--preset--font-size--small)"},"spacing":{"margin":{"top":"0.5rem"}}}} -->
+	<p class="has-text-align-center" style="margin-top:0.5rem;font-size:var(--wp--preset--font-size--small)">Proudly powered by <a href="https://wordpress.org">WordPress</a></p>
+	<!-- /wp:paragraph -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/wes-anderson/parts/header.html
+++ b/wp-themes/wes-anderson/parts/header.html
@@ -1,0 +1,15 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"1.5rem","bottom":"1.5rem"}},"border":{"bottom":{"color":"var(--wp--preset--color--mustard-yellow)","width":"2px","style":"solid"}}},"backgroundColor":"cream","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-cream-background-color has-background" style="border-bottom-color:var(--wp--preset--color--mustard-yellow);border-bottom-style:solid;border-bottom-width:2px;padding-top:1.5rem;padding-bottom:1.5rem">
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"center","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"2rem"}}} -->
+	<div class="wp-block-group">
+		<!-- wp:site-title {"isLink":true,"style":{"typography":{"textDecoration":"none"}}} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"margin":{"top":"0.75rem"}}}} -->
+	<div class="wp-block-group" style="margin-top:0.75rem">
+		<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"blockGap":"2rem"}}} /-->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/wes-anderson/patterns/hero.php
+++ b/wp-themes/wes-anderson/patterns/hero.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Title: Hero
+ * Slug: wes-anderson/hero
+ * Categories: featured
+ * Description: A symmetrically composed hero section inspired by Wes Anderson's visual style
+ */
+?>
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"6rem","bottom":"6rem","left":"2rem","right":"2rem"}}},"backgroundColor":"blush-pink","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-blush-pink-background-color has-background" style="padding-top:6rem;padding-bottom:6rem;padding-left:2rem;padding-right:2rem">
+	<!-- wp:group {"layout":{"type":"constrained","contentSize":"640px"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph {"align":"center","style":{"typography":{"fontFamily":"var(--wp--preset--font-family--jost)","fontSize":"var(--wp--preset--font-size--small)","letterSpacing":"0.2em","textTransform":"uppercase","fontWeight":"400"}},"textColor":"burgundy"} -->
+		<p class="has-text-align-center has-burgundy-color has-text-color" style="font-family:var(--wp--preset--font-family--jost);font-size:var(--wp--preset--font-size--small);font-weight:400;letter-spacing:0.2em;text-transform:uppercase"><?php echo esc_html__( 'Chapter One', 'wes-anderson' ); ?></p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:heading {"textAlign":"center","level":1,"style":{"typography":{"fontSize":"var(--wp--preset--font-size--xx-large)","letterSpacing":"0.06em"}},"textColor":"burgundy"} -->
+		<h1 class="has-text-align-center has-burgundy-color has-text-color" style="font-size:var(--wp--preset--font-size--xx-large);letter-spacing:0.06em"><?php echo esc_html__( 'A Story Told With Symmetry and Care', 'wes-anderson' ); ?></h1>
+		<!-- /wp:heading -->
+
+		<!-- wp:separator {"backgroundColor":"mustard-yellow","style":{"spacing":{"margin":{"top":"2rem","bottom":"2rem"}}}} -->
+		<hr class="wp-block-separator has-text-color has-mustard-yellow-color has-alpha-channel-opacity has-mustard-yellow-background-color has-background" style="margin-top:2rem;margin-bottom:2rem"/>
+		<!-- /wp:separator -->
+
+		<!-- wp:paragraph {"align":"center","style":{"typography":{"lineHeight":"1.8"}},"textColor":"burgundy"} -->
+		<p class="has-text-align-center has-burgundy-color has-text-color" style="line-height:1.8"><?php echo esc_html__( 'Every frame is a composition. Every detail is deliberate. Welcome to a world where the ordinary becomes extraordinary through meticulous attention to color, form, and feeling.', 'wes-anderson' ); ?></p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"margin":{"top":"2.5rem"}}}} -->
+		<div class="wp-block-buttons" style="margin-top:2.5rem">
+			<!-- wp:button {"backgroundColor":"burgundy","textColor":"cream","style":{"spacing":{"padding":{"top":"0.8rem","bottom":"0.8rem","left":"2.5rem","right":"2.5rem"}}}} -->
+			<div class="wp-block-button"><a class="wp-block-button__link has-cream-color has-burgundy-background-color has-text-color has-background wp-element-button" style="padding-top:0.8rem;padding-right:2.5rem;padding-bottom:0.8rem;padding-left:2.5rem"><?php echo esc_html__( 'Begin the Tour', 'wes-anderson' ); ?></a></div>
+			<!-- /wp:button -->
+		</div>
+		<!-- /wp:buttons -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-themes/wes-anderson/style.css
+++ b/wp-themes/wes-anderson/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Wes Anderson
+Theme URI: #
+Author: Artist Themes Collection
+Author URI: #
+Description: A WordPress block theme inspired by the meticulously composed, pastel-rich visual world of filmmaker Wes Anderson. Features symmetrical layouts, whimsical color palettes, and retro-modern typography that channels the aesthetic of his distinctive filmography.
+Version: 1.0.0
+Requires at least: 6.4
+Tested up to: 6.7
+Requires PHP: 7.4
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: wes-anderson
+Tags: block-patterns, full-site-editing, wide-blocks, custom-colors, custom-fonts
+*/

--- a/wp-themes/wes-anderson/styles/grand-budapest.json
+++ b/wp-themes/wes-anderson/styles/grand-budapest.json
@@ -1,0 +1,194 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"title": "Grand Budapest",
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "blush-pink",
+					"color": "#E8A0BF",
+					"name": "Blush Pink"
+				},
+				{
+					"slug": "dusty-rose",
+					"color": "#9B3A5A",
+					"name": "Dusty Rose"
+				},
+				{
+					"slug": "mustard-yellow",
+					"color": "#D4A84B",
+					"name": "Mustard Yellow"
+				},
+				{
+					"slug": "powder-blue",
+					"color": "#7BA7BC",
+					"name": "Powder Blue"
+				},
+				{
+					"slug": "sage-green",
+					"color": "#8B9E6B",
+					"name": "Sage Green"
+				},
+				{
+					"slug": "cream",
+					"color": "#F5EDE0",
+					"name": "Cream"
+				},
+				{
+					"slug": "burgundy",
+					"color": "#4A0E1E",
+					"name": "Burgundy"
+				},
+				{
+					"slug": "lobby-purple",
+					"color": "#6E3A5F",
+					"name": "Lobby Purple"
+				},
+				{
+					"slug": "concierge-red",
+					"color": "#A3243B",
+					"name": "Concierge Red"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "Jost, sans-serif",
+					"slug": "jost",
+					"name": "Jost",
+					"fontFace": [
+						{
+							"fontFamily": "Jost",
+							"fontWeight": "300",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/jost/v15/92zatBhPNqw73oDd4iYl.woff2"
+							]
+						},
+						{
+							"fontFamily": "Jost",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/jost/v15/92zatBhPNqw73oDd4iYl.woff2"
+							]
+						},
+						{
+							"fontFamily": "Jost",
+							"fontWeight": "500",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/jost/v15/92zatBhPNqw73oDd4iYl.woff2"
+							]
+						},
+						{
+							"fontFamily": "Jost",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/jost/v15/92zatBhPNqw73oDd4iYl.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "Libre Franklin, sans-serif",
+					"slug": "libre-franklin",
+					"name": "Libre Franklin",
+					"fontFace": [
+						{
+							"fontFamily": "Libre Franklin",
+							"fontWeight": "300",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/librefranklin/v14/jizOREhUroWOjjwxBB60SxUYmVNRCkI.woff2"
+							]
+						},
+						{
+							"fontFamily": "Libre Franklin",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/librefranklin/v14/jizOREhUroWOjjwxBB60SxUYmVNRCkI.woff2"
+							]
+						},
+						{
+							"fontFamily": "Libre Franklin",
+							"fontWeight": "400",
+							"fontStyle": "italic",
+							"src": [
+								"https://fonts.gstatic.com/s/librefranklin/v14/jizMREhUroWOjjwxBB60SxUY07dKe2E.woff2"
+							]
+						},
+						{
+							"fontFamily": "Libre Franklin",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/librefranklin/v14/jizOREhUroWOjjwxBB60SxUYmVNRCkI.woff2"
+							]
+						}
+					]
+				}
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--cream)",
+			"text": "var(--wp--preset--color--burgundy)"
+		},
+		"elements": {
+			"heading": {
+				"color": {
+					"text": "var(--wp--preset--color--burgundy)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--concierge-red)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--lobby-purple)"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--concierge-red)",
+					"text": "var(--wp--preset--color--cream)"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--lobby-purple)",
+						"text": "var(--wp--preset--color--cream)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/site-title": {
+				"color": {
+					"text": "var(--wp--preset--color--burgundy)"
+				}
+			},
+			"core/quote": {
+				"border": {
+					"left": {
+						"color": "var(--wp--preset--color--concierge-red)",
+						"width": "3px",
+						"style": "solid"
+					}
+				}
+			},
+			"core/separator": {
+				"color": {
+					"text": "var(--wp--preset--color--concierge-red)"
+				}
+			}
+		}
+	}
+}

--- a/wp-themes/wes-anderson/templates/index.html
+++ b/wp-themes/wes-anderson/templates/index.html
@@ -1,0 +1,45 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:heading {"level":1,"textAlign":"center","style":{"spacing":{"margin":{"top":"3rem","bottom":"2rem"}}}} -->
+	<h1 class="has-text-align-center" style="margin-top:3rem;margin-bottom:2rem">The Journal</h1>
+	<!-- /wp:heading -->
+
+	<!-- wp:separator {"className":"is-style-wide","backgroundColor":"mustard-yellow","style":{"spacing":{"margin":{"bottom":"3rem"}}}} -->
+	<hr class="wp-block-separator has-text-color has-mustard-yellow-color has-alpha-channel-opacity has-mustard-yellow-background-color has-background is-style-wide" style="margin-bottom:3rem"/>
+	<!-- /wp:separator -->
+
+	<!-- wp:query {"queryId":1,"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","inherit":true},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-query">
+		<!-- wp:post-template {"layout":{"type":"default"}} -->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"0.75rem","padding":{"bottom":"2.5rem"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="padding-bottom:2.5rem">
+				<!-- wp:post-title {"textAlign":"center","isLink":true,"style":{"typography":{"fontSize":"var(--wp--preset--font-size--x-large)"}}} /-->
+
+				<!-- wp:post-date {"textAlign":"center","style":{"typography":{"fontFamily":"var(--wp--preset--font-family--jost)","fontSize":"var(--wp--preset--font-size--small)","letterSpacing":"0.1em","textTransform":"uppercase"}}} /-->
+
+				<!-- wp:post-excerpt {"textAlign":"center","moreText":"Continue Reading","excerptLength":30} /-->
+
+				<!-- wp:separator {"backgroundColor":"blush-pink","style":{"spacing":{"margin":{"top":"2.5rem"}}}} -->
+				<hr class="wp-block-separator has-text-color has-blush-pink-color has-alpha-channel-opacity has-blush-pink-background-color has-background" style="margin-top:2.5rem"/>
+				<!-- /wp:separator -->
+			</div>
+			<!-- /wp:group -->
+		<!-- /wp:post-template -->
+
+		<!-- wp:group {"layout":{"type":"constrained"},"style":{"spacing":{"margin":{"top":"2rem"}}}} -->
+		<div class="wp-block-group" style="margin-top:2rem">
+			<!-- wp:query-pagination {"paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"center"}} -->
+				<!-- wp:query-pagination-previous /-->
+				<!-- wp:query-pagination-numbers /-->
+				<!-- wp:query-pagination-next /-->
+			<!-- /wp:query-pagination -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/wes-anderson/templates/single.html
+++ b/wp-themes/wes-anderson/templates/single.html
@@ -1,0 +1,58 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"3rem","bottom":"1rem"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:3rem;padding-bottom:1rem">
+		<!-- wp:post-title {"textAlign":"center","level":1} /-->
+
+		<!-- wp:group {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"blockGap":"1.5rem","margin":{"top":"1rem"}},"typography":{"fontFamily":"var(--wp--preset--font-family--jost)","fontSize":"var(--wp--preset--font-size--small)","letterSpacing":"0.1em","textTransform":"uppercase"}}} -->
+		<div class="wp-block-group" style="margin-top:1rem;font-family:var(--wp--preset--font-family--jost);font-size:var(--wp--preset--font-size--small);letter-spacing:0.1em;text-transform:uppercase">
+			<!-- wp:post-date /-->
+			<!-- wp:post-terms {"term":"category"} /-->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:separator {"backgroundColor":"mustard-yellow","style":{"spacing":{"margin":{"top":"2rem","bottom":"2rem"}}}} -->
+		<hr class="wp-block-separator has-text-color has-mustard-yellow-color has-alpha-channel-opacity has-mustard-yellow-background-color has-background" style="margin-top:2rem;margin-bottom:2rem"/>
+		<!-- /wp:separator -->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:post-featured-image {"align":"wide","style":{"spacing":{"margin":{"bottom":"2.5rem"}}}} /-->
+
+	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+
+	<!-- wp:group {"style":{"spacing":{"padding":{"top":"3rem","bottom":"3rem"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:3rem;padding-bottom:3rem">
+		<!-- wp:separator {"backgroundColor":"blush-pink"} -->
+		<hr class="wp-block-separator has-text-color has-blush-pink-color has-alpha-channel-opacity has-blush-pink-background-color has-background"/>
+		<!-- /wp:separator -->
+
+		<!-- wp:post-terms {"term":"tag","textAlign":"center","style":{"spacing":{"margin":{"top":"1.5rem"}},"typography":{"fontFamily":"var(--wp--preset--font-family--jost)","fontSize":"var(--wp--preset--font-size--small)","letterSpacing":"0.08em","textTransform":"uppercase"}}} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"layout":{"type":"constrained"},"style":{"spacing":{"padding":{"bottom":"3rem"}}}} -->
+	<div class="wp-block-group" style="padding-bottom:3rem">
+		<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"2rem"}}}} -->
+		<div class="wp-block-columns">
+			<!-- wp:column -->
+			<div class="wp-block-column">
+				<!-- wp:post-navigation-link {"type":"previous","label":"Previous Chapter","showTitle":true} /-->
+			</div>
+			<!-- /wp:column -->
+
+			<!-- wp:column -->
+			<div class="wp-block-column">
+				<!-- wp:post-navigation-link {"label":"Next Chapter","showTitle":true} /-->
+			</div>
+			<!-- /wp:column -->
+		</div>
+		<!-- /wp:columns -->
+	</div>
+	<!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/wp-themes/wes-anderson/theme.json
+++ b/wp-themes/wes-anderson/theme.json
@@ -1,0 +1,318 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"settings": {
+		"appearanceTools": true,
+		"color": {
+			"palette": [
+				{
+					"slug": "blush-pink",
+					"color": "#F4A4B8",
+					"name": "Blush Pink"
+				},
+				{
+					"slug": "dusty-rose",
+					"color": "#C97B84",
+					"name": "Dusty Rose"
+				},
+				{
+					"slug": "mustard-yellow",
+					"color": "#E8B84B",
+					"name": "Mustard Yellow"
+				},
+				{
+					"slug": "powder-blue",
+					"color": "#A8D8EA",
+					"name": "Powder Blue"
+				},
+				{
+					"slug": "sage-green",
+					"color": "#B5C99A",
+					"name": "Sage Green"
+				},
+				{
+					"slug": "cream",
+					"color": "#FDF6EC",
+					"name": "Cream"
+				},
+				{
+					"slug": "burgundy",
+					"color": "#6B2737",
+					"name": "Burgundy"
+				}
+			]
+		},
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "Jost, sans-serif",
+					"slug": "jost",
+					"name": "Jost",
+					"fontFace": [
+						{
+							"fontFamily": "Jost",
+							"fontWeight": "300",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/jost/v15/92zatBhPNqw73oDd4iYl.woff2"
+							]
+						},
+						{
+							"fontFamily": "Jost",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/jost/v15/92zatBhPNqw73oDd4iYl.woff2"
+							]
+						},
+						{
+							"fontFamily": "Jost",
+							"fontWeight": "500",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/jost/v15/92zatBhPNqw73oDd4iYl.woff2"
+							]
+						},
+						{
+							"fontFamily": "Jost",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/jost/v15/92zatBhPNqw73oDd4iYl.woff2"
+							]
+						}
+					]
+				},
+				{
+					"fontFamily": "Libre Franklin, sans-serif",
+					"slug": "libre-franklin",
+					"name": "Libre Franklin",
+					"fontFace": [
+						{
+							"fontFamily": "Libre Franklin",
+							"fontWeight": "300",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/librefranklin/v14/jizOREhUroWOjjwxBB60SxUYmVNRCkI.woff2"
+							]
+						},
+						{
+							"fontFamily": "Libre Franklin",
+							"fontWeight": "400",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/librefranklin/v14/jizOREhUroWOjjwxBB60SxUYmVNRCkI.woff2"
+							]
+						},
+						{
+							"fontFamily": "Libre Franklin",
+							"fontWeight": "400",
+							"fontStyle": "italic",
+							"src": [
+								"https://fonts.gstatic.com/s/librefranklin/v14/jizMREhUroWOjjwxBB60SxUY07dKe2E.woff2"
+							]
+						},
+						{
+							"fontFamily": "Libre Franklin",
+							"fontWeight": "700",
+							"fontStyle": "normal",
+							"src": [
+								"https://fonts.gstatic.com/s/librefranklin/v14/jizOREhUroWOjjwxBB60SxUYmVNRCkI.woff2"
+							]
+						}
+					]
+				}
+			],
+			"fontSizes": [
+				{
+					"slug": "small",
+					"size": "0.875rem",
+					"name": "Small"
+				},
+				{
+					"slug": "medium",
+					"size": "1rem",
+					"name": "Medium"
+				},
+				{
+					"slug": "large",
+					"size": "1.5rem",
+					"name": "Large"
+				},
+				{
+					"slug": "x-large",
+					"size": "2.25rem",
+					"name": "Extra Large"
+				},
+				{
+					"slug": "xx-large",
+					"size": "3.5rem",
+					"name": "Huge"
+				}
+			]
+		},
+		"layout": {
+			"contentSize": "720px",
+			"wideSize": "1100px"
+		},
+		"spacing": {
+			"units": [
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw",
+				"%"
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--cream)",
+			"text": "var(--wp--preset--color--burgundy)"
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--libre-franklin)",
+			"fontSize": "var(--wp--preset--font-size--medium)",
+			"lineHeight": "1.7"
+		},
+		"spacing": {
+			"blockGap": "1.5rem",
+			"padding": {
+				"top": "0",
+				"right": "1.5rem",
+				"bottom": "0",
+				"left": "1.5rem"
+			}
+		},
+		"elements": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--jost)",
+					"fontWeight": "500",
+					"lineHeight": "1.2",
+					"letterSpacing": "0.04em",
+					"textTransform": "uppercase"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--burgundy)"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--xx-large)"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--x-large)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--dusty-rose)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--burgundy)"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--burgundy)",
+					"text": "var(--wp--preset--color--cream)"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--jost)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "500",
+					"letterSpacing": "0.1em",
+					"textTransform": "uppercase"
+				},
+				"border": {
+					"radius": "2px"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--dusty-rose)",
+						"text": "var(--wp--preset--color--cream)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--jost)",
+					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontWeight": "500",
+					"letterSpacing": "0.15em",
+					"textTransform": "uppercase"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--burgundy)"
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--jost)",
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "400",
+					"letterSpacing": "0.1em",
+					"textTransform": "uppercase"
+				}
+			},
+			"core/quote": {
+				"border": {
+					"left": {
+						"color": "var(--wp--preset--color--mustard-yellow)",
+						"width": "3px",
+						"style": "solid"
+					}
+				},
+				"typography": {
+					"fontStyle": "italic"
+				},
+				"spacing": {
+					"padding": {
+						"left": "1.5rem"
+					}
+				}
+			},
+			"core/separator": {
+				"color": {
+					"text": "var(--wp--preset--color--mustard-yellow)"
+				},
+				"border": {
+					"width": "1px"
+				}
+			},
+			"core/post-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--jost)",
+					"fontWeight": "500",
+					"letterSpacing": "0.04em",
+					"textTransform": "uppercase"
+				}
+			}
+		}
+	},
+	"templateParts": [
+		{
+			"name": "header",
+			"title": "Header",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"title": "Footer",
+			"area": "footer"
+		}
+	]
+}


### PR DESCRIPTION
## Summary
Ten standalone WordPress block themes, each a stylized homage to a different artist across 7 media:

| Theme | Artist | Medium |
|---|---|---|
| `gaudi` | Antoni Gaudí | Architecture / Art Nouveau |
| `rafael` | Raphael | Renaissance painting |
| `hundertwasser` | Hundertwasser | Architecture + painting |
| `hitchcock` | Hitchcock | Cinema |
| `basquiat` | Basquiat | Neo-expressionist painting |
| `ansel-adams` | Ansel Adams | Photography |
| `giacometti` | Giacometti | Sculpture |
| `wes-anderson` | Wes Anderson | Cinema |
| `bjork` | Björk | Music |
| `kusama` | Kusama | Installation art |

Each ships `style.css` with full headers, `theme.json` v3 with artist-driven palette/typography, templates + parts, at least one registered pattern with translatable strings, and at least one style variation. No copyrighted imagery — CSS, gradients, SVG only.

## Validation
`./run-tests.sh` runs 450 assertions across the 10 themes: file-layout checks, `theme.json` schema sanity, balanced block-comment markup, `php -l` on patterns, matching text domains, i18n wrapping on human-readable strings.

CI workflow (`.github/workflows/wp-themes.yml`) runs the validator on every PR touching `wp-themes/`.

## Previewing in WordPress Playground
Ten one-click preview links will be posted as a comment below, each loading one theme directly from this branch via a `git:directory` blueprint resource.

## Test plan
- [x] Local: `UNIT: 450/450 assertions passed`
- [ ] CI green on this PR
- [ ] Each of the 10 Playground links loads and activates its theme
- [ ] Reviewer opens a subset of the Playground links to confirm the visual homage lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)