### PR TITLE
branched-wp: cross-platform port (linux+mac) + release CI

### DIFF
--- a/.github/workflows/branched-wp-release.yml
+++ b/.github/workflows/branched-wp-release.yml
@@ -136,7 +136,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          h=$(printf '%s' "$SPC_EXTENSIONS" | sha256sum | cut -c1-12)
+          # shasum is present on both Linux and macOS runners; sha256sum is
+          # Linux-only. Both emit "<hex>  -" on stdin input.
+          h=$(printf '%s' "$SPC_EXTENSIONS" | shasum -a 256 | cut -c1-12)
           echo "hash=$h" >> "$GITHUB_OUTPUT"
 
       - name: Cache static-php-cli workdir
@@ -164,6 +166,12 @@ jobs:
 
       - name: Build static PHP + extensions
         shell: bash
+        # spc hits GitHub release assets + raw.githubusercontent for
+        # pre-built libs. Shared runner IPs exhaust the 60 req/hr
+        # unauthenticated limit quickly; GITHUB_TOKEN bumps that to
+        # 5000 req/hr and is plumbed via spc/store/CurlHook.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           cd .spc/static-php-cli

--- a/.github/workflows/branched-wp-release.yml
+++ b/.github/workflows/branched-wp-release.yml
@@ -430,11 +430,13 @@ jobs:
           ls -la "target/${{ matrix.rust-target }}/release/gitpress"
 
       # ---------------------------------------------------------------
-      # Package: one tar.gz containing launcher + runtime bundle.
+      # Package: one tar.gz containing ONLY the launcher + a README.
+      # The runtime bundle is already compiled into the launcher via
+      # `include_bytes!(env!("GITPRESS_RUNTIME_BUNDLE"))`, so shipping a
+      # second copy alongside would be ~100 MB of pure redundancy.
       # Layout inside the tarball:
-      #   gitpress                            <- launcher binary
-      #   gitpress-runtime.tar.gz             <- bundle the launcher extracts
-      #   README-gitpress.txt                 <- 3-line quick-start
+      #   gitpress                  <- launcher (self-contained, embeds runtime)
+      #   README.txt                <- quick-start
       # ---------------------------------------------------------------
       - name: Package release tarball
         id: package
@@ -446,30 +448,23 @@ jobs:
           mkdir -p "$stage"
           cp "target/${{ matrix.rust-target }}/release/gitpress" "$stage/gitpress"
           chmod +x "$stage/gitpress"
-          # The runtime bundle is produced by build.rs into OUT_DIR, which
-          # cargo materializes at:
-          #   target/<triple>/release/build/<crate>-<hash>/out/gitpress-runtime.tar.gz
-          # The <hash> suffix changes every run, so glob it. There can be
-          # multiple gitpress-* directories (stale + current) — pick the
-          # most recently modified.
-          bundle=$(ls -t target/${{ matrix.rust-target }}/release/build/gitpress-*/out/gitpress-runtime.tar.gz 2>/dev/null | head -1)
-          if [ -z "$bundle" ] || [ ! -f "$bundle" ]; then
-            echo "FATAL: gitpress-runtime.tar.gz not found under target/" >&2
-            echo "--- diag: build dirs ---" >&2
-            ls -la "target/${{ matrix.rust-target }}/release/build" 2>/dev/null || true
-            echo "--- diag: any match under target/ ---" >&2
-            find "target/${{ matrix.rust-target }}" -name 'gitpress-runtime.tar.gz' 2>/dev/null || true
-            exit 1
-          fi
-          echo "bundle=$bundle"
-          cp "$bundle" "$stage/gitpress-runtime.tar.gz"
-          cat > "$stage/README-gitpress.txt" <<EOF
-          gitpress ${{ steps.version.outputs.version }} (${{ matrix.os-tag }}-${{ matrix.arch-tag }})
+          cat > "$stage/README.txt" <<EOF
+          gitpress ${{ steps.version.outputs.version }} — ${{ matrix.os-tag }}-${{ matrix.arch-tag }} (statically linked)
 
-          Start a local site:
-            ./gitpress start
+          Single self-contained binary. Extracts its embedded runtime
+          (static PHP + Dolt + WordPress + branchfs) to ~/.gitpress/runtime/
+          on first run.
 
-          See branched-wp/README.md for details.
+          Usage:
+            ./gitpress start                  # launch dev stack on :18080
+            ./gitpress branch create <name>   # create a preview branch
+            ./gitpress --help
+
+          Homepage: http://localhost:18080/ (Host: wp.localhost)
+          Admin:    http://localhost:18080/wp-login.php  (admin / admin)
+
+          Full docs: https://github.com/adamziel/experiments/tree/main/branched-wp
+          Build from source: branched-wp/BUILDING.md
           EOF
           tar -C /tmp -czf "/tmp/${name}.tar.gz" "$name"
           (cd /tmp && shasum -a 256 "${name}.tar.gz" > "${name}.sha256")

--- a/.github/workflows/branched-wp-release.yml
+++ b/.github/workflows/branched-wp-release.yml
@@ -18,6 +18,18 @@ on:
   push:
     tags:
       - 'v*'
+    # Temporary: also run on pushes to the release branch so we can
+    # iterate the workflow itself on real runners before it lives on
+    # the default branch (where workflow_dispatch would work).
+    # Remove this branch entry once the workflow merges to main.
+    branches:
+      - branched-wp-cross-platform-release
+    paths:
+      - '.github/workflows/branched-wp-release.yml'
+      - 'branched-wp/Makefile'
+      - 'branched-wp/gitpress/**'
+      - 'branched-wp/ext/**'
+      - 'branched-wp/e2e/test_sqlite_clone_minimal.sh'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -90,7 +102,10 @@ jobs:
         id: version
         shell: bash
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
+          # Tag push → real release version (strip leading v).
+          # Branch push or workflow_dispatch → dry-<short sha>, which also
+          # skips the "Attach to GitHub Release" step below.
+          if [ "${{ github.event_name }}" = "push" ] && [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             v="${GITHUB_REF_NAME#v}"
           else
             v="dry-${GITHUB_SHA::7}"
@@ -181,17 +196,25 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # static-php-cli emits a php-config in buildroot/bin/ that
-          # points at the static PHP's headers + lib paths. Our Makefile
-          # consumes PHP_CONFIG directly.
-          PHP_CONFIG="$PWD/.spc/static-php-cli/buildroot/bin/php-config"
-          if [ ! -x "$PHP_CONFIG" ]; then
-            echo "FATAL: php-config not produced by spc at $PHP_CONFIG" >&2
-            find .spc/static-php-cli/buildroot -name 'php-config' 2>/dev/null || true
+          # spc does NOT run `make install` inside source/php-src — it only
+          # cp's the final `php` binary to buildroot/bin/. So buildroot/
+          # contains the compiled PHP *executable* but NOT php-config or
+          # an installed include tree.
+          #
+          # Our Makefile can be driven purely by PHP_INCLUDE_DIR: given the
+          # top of the php-src tree, it derives all the -I flags our
+          # extension needs (main/, TSRM/, Zend/, ext/, ext/date/lib/).
+          # php_config.h lives under source/php-src/main/ after configure,
+          # so no `install-headers` round-trip is necessary.
+          PHP_SRC_DIR="$PWD/.spc/static-php-cli/source/php-src"
+          if [ ! -f "$PHP_SRC_DIR/main/php.h" ] || [ ! -f "$PHP_SRC_DIR/main/php_config.h" ]; then
+            echo "FATAL: PHP source tree not where expected ($PHP_SRC_DIR)" >&2
+            ls -la "$PHP_SRC_DIR/main" 2>/dev/null || true
+            find .spc/static-php-cli/source -maxdepth 3 -name 'php_config.h' 2>/dev/null || true
             exit 1
           fi
           make clean
-          make PHP_CONFIG="$PHP_CONFIG"
+          make PHP_CONFIG= PHP_INCLUDE_DIR="$PHP_SRC_DIR"
           test -f ext/branchfs.so
           cp ext/branchfs.so runtime/lib/branchfs.so
 
@@ -334,14 +357,22 @@ jobs:
           mkdir -p "$stage"
           cp "target/${{ matrix.rust-target }}/release/gitpress" "$stage/gitpress"
           chmod +x "$stage/gitpress"
-          # The runtime bundle is produced by build.rs into OUT_DIR.
-          # Find it via cargo metadata / the known path under target/.
-          bundle=$(find "target/${{ matrix.rust-target }}/release/build" -name 'gitpress-runtime.tar.gz' | head -1)
+          # The runtime bundle is produced by build.rs into OUT_DIR, which
+          # cargo materializes at:
+          #   target/<triple>/release/build/<crate>-<hash>/out/gitpress-runtime.tar.gz
+          # The <hash> suffix changes every run, so glob it. There can be
+          # multiple gitpress-* directories (stale + current) — pick the
+          # most recently modified.
+          bundle=$(ls -t target/${{ matrix.rust-target }}/release/build/gitpress-*/out/gitpress-runtime.tar.gz 2>/dev/null | head -1)
           if [ -z "$bundle" ] || [ ! -f "$bundle" ]; then
             echo "FATAL: gitpress-runtime.tar.gz not found under target/" >&2
-            find "target/${{ matrix.rust-target }}" -name 'gitpress-runtime.tar.gz' || true
+            echo "--- diag: build dirs ---" >&2
+            ls -la "target/${{ matrix.rust-target }}/release/build" 2>/dev/null || true
+            echo "--- diag: any match under target/ ---" >&2
+            find "target/${{ matrix.rust-target }}" -name 'gitpress-runtime.tar.gz' 2>/dev/null || true
             exit 1
           fi
+          echo "bundle=$bundle"
           cp "$bundle" "$stage/gitpress-runtime.tar.gz"
           cat > "$stage/README-gitpress.txt" <<EOF
           gitpress ${{ steps.version.outputs.version }} (${{ matrix.os-tag }}-${{ matrix.arch-tag }})

--- a/.github/workflows/branched-wp-release.yml
+++ b/.github/workflows/branched-wp-release.yml
@@ -18,18 +18,6 @@ on:
   push:
     tags:
       - 'v*'
-    # Temporary: also run on pushes to the release branch so we can
-    # iterate the workflow itself on real runners before it lives on
-    # the default branch (where workflow_dispatch would work).
-    # Remove this branch entry once the workflow merges to main.
-    branches:
-      - branched-wp-cross-platform-release
-    paths:
-      - '.github/workflows/branched-wp-release.yml'
-      - 'branched-wp/Makefile'
-      - 'branched-wp/gitpress/**'
-      - 'branched-wp/ext/**'
-      - 'branched-wp/e2e/test_sqlite_clone_minimal.sh'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/branched-wp-release.yml
+++ b/.github/workflows/branched-wp-release.yml
@@ -198,11 +198,35 @@ jobs:
           # and is idempotent; safe to re-run on a cache hit.
           ./bin/spc doctor --auto-fix
           ./bin/spc download --with-php="${PHP_VERSION}" --for-extensions="${SPC_EXTENSIONS}" --prefer-pre-built
-          ./bin/spc build "${SPC_EXTENSIONS}" --build-cli
-          # Sanity-check the built PHP runs and has all requested exts,
-          # including branchfs (which lives in the binary, not a .so).
-          ./buildroot/bin/php -v
-          ./buildroot/bin/php -m
+          # spc's internal sanity check runs `php -r "echo \"hello\";"`
+          # via PHP's exec() which swallows stderr — if branchfs's MINIT
+          # fails or prints a warning at startup, the symptom is an
+          # opaque "cli failed sanity check" with no hint why. Let spc
+          # try first, but on failure re-run the same check with stderr
+          # captured so we get an actionable message on the next push.
+          set +e
+          ./bin/spc build "${SPC_EXTENSIONS}" --build-cli --debug
+          spc_rc=$?
+          set -e
+          echo "=== post-build diagnostic (runs even on spc failure) ==="
+          if [ -x ./buildroot/bin/php ]; then
+            echo '--- php -v (stderr merged) ---'
+            ./buildroot/bin/php -v 2>&1 || true
+            echo '--- php -r "echo hello;" (stderr merged) ---'
+            ./buildroot/bin/php -r 'echo "hello\n";' 2>&1
+            echo "--- explicit exit status ---"
+            ./buildroot/bin/php -r 'echo "hello\n";' >/dev/null 2>&1; echo "exit=$?"
+            echo '--- php -m (stderr merged) ---'
+            ./buildroot/bin/php -m 2>&1 || true
+          else
+            echo "(no buildroot/bin/php yet — spc failed before deploy)"
+          fi
+          if [ "$spc_rc" -ne 0 ]; then
+            echo "spc build exited $spc_rc" >&2
+            exit "$spc_rc"
+          fi
+          # Sanity-check the built PHP has all requested exts, including
+          # branchfs (which lives in the binary, not a .so).
           ./buildroot/bin/php -r 'foreach (explode(",", getenv("SPC_EXTENSIONS")) as $e) { if (!extension_loaded(trim($e))) { fwrite(STDERR, "missing: $e\n"); exit(1);} } echo "all extensions present\n";'
           # Explicit branchfs assertion for log-scrapability.
           if ! ./buildroot/bin/php -m | grep -qi '^branchfs$'; then

--- a/.github/workflows/branched-wp-release.yml
+++ b/.github/workflows/branched-wp-release.yml
@@ -1,0 +1,422 @@
+name: branched-wp release
+
+# Release pipeline for the `gitpress` single-binary distribution of
+# branched-wp. Builds a per-platform self-contained tarball containing
+# a statically-linked PHP (via static-php-cli), a platform-matching Dolt
+# binary, the compiled `branchfs.so` PHP extension, and the bundled
+# WordPress source + vendored plugins.
+#
+# Triggers:
+#   - push of a tag matching `v*` → full release upload to GitHub Releases.
+#   - workflow_dispatch with dry_run=true → artifacts attach to the workflow
+#     run only (no Release touched), useful for testing before tagging.
+#
+# The matrix covers the four tier-1 targets. Windows is not yet supported —
+# see branched-wp/LIMITATIONS.md for the port blockers.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Upload artifacts to workflow run instead of Release'
+        required: false
+        default: 'true'
+        type: boolean
+
+permissions:
+  contents: write   # needed for softprops/action-gh-release
+
+concurrency:
+  group: branched-wp-release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  # static-php-cli extension list. Keep in sync with README's "Supported
+  # extensions" note. Adding/removing extensions here invalidates the
+  # spc workdir cache (the extension list is part of the cache key).
+  SPC_EXTENSIONS: "mbstring,mysqli,pdo_mysql,sqlite3,pdo_sqlite,phar,tokenizer,fileinfo,filter,session"
+  # Pin static-php-cli to a known-good ref. Bump manually when we want a
+  # newer PHP minor or an spc fix.
+  SPC_REF: "2.4.0"
+  PHP_VERSION: "8.2"
+
+jobs:
+  build:
+    name: build ${{ matrix.os-tag }}-${{ matrix.arch-tag }}
+    runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        working-directory: branched-wp
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os-tag: linux
+            arch-tag: x86_64
+            runner: ubuntu-24.04
+            dolt-archive: dolt-linux-amd64
+            rust-target: x86_64-unknown-linux-musl
+          - os-tag: linux
+            arch-tag: aarch64
+            runner: ubuntu-24.04-arm
+            dolt-archive: dolt-linux-arm64
+            rust-target: aarch64-unknown-linux-musl
+          - os-tag: macos
+            arch-tag: x86_64
+            # Intel-mac runners; GitHub retired macos-13, use the
+            # last Intel-labelled image (macos-15-intel) until it too
+            # is removed, at which point Intel macOS support needs
+            # a self-hosted runner.
+            runner: macos-15-intel
+            dolt-archive: dolt-darwin-amd64
+            rust-target: x86_64-apple-darwin
+          - os-tag: macos
+            arch-tag: aarch64
+            runner: macos-14
+            dolt-archive: dolt-darwin-arm64
+            rust-target: aarch64-apple-darwin
+    steps:
+      - uses: actions/checkout@v4
+
+      # ---------------------------------------------------------------
+      # Resolve a stable, human-readable version string once. On a tag
+      # push it's the tag without the leading 'v'. On workflow_dispatch
+      # it's "dry-<short-sha>" so nothing collides with real releases.
+      # ---------------------------------------------------------------
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            v="${GITHUB_REF_NAME#v}"
+          else
+            v="dry-${GITHUB_SHA::7}"
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "artifact-name=gitpress-${v}-${{ matrix.os-tag }}-${{ matrix.arch-tag }}" >> "$GITHUB_OUTPUT"
+
+      # ---------------------------------------------------------------
+      # Host PHP — only needed to *run* static-php-cli itself. The
+      # actual release PHP comes from spc's build output below.
+      # ---------------------------------------------------------------
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+          tools: composer
+          coverage: none
+
+      # Cache keys:
+      #   spc-<target>-<php>-<spc ref>-<extensions>
+      # Any change to SPC_EXTENSIONS or SPC_REF invalidates. Per-target
+      # because the artifacts inside buildroot/ are platform-specific.
+      - name: Cache static-php-cli workdir
+        id: spc-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            branched-wp/.spc/downloads
+            branched-wp/.spc/source
+            branched-wp/.spc/buildroot
+          key: spc-${{ matrix.os-tag }}-${{ matrix.arch-tag }}-php${{ env.PHP_VERSION }}-spc${{ env.SPC_REF }}-${{ hashFiles('branched-wp/.github/spc-extensions.txt') }}-${{ env.SPC_EXTENSIONS }}
+
+      - name: Install static-php-cli
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .spc
+          cd .spc
+          if [ ! -d static-php-cli ]; then
+            git clone --depth 1 --branch "${SPC_REF}" \
+              https://github.com/crazywhalecc/static-php-cli.git
+          fi
+          cd static-php-cli
+          composer install --no-dev --no-interaction
+
+      - name: Build static PHP + extensions
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd .spc/static-php-cli
+          # `doctor` auto-installs build deps (compiler, autotools, etc.)
+          # and is idempotent; safe to re-run on a cache hit.
+          ./bin/spc doctor --auto-fix
+          ./bin/spc download --with-php="${PHP_VERSION}" --for-extensions="${SPC_EXTENSIONS}" --prefer-pre-built
+          ./bin/spc build "${SPC_EXTENSIONS}" --build-cli
+          # Sanity-check the built PHP runs and has all requested exts.
+          ./buildroot/bin/php -v
+          ./buildroot/bin/php -r 'foreach (explode(",", getenv("SPC_EXTENSIONS")) as $e) { if (!extension_loaded(trim($e))) { fwrite(STDERR, "missing: $e\n"); exit(1);} } echo "all extensions present\n";'
+
+      # ---------------------------------------------------------------
+      # Stage the runtime directory that gitpress's build.rs consumes
+      # when GITPRESS_RUNTIME_DIR is set: runtime/bin/php, bin/dolt,
+      # lib/branchfs.so.
+      # ---------------------------------------------------------------
+      - name: Stage runtime/bin/php
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p runtime/bin runtime/lib
+          cp .spc/static-php-cli/buildroot/bin/php runtime/bin/php
+          chmod +x runtime/bin/php
+
+      - name: Download matching Dolt binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Dolt's release assets follow `<archive>.tar.gz` for linux/mac.
+          archive="${{ matrix.dolt-archive }}"
+          url="https://github.com/dolthub/dolt/releases/latest/download/${archive}.tar.gz"
+          curl -fsSL "$url" -o /tmp/dolt.tgz
+          mkdir -p /tmp/dolt-unpack
+          tar -xzf /tmp/dolt.tgz -C /tmp/dolt-unpack
+          # Archive contains <archive>/bin/dolt — copy out.
+          cp "/tmp/dolt-unpack/${archive}/bin/dolt" runtime/bin/dolt
+          chmod +x runtime/bin/dolt
+          runtime/bin/dolt version
+
+      - name: Build ext/branchfs.so against static PHP
+        shell: bash
+        run: |
+          set -euo pipefail
+          # static-php-cli emits a php-config in buildroot/bin/ that
+          # points at the static PHP's headers + lib paths. Our Makefile
+          # consumes PHP_CONFIG directly.
+          PHP_CONFIG="$PWD/.spc/static-php-cli/buildroot/bin/php-config"
+          if [ ! -x "$PHP_CONFIG" ]; then
+            echo "FATAL: php-config not produced by spc at $PHP_CONFIG" >&2
+            find .spc/static-php-cli/buildroot -name 'php-config' 2>/dev/null || true
+            exit 1
+          fi
+          make clean
+          make PHP_CONFIG="$PHP_CONFIG"
+          test -f ext/branchfs.so
+          cp ext/branchfs.so runtime/lib/branchfs.so
+
+      # ---------------------------------------------------------------
+      # Unit suite — runs against the just-built static PHP + extension.
+      # Catches ABI drift between spc PHP and our extension.
+      # ---------------------------------------------------------------
+      - name: Unit tests (make test-all)
+        shell: bash
+        env:
+          PHP: ${{ github.workspace }}/branched-wp/.spc/static-php-cli/buildroot/bin/php
+        run: |
+          set -euo pipefail
+          # Point make test-all at the spc-built PHP by overriding the
+          # `php` command it shells out to.
+          PHP_BIN="$PHP"
+          export PATH="$(dirname "$PHP_BIN"):$PATH"
+          which php
+          php -v
+          make test-all
+
+      # ---------------------------------------------------------------
+      # Lightweight e2e smoke: spin up dev stack with the bundled
+      # binaries ONLY, then run test_sqlite_clone_minimal.sh.
+      # ---------------------------------------------------------------
+      - name: Fetch WordPress 6.5 source for e2e
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p e2e
+          # e2e/wp-src/ is what dev.sh expects. wp.zip ships in the repo
+          # but may be stale across PHP versions — use the official
+          # tarball here so the dev stack boots cleanly regardless.
+          if [ ! -d e2e/wp-src ]; then
+            curl -fsSL https://wordpress.org/wordpress-6.5.tar.gz -o /tmp/wp.tgz
+            tar -C e2e -xzf /tmp/wp.tgz
+            mv e2e/wordpress e2e/wp-src
+          fi
+
+      - name: Run e2e smoke (test_sqlite_clone_minimal.sh)
+        shell: bash
+        env:
+          BUNDLED_PHP: ${{ github.workspace }}/branched-wp/runtime/bin/php
+          BUNDLED_DOLT: ${{ github.workspace }}/branched-wp/runtime/bin/dolt
+        run: |
+          set -euo pipefail
+          # Preflight: confirm the bundled binaries actually execute and
+          # the extension loads. Fails fast with a clear message rather
+          # than a confusing dev.sh timeout.
+          "$BUNDLED_PHP" -d "extension=$PWD/runtime/lib/branchfs.so" -r \
+            'if(!extension_loaded("branchfs")){fwrite(STDERR,"branchfs.so did not load\n");exit(1);} echo "branchfs loaded\n";'
+          "$BUNDLED_DOLT" version
+          # Start the dev stack with bundled binaries only. dev.sh
+          # respects PHP_BIN and DOLT env vars.
+          export PHP_BIN="$BUNDLED_PHP"
+          export DOLT="$BUNDLED_DOLT"
+          # Background dev.sh (nohup + redirect so the shell doesn't
+          # hold it open). The cleanup trap in dev.sh kills its
+          # children on SIGTERM, which we'll send at the end.
+          nohup bash e2e/dev.sh > /tmp/dev.log 2>&1 &
+          DEV_PID=$!
+          echo "dev.sh PID=$DEV_PID"
+          # Wait for the site to come up (dev.sh normally takes ~30s).
+          for i in $(seq 1 90); do
+            if curl -sf -H "Host: wp.localhost" -o /dev/null http://127.0.0.1:18080/; then
+              echo "dev stack up after ${i}s"
+              break
+            fi
+            if ! kill -0 "$DEV_PID" 2>/dev/null; then
+              echo "dev.sh died early:" >&2
+              tail -60 /tmp/dev.log >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          if ! curl -sf -H "Host: wp.localhost" -o /dev/null http://127.0.0.1:18080/; then
+            echo "dev stack never came up" >&2
+            tail -80 /tmp/dev.log >&2
+            exit 1
+          fi
+          # Run the minimal test.
+          set +e
+          PHP_BIN="$BUNDLED_PHP" bash e2e/test_sqlite_clone_minimal.sh
+          rc=$?
+          set -e
+          # Shut down dev stack.
+          kill -TERM "$DEV_PID" 2>/dev/null || true
+          wait "$DEV_PID" 2>/dev/null || true
+          exit "$rc"
+
+      # ---------------------------------------------------------------
+      # Build gitpress, consuming the pre-staged runtime directory.
+      # ---------------------------------------------------------------
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-target }}
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            branched-wp/target
+          key: cargo-${{ matrix.rust-target }}-${{ hashFiles('branched-wp/Cargo.lock') }}
+
+      # Linux musl targets need `musl-tools` for the `musl-gcc` linker.
+      - name: Install musl toolchain (Linux only)
+        if: matrix.os-tag == 'linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends musl-tools
+
+      - name: Build gitpress
+        shell: bash
+        env:
+          GITPRESS_RUNTIME_DIR: ${{ github.workspace }}/branched-wp/runtime
+        run: |
+          set -euo pipefail
+          cargo build --release -p gitpress --target "${{ matrix.rust-target }}"
+          ls -la "target/${{ matrix.rust-target }}/release/gitpress"
+
+      # ---------------------------------------------------------------
+      # Package: one tar.gz containing launcher + runtime bundle.
+      # Layout inside the tarball:
+      #   gitpress                            <- launcher binary
+      #   gitpress-runtime.tar.gz             <- bundle the launcher extracts
+      #   README-gitpress.txt                 <- 3-line quick-start
+      # ---------------------------------------------------------------
+      - name: Package release tarball
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          name="${{ steps.version.outputs.artifact-name }}"
+          stage="/tmp/${name}"
+          mkdir -p "$stage"
+          cp "target/${{ matrix.rust-target }}/release/gitpress" "$stage/gitpress"
+          chmod +x "$stage/gitpress"
+          # The runtime bundle is produced by build.rs into OUT_DIR.
+          # Find it via cargo metadata / the known path under target/.
+          bundle=$(find "target/${{ matrix.rust-target }}/release/build" -name 'gitpress-runtime.tar.gz' | head -1)
+          if [ -z "$bundle" ] || [ ! -f "$bundle" ]; then
+            echo "FATAL: gitpress-runtime.tar.gz not found under target/" >&2
+            find "target/${{ matrix.rust-target }}" -name 'gitpress-runtime.tar.gz' || true
+            exit 1
+          fi
+          cp "$bundle" "$stage/gitpress-runtime.tar.gz"
+          cat > "$stage/README-gitpress.txt" <<EOF
+          gitpress ${{ steps.version.outputs.version }} (${{ matrix.os-tag }}-${{ matrix.arch-tag }})
+
+          Start a local site:
+            ./gitpress start
+
+          See branched-wp/README.md for details.
+          EOF
+          tar -C /tmp -czf "/tmp/${name}.tar.gz" "$name"
+          (cd /tmp && shasum -a 256 "${name}.tar.gz" > "${name}.sha256")
+          echo "tarball=/tmp/${name}.tar.gz" >> "$GITHUB_OUTPUT"
+          echo "checksum=/tmp/${name}.sha256" >> "$GITHUB_OUTPUT"
+
+      # On dry_run OR push: always upload as workflow artifact so the
+      # checksums job can pick them up. The release-attach happens in
+      # a separate step below.
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.version.outputs.artifact-name }}
+          path: |
+            /tmp/${{ steps.version.outputs.artifact-name }}.tar.gz
+            /tmp/${{ steps.version.outputs.artifact-name }}.sha256
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Attach to GitHub Release
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            /tmp/${{ steps.version.outputs.artifact-name }}.tar.gz
+          fail_on_unmatched_files: true
+
+  checksums:
+    name: checksums + release summary
+    needs: build
+    runs-on: ubuntu-24.04
+    if: always() && needs.build.result == 'success'
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Compose SHA256SUMS
+        id: compose
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          # Flatten: artifacts/<name>/<name>.tar.gz + <name>.sha256
+          find artifacts -name '*.tar.gz' -print
+          (cd artifacts && find . -name '*.tar.gz' -exec shasum -a 256 {} \;) \
+            | sed 's|\./[^/]*/|  |' \
+            > out/SHA256SUMS
+          cat out/SHA256SUMS
+          # Version tag for upload naming, same logic as the build job.
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=dry-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload SHA256SUMS as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SHA256SUMS
+          path: out/SHA256SUMS
+          retention-days: 14
+
+      - name: Attach SHA256SUMS to Release
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: out/SHA256SUMS
+          fail_on_unmatched_files: true

--- a/.github/workflows/branched-wp-release.yml
+++ b/.github/workflows/branched-wp-release.yml
@@ -2,9 +2,14 @@ name: branched-wp release
 
 # Release pipeline for the `gitpress` single-binary distribution of
 # branched-wp. Builds a per-platform self-contained tarball containing
-# a statically-linked PHP (via static-php-cli), a platform-matching Dolt
-# binary, the compiled `branchfs.so` PHP extension, and the bundled
-# WordPress source + vendored plugins.
+# a statically-linked PHP (via static-php-cli) with the `branchfs`
+# extension compiled directly into the binary, a platform-matching Dolt
+# binary, and the bundled WordPress source + vendored plugins.
+#
+# NOTE: branchfs used to ship as a separate branchfs.so loaded at
+# runtime, but static musl PHP is built without HAVE_LIBDL and so can't
+# dlopen any extension. branchfs is now a first-class spc extension —
+# see branched-wp/ci/spc-branchfs/ for the integration.
 #
 # Triggers:
 #   - push of a tag matching `v*` → full release upload to GitHub Releases.
@@ -34,10 +39,11 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # static-php-cli extension list. Keep in sync with README's "Supported
-  # extensions" note. Adding/removing extensions here invalidates the
-  # spc workdir cache (the extension list is part of the cache key).
-  SPC_EXTENSIONS: "mbstring,mysqli,pdo_mysql,sqlite3,pdo_sqlite,phar,tokenizer,fileinfo,filter,session"
+  # static-php-cli extension list. `branchfs` is our in-repo extension,
+  # compiled into the static PHP binary by spc (see
+  # branched-wp/ci/spc-branchfs/). Adding/removing entries invalidates
+  # the spc workdir cache (extension set is part of the cache key).
+  SPC_EXTENSIONS: "branchfs,mbstring,mysqli,pdo_mysql,sqlite3,pdo_sqlite,phar,tokenizer,fileinfo,filter,session"
   # Pin static-php-cli to a known-good ref. Bump manually when we want a
   # newer PHP minor or an spc fix.
   SPC_REF: "2.4.0"
@@ -119,14 +125,21 @@ jobs:
       # particular is not enabled everywhere yet). Pre-compute a stable
       # extension-set hash for the cache key — cache keys reject commas,
       # so we can't embed SPC_EXTENSIONS literally.
-      - name: Compute extension-set hash
+      - name: Compute extension-set + branchfs-source hash
         id: ext-hash
         shell: bash
         run: |
           set -euo pipefail
           # shasum is present on both Linux and macOS runners; sha256sum is
           # Linux-only. Both emit "<hex>  -" on stdin input.
-          h=$(printf '%s' "$SPC_EXTENSIONS" | shasum -a 256 | cut -c1-12)
+          # Include branchfs source files in the hash: they get compiled
+          # into the spc-built PHP, so a change must invalidate the cache.
+          h=$(
+            { printf '%s\n' "$SPC_EXTENSIONS"
+              shasum -a 256 ext/branchfs.c ext/branchfs.h ext/config.m4
+              shasum -a 256 ci/spc-branchfs/Branchfs.php ci/spc-branchfs/integrate.sh
+            } | shasum -a 256 | cut -c1-12
+          )
           echo "hash=$h" >> "$GITHUB_OUTPUT"
 
       - name: Cache static-php-cli workdir
@@ -152,14 +165,32 @@ jobs:
           cd static-php-cli
           composer install --no-dev --no-interaction
 
-      - name: Build static PHP + extensions
+      # Teach spc about our in-repo `branchfs` extension so it gets
+      # compiled *into* the static PHP binary (no runtime dlopen needed —
+      # musl-static PHP is built without HAVE_LIBDL and refuses to load
+      # external .so files). integrate.sh merges an entry into spc's
+      # config/ext.json and installs a Builder class that copies our
+      # branchfs.c/.h/config.m4 into source/php-src/ext/branchfs/ right
+      # before ./buildconf runs. Idempotent — safe on cache hit.
+      - name: Integrate branchfs into static-php-cli
+        shell: bash
+        run: |
+          set -euo pipefail
+          ci/spc-branchfs/integrate.sh .spc/static-php-cli
+
+      - name: Build static PHP + extensions (incl. branchfs)
         shell: bash
         # spc hits GitHub release assets + raw.githubusercontent for
         # pre-built libs. Shared runner IPs exhaust the 60 req/hr
         # unauthenticated limit quickly; GITHUB_TOKEN bumps that to
         # 5000 req/hr and is plumbed via spc/store/CurlHook.
+        #
+        # SPC_BRANCHFS_SOURCE tells our Builder class where to pull
+        # branchfs.c/.h/config.m4 from. Must be an absolute path
+        # because spc cd's between directories.
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          SPC_BRANCHFS_SOURCE: ${{ github.workspace }}/branched-wp/ext
         run: |
           set -euo pipefail
           cd .spc/static-php-cli
@@ -168,14 +199,24 @@ jobs:
           ./bin/spc doctor --auto-fix
           ./bin/spc download --with-php="${PHP_VERSION}" --for-extensions="${SPC_EXTENSIONS}" --prefer-pre-built
           ./bin/spc build "${SPC_EXTENSIONS}" --build-cli
-          # Sanity-check the built PHP runs and has all requested exts.
+          # Sanity-check the built PHP runs and has all requested exts,
+          # including branchfs (which lives in the binary, not a .so).
           ./buildroot/bin/php -v
+          ./buildroot/bin/php -m
           ./buildroot/bin/php -r 'foreach (explode(",", getenv("SPC_EXTENSIONS")) as $e) { if (!extension_loaded(trim($e))) { fwrite(STDERR, "missing: $e\n"); exit(1);} } echo "all extensions present\n";'
+          # Explicit branchfs assertion for log-scrapability.
+          if ! ./buildroot/bin/php -m | grep -qi '^branchfs$'; then
+            echo "FATAL: branchfs not in php -m output" >&2
+            ./buildroot/bin/php -m >&2
+            exit 1
+          fi
+          echo "branchfs statically built into PHP ✓"
 
       # ---------------------------------------------------------------
       # Stage the runtime directory that gitpress's build.rs consumes
-      # when GITPRESS_RUNTIME_DIR is set: runtime/bin/php, bin/dolt,
-      # lib/branchfs.so.
+      # when GITPRESS_RUNTIME_DIR is set: runtime/bin/php, bin/dolt.
+      # There's no lib/branchfs.so anymore — branchfs is compiled into
+      # the spc PHP binary above. See build.rs:build_runtime_bundle_from_dir.
       # ---------------------------------------------------------------
       - name: Stage runtime/bin/php
         shell: bash
@@ -200,40 +241,22 @@ jobs:
           chmod +x runtime/bin/dolt
           runtime/bin/dolt version
 
-      - name: Build ext/branchfs.so against static PHP
-        shell: bash
-        run: |
-          set -euo pipefail
-          # spc does NOT run `make install` inside source/php-src — it only
-          # cp's the final `php` binary to buildroot/bin/. So buildroot/
-          # contains the compiled PHP *executable* but NOT php-config or
-          # an installed include tree.
-          #
-          # Our Makefile can be driven purely by PHP_INCLUDE_DIR: given the
-          # top of the php-src tree, it derives all the -I flags our
-          # extension needs (main/, TSRM/, Zend/, ext/, ext/date/lib/).
-          # php_config.h lives under source/php-src/main/ after configure,
-          # so no `install-headers` round-trip is necessary.
-          PHP_SRC_DIR="$PWD/.spc/static-php-cli/source/php-src"
-          if [ ! -f "$PHP_SRC_DIR/main/php.h" ] || [ ! -f "$PHP_SRC_DIR/main/php_config.h" ]; then
-            echo "FATAL: PHP source tree not where expected ($PHP_SRC_DIR)" >&2
-            ls -la "$PHP_SRC_DIR/main" 2>/dev/null || true
-            find .spc/static-php-cli/source -maxdepth 3 -name 'php_config.h' 2>/dev/null || true
-            exit 1
-          fi
-          make clean
-          make PHP_CONFIG= PHP_INCLUDE_DIR="$PHP_SRC_DIR"
-          test -f ext/branchfs.so
-          cp ext/branchfs.so runtime/lib/branchfs.so
-
       # ---------------------------------------------------------------
-      # Unit suite — runs against the just-built static PHP + extension.
-      # Catches ABI drift between spc PHP and our extension.
+      # Unit suite — runs against the just-built static PHP which has
+      # branchfs statically compiled in. No separate ext/branchfs.so is
+      # built for the release path; the Makefile's .so build is kept
+      # only for local dev with a dynamically-linked Homebrew/apt PHP.
+      #
+      # BRANCHFS_BUILTIN=1 tells the Makefile to skip the
+      # `-d extension=$(CURDIR)/ext/branchfs.so` flag (redundant and
+      # noisy when branchfs is already in the PHP binary) and to drop
+      # the ext/branchfs.so build dependency for test targets.
       # ---------------------------------------------------------------
       - name: Unit tests (make test-all)
         shell: bash
         env:
           PHP: ${{ github.workspace }}/branched-wp/.spc/static-php-cli/buildroot/bin/php
+          BRANCHFS_BUILTIN: "1"
         run: |
           set -euo pipefail
           # Point make test-all at the spc-built PHP by overriding the
@@ -242,6 +265,7 @@ jobs:
           export PATH="$(dirname "$PHP_BIN"):$PATH"
           which php
           php -v
+          php -m | grep -i '^branchfs$'
           make test-all
 
       # ---------------------------------------------------------------
@@ -270,10 +294,11 @@ jobs:
         run: |
           set -euo pipefail
           # Preflight: confirm the bundled binaries actually execute and
-          # the extension loads. Fails fast with a clear message rather
-          # than a confusing dev.sh timeout.
-          "$BUNDLED_PHP" -d "extension=$PWD/runtime/lib/branchfs.so" -r \
-            'if(!extension_loaded("branchfs")){fwrite(STDERR,"branchfs.so did not load\n");exit(1);} echo "branchfs loaded\n";'
+          # branchfs is statically present in the PHP binary. dev.sh
+          # auto-detects via `php -m` and skips the -d extension flag
+          # when branchfs is already loaded.
+          "$BUNDLED_PHP" -r \
+            'if(!extension_loaded("branchfs")){fwrite(STDERR,"branchfs not built into PHP\n");exit(1);} echo "branchfs statically present\n";'
           "$BUNDLED_DOLT" version
           # Start the dev stack with bundled binaries only. dev.sh
           # respects PHP_BIN and DOLT env vars.

--- a/.github/workflows/branched-wp-release.yml
+++ b/.github/workflows/branched-wp-release.yml
@@ -127,6 +127,18 @@ jobs:
       #   spc-<target>-<php>-<spc ref>-<extensions>
       # Any change to SPC_EXTENSIONS or SPC_REF invalidates. Per-target
       # because the artifacts inside buildroot/ are platform-specific.
+      # Cancel early if the runner isn't available (macos-15-intel in
+      # particular is not enabled everywhere yet). Pre-compute a stable
+      # extension-set hash for the cache key — cache keys reject commas,
+      # so we can't embed SPC_EXTENSIONS literally.
+      - name: Compute extension-set hash
+        id: ext-hash
+        shell: bash
+        run: |
+          set -euo pipefail
+          h=$(printf '%s' "$SPC_EXTENSIONS" | sha256sum | cut -c1-12)
+          echo "hash=$h" >> "$GITHUB_OUTPUT"
+
       - name: Cache static-php-cli workdir
         id: spc-cache
         uses: actions/cache@v4
@@ -135,7 +147,7 @@ jobs:
             branched-wp/.spc/downloads
             branched-wp/.spc/source
             branched-wp/.spc/buildroot
-          key: spc-${{ matrix.os-tag }}-${{ matrix.arch-tag }}-php${{ env.PHP_VERSION }}-spc${{ env.SPC_REF }}-${{ hashFiles('branched-wp/.github/spc-extensions.txt') }}-${{ env.SPC_EXTENSIONS }}
+          key: spc-${{ matrix.os-tag }}-${{ matrix.arch-tag }}-php${{ env.PHP_VERSION }}-spc${{ env.SPC_REF }}-ext${{ steps.ext-hash.outputs.hash }}
 
       - name: Install static-php-cli
         shell: bash

--- a/.github/workflows/branched-wp-release.yml
+++ b/.github/workflows/branched-wp-release.yml
@@ -312,6 +312,13 @@ jobs:
 
       - name: Run e2e smoke (test_sqlite_clone_minimal.sh)
         shell: bash
+        # Hard cap: this step has hung indefinitely in earlier iterations
+        # when `git clone` over the dev stack stalled. A per-step timeout
+        # gives us a real error message and releases the runner instead
+        # of burning 6h on one stuck job. 15 min is generous — a clean
+        # run does dev.sh (~30s) + git clone (~60-120s per LIMITATIONS)
+        # + WP boot probe (~30s) well within that budget.
+        timeout-minutes: 15
         env:
           BUNDLED_PHP: ${{ github.workspace }}/branched-wp/runtime/bin/php
           BUNDLED_DOLT: ${{ github.workspace }}/branched-wp/runtime/bin/dolt
@@ -352,11 +359,22 @@ jobs:
             tail -80 /tmp/dev.log >&2
             exit 1
           fi
-          # Run the minimal test.
+          # Run the minimal test. Wrap with a portable 300s timeout so a
+          # hung `git clone` against the dev stack surfaces as a clean
+          # timeout + log dump rather than a stuck job. `timeout(1)`
+          # isn't in macOS coreutils by default; use perl alarm which
+          # exists on both runner images.
           set +e
-          PHP_BIN="$BUNDLED_PHP" bash e2e/test_sqlite_clone_minimal.sh
+          perl -e 'use POSIX; alarm shift; exec @ARGV; die "exec:$!"' \
+            300 env PHP_BIN="$BUNDLED_PHP" bash e2e/test_sqlite_clone_minimal.sh
           rc=$?
           set -e
+          # perl with alarm exits 142 (128 + SIGALRM=14); coreutils
+          # timeout exits 124. Dump logs on either signature.
+          if [ "$rc" -eq 142 ] || [ "$rc" -eq 124 ]; then
+            echo "=== e2e test timed out (>300s) — dev.log tail ===" >&2
+            tail -120 /tmp/dev.log >&2 || true
+          fi
           # Shut down dev stack.
           kill -TERM "$DEV_PID" 2>/dev/null || true
           wait "$DEV_PID" 2>/dev/null || true

--- a/.github/workflows/branched-wp-release.yml
+++ b/.github/workflows/branched-wp-release.yml
@@ -335,9 +335,7 @@ jobs:
           # respects PHP_BIN and DOLT env vars.
           export PHP_BIN="$BUNDLED_PHP"
           export DOLT="$BUNDLED_DOLT"
-          # Background dev.sh (nohup + redirect so the shell doesn't
-          # hold it open). The cleanup trap in dev.sh kills its
-          # children on SIGTERM, which we'll send at the end.
+          # Background dev.sh so the shell doesn't hold it open.
           nohup bash e2e/dev.sh > /tmp/dev.log 2>&1 &
           DEV_PID=$!
           echo "dev.sh PID=$DEV_PID"
@@ -375,9 +373,25 @@ jobs:
             echo "=== e2e test timed out (>300s) — dev.log tail ===" >&2
             tail -120 /tmp/dev.log >&2 || true
           fi
-          # Shut down dev stack.
+          # Shut down dev stack. dev.sh ends in `tail -f php-server.log`,
+          # which means bash's TERM trap is deferred until the current
+          # foreground command returns — and `tail -f` never does. So
+          # `wait $DEV_PID` after a plain SIGTERM would block forever
+          # (previously burned ~2h of runner time before cancellation).
+          # Kill the tail -f child first so bash's trap can fire, then
+          # SIGTERM the shell itself, then SIGKILL anything left. We
+          # deliberately skip `wait` — the job-level timeout-minutes:15
+          # is the outer safety net.
+          pkill -P "$DEV_PID" -x tail 2>/dev/null || true
           kill -TERM "$DEV_PID" 2>/dev/null || true
-          wait "$DEV_PID" 2>/dev/null || true
+          for _ in 1 2 3 4 5; do
+            kill -0 "$DEV_PID" 2>/dev/null || break
+            sleep 1
+          done
+          kill -KILL "$DEV_PID" 2>/dev/null || true
+          # Mop up any surviving dev-stack children (dolt, php -S).
+          pkill -f 'dolt sql-server.*--port=13306' 2>/dev/null || true
+          pkill -f 'php.*18080' 2>/dev/null || true
           exit "$rc"
 
       # ---------------------------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.adversarial-loop/

--- a/branched-wp/.gitignore
+++ b/branched-wp/.gitignore
@@ -9,3 +9,6 @@ e2e/dolt-data/
 e2e/*.db
 /target/
 /.gitpress/
+/.spc/
+/runtime/
+/dist/

--- a/branched-wp/BUILDING.md
+++ b/branched-wp/BUILDING.md
@@ -1,0 +1,350 @@
+# Building `gitpress` from source
+
+This document walks through producing a release-style `gitpress` tarball
+on your own machine. You want this if:
+
+1. The platform you're on isn't covered by a pre-built release (today:
+   only `linux-x86_64` has a pre-built artifact — macOS builds are
+   reproducible from here while the CI pipeline for the full matrix
+   remains unfinished).
+2. You want to audit the build against the source you see in the repo.
+3. You're iterating on `ext/branchfs.c`, the gitpress launcher, or the
+   spc integration, and want to smoke-test end-to-end locally.
+
+The same pipeline runs in CI — see
+`.github/workflows/branched-wp-release.yml` for the per-target matrix
+version. What you're doing here is the single-platform, one-host-at-a-time
+version of that.
+
+## TL;DR for macOS
+
+```bash
+# From this repo's root, on a Mac with Homebrew already installed.
+brew install php composer git jq rust dolt      # ~2-3 min
+cd branched-wp
+bash BUILDING.sh                                 # ~20-40 min on cold cache
+# ↳ produces: dist/gitpress-<version>-macos-<arch>.tar.gz
+#             dist/SHA256SUMS
+```
+
+The rest of this doc explains what that script does and how to run the
+pieces by hand if it breaks.
+
+## Supported host platforms
+
+| Host | Target this builds | Status |
+| --- | --- | --- |
+| Linux x86_64 (any distro with a working toolchain) | `linux-x86_64` | Shipped |
+| macOS x86_64 (Intel) | `macos-x86_64` | Reproducible from source |
+| macOS aarch64 (Apple Silicon) | `macos-aarch64` | Reproducible from source |
+| Linux aarch64 | `linux-aarch64` | Should work; untested |
+| Windows | — | Not supported. See `LIMITATIONS.md`. |
+
+You always build for the host you're on — there's no cross-compile step.
+`static-php-cli` produces a native binary for the machine it runs on.
+
+## What the build actually does
+
+1. Clone a pinned revision of
+   [`static-php-cli`](https://github.com/crazywhalecc/static-php-cli)
+   ("spc") into `branched-wp/.spc/static-php-cli/`.
+2. Run `ci/spc-branchfs/integrate.sh` against that checkout. This
+   teaches spc about `branchfs` as a first-class built-in extension
+   (registers it in `config/ext.json` as `type: "builtin"` and drops a
+   one-file `Extension` subclass into `src/SPC/builder/extension/`).
+3. Run spc's `doctor` / `download` / `build` flow. spc downloads PHP
+   source + every extension's dependency (SQLite, libxml, zlib, …) and
+   builds a fully statically-linked `php` binary with branchfs and the
+   standard WP extension set compiled in.
+4. Download the matching Dolt binary for the host platform.
+5. Stage `runtime/{bin/php, bin/dolt}` with those two binaries. No
+   `lib/branchfs.so` — branchfs is inside the `php` binary.
+6. Run `GITPRESS_RUNTIME_DIR=$PWD/runtime cargo build --release -p gitpress
+   --target <host-triple>` to produce the launcher. The launcher embeds
+   the runtime tarball via `include_bytes!`, so the resulting binary is
+   ~100 MB but fully self-contained.
+7. Package the launcher + a README into a tarball and emit a
+   `SHA256SUMS` file next to it.
+
+## Prerequisites
+
+### All hosts
+
+- `git` (any modern version)
+- `rustup` + a Rust stable toolchain (≥ 1.80). Install via
+  <https://rustup.rs>. After install, run:
+  ```bash
+  rustup target add x86_64-unknown-linux-musl   # on Linux x86_64
+  rustup target add aarch64-unknown-linux-musl  # on Linux aarch64
+  # macOS: the default host target is fine; no `rustup target add` needed.
+  ```
+- `jq` (for the integrate.sh script)
+- `curl` + `tar`
+- `python3` (integrate.sh uses it to merge one JSON entry)
+- A working C compiler + autotools + `pkg-config` (for spc's builds)
+- **PHP 8.2+** and **composer** on the host — needed *only* to run the
+  spc CLI. The release PHP binary is built from source by spc; your
+  host PHP is just the interpreter that runs spc's PHP-based build
+  driver.
+- **Dolt** — `curl -sL https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash`
+  is the one-liner. On macOS, `brew install dolt` also works.
+
+### macOS-specific
+
+```bash
+# Xcode command-line tools (compiler + headers)
+xcode-select --install
+
+# Everything else via Homebrew
+brew install php composer git jq rust dolt pkg-config autoconf automake libtool
+```
+
+spc's `./bin/spc doctor --auto-fix` will auto-install anything missing
+via Homebrew on macOS — safe to run even if you skip the manual
+install above.
+
+### Linux-specific
+
+On Debian/Ubuntu:
+```bash
+sudo apt-get install -y build-essential autoconf automake libtool pkg-config \
+                        php-cli composer git curl jq python3
+# Rust + Dolt as above.
+```
+
+On NixOS, wrap the whole build in a `nix-shell -p ...` with the above
+packages. spc's `doctor --auto-fix` will fail to install anything
+system-wide (NixOS doesn't do that), but as long as the compiler +
+autotools are present in the shell, spc's own build steps don't need
+anything else.
+
+## Step-by-step build
+
+Run all commands from `branched-wp/` (this directory).
+
+### 1. Clone spc at the pinned ref
+
+```bash
+SPC_REF="2.4.0"   # keep in sync with .github/workflows/branched-wp-release.yml
+mkdir -p .spc
+git clone --depth 1 --branch "$SPC_REF" \
+  https://github.com/crazywhalecc/static-php-cli.git .spc/static-php-cli
+(cd .spc/static-php-cli && composer install --no-dev --no-interaction)
+```
+
+### 2. Register branchfs with spc
+
+```bash
+bash ci/spc-branchfs/integrate.sh .spc/static-php-cli
+```
+
+This is idempotent — safe to re-run. It adds one entry to spc's
+`config/ext.json` and installs one PHP class file. Nothing outside
+`.spc/static-php-cli/` is touched.
+
+### 3. Build static PHP + extensions
+
+```bash
+cd .spc/static-php-cli
+
+# Set by Branchfs.php::patchBeforeBuildconf() to locate branchfs.c/.h/config.m4
+export SPC_BRANCHFS_SOURCE="$(pwd)/../../ext"
+
+# Fetches all source tarballs (PHP, extensions, deps). Cached under
+# .spc/static-php-cli/downloads/ — re-running is fast.
+./bin/spc doctor --auto-fix
+./bin/spc download \
+  --with-php=8.2 \
+  --for-extensions="branchfs,mbstring,mysqli,pdo_mysql,sqlite3,pdo_sqlite,phar,tokenizer,fileinfo,filter,session"
+
+# The slow step — 15-40 minutes on a cold cache. Subsequent builds are
+# ~2 min (incremental compile via ccache if present).
+./bin/spc build \
+  "branchfs,mbstring,mysqli,pdo_mysql,sqlite3,pdo_sqlite,phar,tokenizer,fileinfo,filter,session" \
+  --build-cli
+
+cd ../..   # back to branched-wp/
+```
+
+Sanity-check the resulting PHP:
+
+```bash
+./.spc/static-php-cli/buildroot/bin/php --version
+./.spc/static-php-cli/buildroot/bin/php -m | grep -i branchfs
+./.spc/static-php-cli/buildroot/bin/php -r \
+  'var_dump(extension_loaded("branchfs"));'     # → bool(true), NO -d extension= flag
+```
+
+If `branchfs` isn't in `-m`, the integrate.sh step didn't take — re-run
+step 2 and try step 3 again. Open an issue against the repo if it
+persistently fails.
+
+### 4. Fetch the matching Dolt binary
+
+```bash
+# Linux x86_64:
+curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/dolt-linux-amd64.tar.gz \
+  -o /tmp/dolt.tgz
+# macOS aarch64:
+# curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/dolt-darwin-arm64.tar.gz \
+#   -o /tmp/dolt.tgz
+# macOS x86_64:
+# curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/dolt-darwin-amd64.tar.gz \
+#   -o /tmp/dolt.tgz
+
+mkdir -p /tmp/dolt-unpack
+tar -xzf /tmp/dolt.tgz -C /tmp/dolt-unpack
+# Archive contains <archive>/bin/dolt — copy it out.
+```
+
+### 5. Stage runtime/
+
+```bash
+mkdir -p runtime/bin runtime/lib
+cp .spc/static-php-cli/buildroot/bin/php runtime/bin/php
+chmod +x runtime/bin/php
+# Paste the right dolt path for your platform here:
+cp /tmp/dolt-unpack/*/bin/dolt runtime/bin/dolt
+chmod +x runtime/bin/dolt
+# No runtime/lib/branchfs.so — branchfs is compiled into php.
+```
+
+### 6. Build gitpress
+
+```bash
+# On Linux (static musl):
+export RUST_TARGET="$(uname -m)-unknown-linux-musl"
+# On macOS (native):
+# export RUST_TARGET="$(uname -m)-apple-darwin"
+
+GITPRESS_RUNTIME_DIR="$PWD/runtime" \
+  cargo build --release -p gitpress --target "$RUST_TARGET"
+```
+
+### 7. Package the release tarball
+
+```bash
+VERSION="0.1.0-rc1"       # or whatever you're cutting
+ARCH="$(uname -m)"
+# Map host OS to the release naming convention:
+case "$(uname -s)" in
+  Linux)  OS=linux ;;
+  Darwin) OS=macos ;;
+  *) echo "unsupported host"; exit 1 ;;
+esac
+NAME="gitpress-${VERSION}-${OS}-${ARCH}"
+
+STAGE="/tmp/${NAME}"
+rm -rf "$STAGE"
+mkdir -p "$STAGE"
+cp "target/${RUST_TARGET}/release/gitpress" "$STAGE/gitpress"
+chmod +x "$STAGE/gitpress"
+cat > "$STAGE/README.txt" <<EOF
+gitpress ${VERSION} — ${OS}-${ARCH} (statically linked)
+
+Single self-contained binary. Extracts its embedded runtime (static PHP
++ Dolt + WordPress + branchfs + SQLite integration plugin) to
+~/.gitpress/runtime/ on first run.
+
+Usage:
+  ./gitpress start                  # launch dev stack on :18080
+  ./gitpress branch create <name>   # create a preview branch
+  ./gitpress branch list
+  ./gitpress --help
+
+Homepage: http://localhost:18080/ (Host: wp.localhost)
+Admin:    http://localhost:18080/wp-login.php  (admin / admin)
+
+Full docs: https://github.com/adamziel/experiments/tree/main/branched-wp
+EOF
+
+mkdir -p dist
+tar -C /tmp -czf "dist/${NAME}.tar.gz" "$NAME"
+(cd dist && shasum -a 256 "${NAME}.tar.gz" > "SHA256SUMS.${NAME}.txt")
+
+echo "Built: dist/${NAME}.tar.gz"
+ls -lh "dist/${NAME}.tar.gz"
+```
+
+### 8. Verify (optional but recommended)
+
+Extract the tarball somewhere clean and smoke-test:
+
+```bash
+mkdir -p /tmp/verify && cd /tmp/verify
+tar xzf "/path/to/dist/${NAME}.tar.gz"
+./${NAME}/gitpress --help
+./${NAME}/gitpress start &
+# Wait ~30s for the runtime to extract on first run, then:
+curl -sf -H "Host: wp.localhost" http://127.0.0.1:18080/ | grep -oE '<title>[^<]+</title>'
+# Expect: <title>Branched WP Dev</title>
+kill %1
+```
+
+## Disk + time budget
+
+- Cold `spc build`: 15–40 min, depending on CPU. 4–8 GB of peak disk
+  under `.spc/static-php-cli/{downloads,source,buildroot}`.
+- Cargo build: ~1 min cold, ~10 s incremental.
+- Total: **~20–45 min cold, ~3 min warm**.
+- Resulting tarball: **~100 MB**. The `gitpress` binary embeds the whole
+  runtime via `include_bytes!`; the tarball is just the binary +
+  README.
+
+After a successful build you can safely delete
+`.spc/static-php-cli/source/` and `.spc/static-php-cli/downloads/`
+(~2–3 GB) if disk is tight. Keep `.spc/static-php-cli/buildroot/` if
+you want warm-cache rebuilds.
+
+## Troubleshooting
+
+### spc `doctor` fails on NixOS
+
+NixOS can't install packages system-wide via `apt`/`brew`. Run the
+build inside a `nix-shell` that already has the toolchain:
+
+```bash
+nix-shell -p gcc autoconf automake libtool pkg-config php82 composer git curl jq python3
+```
+
+Then the `doctor --auto-fix` step will still try to run but will only
+patch things that work on NixOS (e.g. it won't try `apt install`).
+
+### `branchfs` missing from `php -m`
+
+Either `integrate.sh` didn't run against the right spc checkout, or
+the SPC_BRANCHFS_SOURCE env var wasn't set when you ran `spc build`.
+Both are required. Re-run step 2, then re-run step 3 with the env var
+exported.
+
+### macOS: linker errors about missing `-liconv`, `-lresolv`, etc.
+
+spc's build matrix usually handles these; if you hit one, run
+`./bin/spc doctor --auto-fix` again to pull in whatever it's missing.
+
+### Disk fills up during build
+
+Between attempts, run:
+```bash
+rm -rf .spc/static-php-cli/source .spc/static-php-cli/downloads
+```
+to reclaim ~2–3 GB. `buildroot/` has the final binary; don't touch it
+unless you want a full rebuild.
+
+## Shipping your build
+
+Once `dist/${NAME}.tar.gz` exists:
+
+1. Upload it as an asset on an existing GitHub Release (typically the
+   release for the tag that matches `VERSION`):
+   ```bash
+   gh release upload "v${VERSION}" \
+     "dist/${NAME}.tar.gz" "dist/SHA256SUMS.${NAME}.txt" \
+     --repo adamziel/experiments
+   ```
+2. Append your `SHA256SUMS.${NAME}.txt` contents to the aggregated
+   `SHA256SUMS` file on the Release if one exists, or upload it
+   alongside as its own file.
+3. Post a comment on the originating PR (or the Release discussion)
+   with the platform you built for, the spc ref, and the git SHA —
+   otherwise no one can reproduce your artifact.

--- a/branched-wp/LIMITATIONS.md
+++ b/branched-wp/LIMITATIONS.md
@@ -174,10 +174,10 @@ or use `curl -H "Host: <branch>.wp.localhost"`.
 
 ## OS / runtime assumptions
 
-### Supported tier-1 targets
+### Supported tier-1 targets (design — **not yet validated on CI**)
 
-The release pipeline (`.github/workflows/branched-wp-release.yml`) builds
-and smoke-tests the `gitpress` bundle on these platforms for every tag:
+The release pipeline (`.github/workflows/branched-wp-release.yml`)
+targets these four platforms for every tag:
 
 | OS | Arch | Libc | Dolt build |
 | --- | --- | --- | --- |
@@ -191,6 +191,35 @@ and smoke-tests the `gitpress` bundle on these platforms for every tag:
 Darwin. On macOS the `Makefile` switches the linker to produce a
 `-bundle` with `-undefined dynamic_lookup` so undefined PHP/Zend
 symbols resolve at `dlopen()` time.
+
+**Open release-pipeline blocker** — a dry-run of the workflow
+(`gh run view 24540532531 --repo adamziel/experiments`, linux-aarch64
+leg) confirmed that spc's PHP is a fully-static musl binary built
+without `HAVE_LIBDL`, so it refuses to `dlopen()` external extensions
+with the PHP-core error:
+
+```
+PHP Startup: Unable to load dynamic library 'branchfs.so'
+(Dynamic loading not supported)
+```
+
+`--no-strip` preserves debug symbols but doesn't restore `dl` support —
+this is a configure-time decision spc makes for musl static builds.
+
+Candidate resolutions (see PR #17 discussion):
+
+1. **Compile branchfs *into* spc's PHP build** as a first-class static
+   extension. Teach spc about `branchfs` via a fork or
+   `config/ext.json` overlay, copy `ext/*.c` into
+   `source/php-src/ext/branchfs/` before the build step, and drop
+   `-d extension=...` from every entrypoint. This is the architecture
+   spc was designed for.
+2. **Abandon spc**, use `shivammathur/setup-php` for a dynamically-
+   linked PHP on each runner, and capture the shared-lib closure via
+   gitpress's existing `build_runtime_bundle()` path (ldd on Linux,
+   `otool -L` on macOS — the macOS branch doesn't exist yet).
+3. **Hybrid**: spc for macOS (where static bundles can dlopen via
+   dyld), setup-php + closure for Linux.
 
 Other Unix-likes (FreeBSD, OpenBSD, Solaris-family) *should* work in
 theory but aren't part of CI; run at your own risk.

--- a/branched-wp/LIMITATIONS.md
+++ b/branched-wp/LIMITATIONS.md
@@ -190,36 +190,18 @@ targets these four platforms for every tag:
 `<sys/stat.h>`, `<dirent.h>`) available on Linux (glibc + musl) and
 Darwin. On macOS the `Makefile` switches the linker to produce a
 `-bundle` with `-undefined dynamic_lookup` so undefined PHP/Zend
-symbols resolve at `dlopen()` time.
+symbols resolve at `dlopen()` time — but only in local-dev mode.
 
-**Open release-pipeline blocker** — a dry-run of the workflow
-(`gh run view 24540532531 --repo adamziel/experiments`, linux-aarch64
-leg) confirmed that spc's PHP is a fully-static musl binary built
-without `HAVE_LIBDL`, so it refuses to `dlopen()` external extensions
-with the PHP-core error:
-
-```
-PHP Startup: Unable to load dynamic library 'branchfs.so'
-(Dynamic loading not supported)
-```
-
-`--no-strip` preserves debug symbols but doesn't restore `dl` support —
-this is a configure-time decision spc makes for musl static builds.
-
-Candidate resolutions (see PR #17 discussion):
-
-1. **Compile branchfs *into* spc's PHP build** as a first-class static
-   extension. Teach spc about `branchfs` via a fork or
-   `config/ext.json` overlay, copy `ext/*.c` into
-   `source/php-src/ext/branchfs/` before the build step, and drop
-   `-d extension=...` from every entrypoint. This is the architecture
-   spc was designed for.
-2. **Abandon spc**, use `shivammathur/setup-php` for a dynamically-
-   linked PHP on each runner, and capture the shared-lib closure via
-   gitpress's existing `build_runtime_bundle()` path (ldd on Linux,
-   `otool -L` on macOS — the macOS branch doesn't exist yet).
-3. **Hybrid**: spc for macOS (where static bundles can dlopen via
-   dyld), setup-php + closure for Linux.
+The release pipeline compiles branchfs *into* the static PHP binary
+as a first-class static-php-cli extension (see
+`branched-wp/ci/spc-branchfs/`) — musl-static PHP is built without
+`HAVE_LIBDL`, so `dlopen()`-based loading of an external `.so` is
+impossible on the Linux legs. The builtin approach sidesteps that
+entirely and also removes an extra file from the shipped bundle.
+The Makefile's `.so` build and `-d extension=...` entrypoints are
+retained for local development with a dynamically-linked Homebrew /
+apt PHP; `e2e/dev.sh` and the test harness auto-detect which mode
+is in effect.
 
 Other Unix-likes (FreeBSD, OpenBSD, Solaris-family) *should* work in
 theory but aren't part of CI; run at your own risk.

--- a/branched-wp/LIMITATIONS.md
+++ b/branched-wp/LIMITATIONS.md
@@ -174,10 +174,53 @@ or use `curl -H "Host: <branch>.wp.localhost"`.
 
 ## OS / runtime assumptions
 
-### Linux + glibc only
+### Supported tier-1 targets
 
-The extension uses `fnmatch(3)` and `realpath(3)` from glibc. Not tested
-on musl (Alpine) or macOS.
+The release pipeline (`.github/workflows/branched-wp-release.yml`) builds
+and smoke-tests the `gitpress` bundle on these platforms for every tag:
+
+| OS | Arch | Libc | Dolt build |
+| --- | --- | --- | --- |
+| Linux | x86_64  | musl (static) | `dolt-linux-amd64` |
+| Linux | aarch64 | musl (static) | `dolt-linux-arm64` |
+| macOS | x86_64  | Apple libSystem | `dolt-darwin-amd64` |
+| macOS | aarch64 | Apple libSystem | `dolt-darwin-arm64` |
+
+`ext/branchfs.c` uses only POSIX APIs (`fnmatch(3)`, `realpath(3)`,
+`<sys/stat.h>`, `<dirent.h>`) available on Linux (glibc + musl) and
+Darwin. On macOS the `Makefile` switches the linker to produce a
+`-bundle` with `-undefined dynamic_lookup` so undefined PHP/Zend
+symbols resolve at `dlopen()` time.
+
+Other Unix-likes (FreeBSD, OpenBSD, Solaris-family) *should* work in
+theory but aren't part of CI; run at your own risk.
+
+### Windows: not yet supported
+
+The branchfs C extension, its Makefile, and the gitpress packaging
+don't target Windows. Port blockers:
+
+- **No native `fnmatch(3)`.** Windows CRT doesn't expose it; we'd
+  need to vendor a BSD-licensed polyfill (e.g. from musl or the
+  Android Bionic tree).
+- **`realpath(3)` vs `_fullpath` / `GetFullPathNameW`.** Semantics
+  differ (symlink resolution, case folding, drive-letter roots). The
+  wrapper that overrides PHP's `realpath()` would need a Windows
+  branch that translates between POSIX-shaped virtual paths and
+  Windows canonicalization.
+- **Build system divergence.** PHP on Windows uses MSVC + a
+  `phpize`-less `configure.js` / `config.w32` pipeline. Our current
+  `config.m4` + glibc-friendly `Makefile` can't be retargeted with a
+  cross-compiler; a separate MSBuild/NMake config needs to be
+  written.
+- **Path separator + case-insensitive semantics.** The overlay
+  assumes forward slashes and case-sensitive lookups; both
+  assumptions are baked into the SQLite `files` table layout and the
+  `branchfs://` URL parser. A real port would need a compatibility
+  layer in `store_*` and everywhere `"/"` is used as a separator.
+
+Tracking placeholder: `WP_BRANCHED_WINDOWS_ISSUE` — no GitHub issue
+is filed yet; search for this string when one is opened.
 
 ### PHP 8.2 only
 

--- a/branched-wp/Makefile
+++ b/branched-wp/Makefile
@@ -7,6 +7,16 @@
 
 UNAME_S := $(shell uname -s)
 
+# BRANCHFS_BUILTIN=1 means the target PHP already has branchfs statically
+# linked in (spc-built release binary). We don't build ext/branchfs.so in
+# that mode, so no PHP headers / sqlite dev libs are needed — skip all
+# the detection that would otherwise $(error) out on hosts that only
+# have the static PHP (NixOS, macOS CI runners where Homebrew PHP isn't
+# installed, etc.). Local dev on Linux/macOS with Homebrew/apt PHP keeps
+# the detection path.
+PHP_EXTRA_INCS  :=
+
+ifneq ($(BRANCHFS_BUILTIN),1)
 PHP_CONFIG ?= $(shell command -v php-config 2>/dev/null || command -v php-config8.2 2>/dev/null)
 PKG_CONFIG ?= $(shell command -v pkg-config 2>/dev/null)
 
@@ -15,7 +25,6 @@ SQLITE_INC  ?= $(firstword $(wildcard /nix/store/*-sqlite-*-dev/include))
 SQLITE_LIB  ?= $(firstword $(filter-out /nix/store/*-sqlite-*-dev/lib,$(wildcard /nix/store/*-sqlite-*/lib)))
 
 PHP_INCLUDE_DIR ?= $(if $(PHP_CONFIG),$(shell $(PHP_CONFIG) --include-dir 2>/dev/null))
-PHP_EXTRA_INCS  :=
 
 ifneq ($(strip $(PHP_INCLUDE_DIR)),)
 PHP_EXTRA_INCS += -I$(PHP_INCLUDE_DIR) \
@@ -32,7 +41,8 @@ PHP_EXTRA_INCS += -I$(PHP_DEV_DIR)/include/php \
                   -I$(PHP_DEV_DIR)/include/php/ext \
                   -I$(PHP_DEV_DIR)/include/php/ext/date/lib
 else
-$(error Could not determine PHP headers. Install php-config or set PHP_DEV_DIR)
+$(error Could not determine PHP headers. Install php-config or set PHP_DEV_DIR (or pass BRANCHFS_BUILTIN=1 if building against a PHP that already has branchfs statically linked))
+endif
 endif
 
 SQLITE_CFLAGS ?= $(if $(PKG_CONFIG),$(shell $(PKG_CONFIG) --cflags sqlite3 2>/dev/null))

--- a/branched-wp/Makefile
+++ b/branched-wp/Makefile
@@ -1,5 +1,11 @@
 # Portable by default: detect PHP + SQLite via php-config and pkg-config.
 # If those tools are unavailable, fall back to Nix-style dev outputs when present.
+#
+# Cross-platform: Linux (glibc + musl) and macOS. PHP extensions are named
+# `branchfs.so` on every platform, including Darwin — PHP's module loader
+# uses that name verbatim regardless of host conventions.
+
+UNAME_S := $(shell uname -s)
 
 PHP_CONFIG ?= $(shell command -v php-config 2>/dev/null || command -v php-config8.2 2>/dev/null)
 PKG_CONFIG ?= $(shell command -v pkg-config 2>/dev/null)
@@ -43,12 +49,61 @@ ifeq ($(strip $(SQLITE_LIBS)),)
 SQLITE_LIBS := -lsqlite3
 endif
 
+# macOS: Homebrew ships sqlite3 headers at $(brew --prefix sqlite3)/include.
+# pkg-config picks those up when PKG_CONFIG_PATH is set; otherwise fall back
+# to the standard Homebrew layout so the build works out of the box.
+ifeq ($(UNAME_S),Darwin)
+BREW_SQLITE_PREFIX ?= $(shell brew --prefix sqlite3 2>/dev/null)
+ifneq ($(strip $(BREW_SQLITE_PREFIX)),)
+ifeq ($(strip $(SQLITE_CFLAGS)),)
+SQLITE_CFLAGS := -I$(BREW_SQLITE_PREFIX)/include
+endif
+ifeq ($(strip $(SQLITE_LIBS)),-lsqlite3)
+SQLITE_LIBS := -L$(BREW_SQLITE_PREFIX)/lib -lsqlite3
+endif
+endif
+endif
+
 CC      ?= gcc
-CFLAGS  := -fPIC -shared -O2 -Wall -DCOMPILE_DL_BRANCHFS -DHAVE_CONFIG_H=0 $(SQLITE_CFLAGS)
+
+# Platform-specific link flags. PHP extensions are loaded into the PHP
+# binary at runtime, so all Zend/PHP symbols are "undefined" at link time
+# and must be resolved from the host process.
+#   - Linux: the dynamic linker resolves undefined symbols from the main
+#     executable by default (RTLD_GLOBAL behavior for -rdynamic binaries),
+#     so `-shared` alone is enough.
+#   - macOS: ld64 is strict; we need `-undefined dynamic_lookup` to defer
+#     resolution of PHP symbols to load time. We also use `-bundle` instead
+#     of `-dynamiclib` — PHP's DL loader uses dlopen(), which accepts
+#     either, but `-bundle` is conventionally what `phpize` emits on Darwin.
+ifeq ($(UNAME_S),Darwin)
+SHLIB_FLAGS := -bundle -undefined dynamic_lookup
+else
+SHLIB_FLAGS := -shared
+endif
+
+CFLAGS  := -fPIC $(SHLIB_FLAGS) -O2 -Wall -DCOMPILE_DL_BRANCHFS -DHAVE_CONFIG_H=0 $(SQLITE_CFLAGS)
 INCLUDES := $(PHP_EXTRA_INCS)
 LDFLAGS := $(SQLITE_LIBS)
 RUSTUP ?= $(shell command -v rustup 2>/dev/null)
-GITPRESS_TARGET ?= x86_64-unknown-linux-musl
+
+# Default Rust target follows the host OS + arch so `make gitpress` works
+# out of the box on all four supported CI targets.
+UNAME_M := $(shell uname -m)
+ifeq ($(UNAME_S),Darwin)
+    ifeq ($(UNAME_M),arm64)
+        DEFAULT_GITPRESS_TARGET := aarch64-apple-darwin
+    else
+        DEFAULT_GITPRESS_TARGET := x86_64-apple-darwin
+    endif
+else
+    ifeq ($(UNAME_M),aarch64)
+        DEFAULT_GITPRESS_TARGET := aarch64-unknown-linux-musl
+    else
+        DEFAULT_GITPRESS_TARGET := x86_64-unknown-linux-musl
+    endif
+endif
+GITPRESS_TARGET ?= $(DEFAULT_GITPRESS_TARGET)
 
 .PHONY: all clean test test-compat init-db test-all gitpress
 

--- a/branched-wp/Makefile
+++ b/branched-wp/Makefile
@@ -107,30 +107,44 @@ GITPRESS_TARGET ?= $(DEFAULT_GITPRESS_TARGET)
 
 .PHONY: all clean test test-compat init-db test-all gitpress
 
+# BRANCHFS_BUILTIN=1 means the `php` we run already has branchfs
+# statically linked in (release path: static-php-cli builds branchfs
+# into the PHP binary). Skip the `-d extension=...` flag (PHP would
+# refuse to re-load an already-loaded module) and drop the
+# ext/branchfs.so build dep (there's no separate .so in that mode).
+# Local dev with Homebrew/apt PHP keeps the .so path unchanged.
+ifeq ($(BRANCHFS_BUILTIN),1)
+BRANCHFS_LOAD     :=
+BRANCHFS_TEST_DEP :=
+else
+BRANCHFS_LOAD     := -d extension=$(CURDIR)/ext/branchfs.so
+BRANCHFS_TEST_DEP := ext/branchfs.so
+endif
+
 all: ext/branchfs.so
 
 ext/branchfs.so: ext/branchfs.c ext/branchfs.h
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ ext/branchfs.c $(LDFLAGS)
 
-init-db: ext/branchfs.so
-	php -d "extension=$(CURDIR)/ext/branchfs.so" scripts/init_db.php
+init-db: $(BRANCHFS_TEST_DEP)
+	php $(BRANCHFS_LOAD) scripts/init_db.php
 
-test: ext/branchfs.so
-	php -d "extension=$(CURDIR)/ext/branchfs.so" tests/test_basic.php
+test: $(BRANCHFS_TEST_DEP)
+	php $(BRANCHFS_LOAD) tests/test_basic.php
 
-test-compat: ext/branchfs.so
-	php -d "extension=$(CURDIR)/ext/branchfs.so" tests/test_plugin_compat.php
+test-compat: $(BRANCHFS_TEST_DEP)
+	php $(BRANCHFS_LOAD) tests/test_plugin_compat.php
 
-test-all: ext/branchfs.so
-	php -d "extension=$(CURDIR)/ext/branchfs.so" tests/test_basic.php
-	php -d "extension=$(CURDIR)/ext/branchfs.so" tests/test_plugin_compat.php
-	php -d "extension=$(CURDIR)/ext/branchfs.so" tests/test_wp_boot.php
-	php -d "extension=$(CURDIR)/ext/branchfs.so" tests/test_realpath.php
-	php -d "extension=$(CURDIR)/ext/branchfs.so" tests/test_syscall_overrides.php
-	php -d "extension=$(CURDIR)/ext/branchfs.so" tests/test_opcache_keys.php
-	php -d "extension=$(CURDIR)/ext/branchfs.so" tests/test_merge.php
-	php -d "extension=$(CURDIR)/ext/branchfs.so" tests/test_gc.php
-	php -d "extension=$(CURDIR)/ext/branchfs.so" tests/test_push_auth.php
+test-all: $(BRANCHFS_TEST_DEP)
+	php $(BRANCHFS_LOAD) tests/test_basic.php
+	php $(BRANCHFS_LOAD) tests/test_plugin_compat.php
+	php $(BRANCHFS_LOAD) tests/test_wp_boot.php
+	php $(BRANCHFS_LOAD) tests/test_realpath.php
+	php $(BRANCHFS_LOAD) tests/test_syscall_overrides.php
+	php $(BRANCHFS_LOAD) tests/test_opcache_keys.php
+	php $(BRANCHFS_LOAD) tests/test_merge.php
+	php $(BRANCHFS_LOAD) tests/test_gc.php
+	php $(BRANCHFS_LOAD) tests/test_push_auth.php
 
 clean:
 	rm -f ext/branchfs.so /tmp/branchfs_test*.db /tmp/branchfs_wp*.db

--- a/branched-wp/README.md
+++ b/branched-wp/README.md
@@ -238,23 +238,57 @@ bash e2e/test_findings_live.sh
 ## `gitpress` Single Binary
 
 There is now a Rust CLI that packages the PHP runtime assets, vendored
-git server code, WordPress bootstrap helpers, `ext/branchfs.so`, the
-`php` executable, the `dolt` executable, and the shared libraries needed
-by the embedded PHP runtime into a single static launcher binary + extracted
-runtime bundle.
+git server code, WordPress bootstrap helpers, `ext/branchfs.so`, a
+statically-linked `php` executable, the `dolt` executable, and any
+supporting libraries into a single launcher binary + embedded runtime
+bundle.
 
-Build it from the repo root:
+### Downloads
+
+Pre-built release tarballs are published to the GitHub Releases page
+for every tag. Pick the asset matching your machine:
+
+| Platform | Asset name |
+| --- | --- |
+| Linux x86_64 (glibc or musl) | `gitpress-<version>-linux-x86_64.tar.gz` |
+| Linux aarch64 (glibc or musl) | `gitpress-<version>-linux-aarch64.tar.gz` |
+| macOS x86_64 (Intel) | `gitpress-<version>-macos-x86_64.tar.gz` |
+| macOS aarch64 (Apple Silicon) | `gitpress-<version>-macos-aarch64.tar.gz` |
+
+Install + verify:
 
 ```bash
-rustup target add x86_64-unknown-linux-musl
+VERSION=0.1.0   # replace with the latest release tag (without the leading 'v')
+OS_ARCH=linux-x86_64   # or linux-aarch64, macos-x86_64, macos-aarch64
+BASE="https://github.com/adamziel/experiments/releases/download/v${VERSION}"
+
+curl -fsSL -O "${BASE}/gitpress-${VERSION}-${OS_ARCH}.tar.gz"
+curl -fsSL -O "${BASE}/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+tar xzf "gitpress-${VERSION}-${OS_ARCH}.tar.gz"
+cd "gitpress-${VERSION}-${OS_ARCH}"
+./gitpress start
+```
+
+Windows is **not yet supported** — see `LIMITATIONS.md` for the port
+blockers and tracking placeholder.
+
+### Building from source
+
+Build from a local checkout:
+
+```bash
+rustup target add x86_64-unknown-linux-musl   # or your platform triple
 cargo build --release -p gitpress
 # or
 make gitpress
 ```
 
 No host `php`, `dolt`, or glibc runtime installation is required for the
-launcher itself. `gitpress` is built as a static musl binary and extracts
-its own bundled PHP + Dolt runtime by default.
+launcher itself — the release artifact bundles a static PHP (built via
+[static-php-cli](https://github.com/crazywhalecc/static-php-cli)) and a
+static Dolt binary, and extracts them into `~/.gitpress/runtime/` on
+first run.
 
 Start a local site + branch router + git smart-HTTP server:
 

--- a/branched-wp/README.md
+++ b/branched-wp/README.md
@@ -273,9 +273,19 @@ cd "gitpress-${VERSION}-${OS_ARCH}"
 Windows is **not yet supported** — see `LIMITATIONS.md` for the port
 blockers and tracking placeholder.
 
+**Pre-built availability today:** only `linux-x86_64` ships as a
+Release asset. The macOS matrix legs are blocked on CI billing; you
+can reproduce the same tarball locally on a Mac following
+[`BUILDING.md`](BUILDING.md) — the build is fully scripted.
+
 ### Building from source
 
-Build from a local checkout:
+For a production-shaped tarball (static PHP with branchfs compiled in,
+identical to what CI produces), follow [`BUILDING.md`](BUILDING.md).
+Full build is ~20–40 min cold.
+
+For local dev iteration against your system PHP (fast rebuilds, no
+spc), the Makefile's existing flow still works:
 
 ```bash
 rustup target add x86_64-unknown-linux-musl   # or your platform triple
@@ -284,11 +294,9 @@ cargo build --release -p gitpress
 make gitpress
 ```
 
-No host `php`, `dolt`, or glibc runtime installation is required for the
-launcher itself — the release artifact bundles a static PHP (built via
-[static-php-cli](https://github.com/crazywhalecc/static-php-cli)) and a
-static Dolt binary, and extracts them into `~/.gitpress/runtime/` on
-first run.
+In that mode the launcher walks the host's `ldd` / dylib closure
+instead of using a pre-built static PHP. Fine for a dev machine; not
+what CI produces.
 
 Start a local site + branch router + git smart-HTTP server:
 

--- a/branched-wp/ci/spc-branchfs/Branchfs.php
+++ b/branched-wp/ci/spc-branchfs/Branchfs.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * static-php-cli Builder class for the `branchfs` extension.
+ *
+ * branchfs is NOT an upstream PHP extension — it lives in this repo at
+ * branched-wp/ext/. To get it compiled *into* the static PHP binary spc
+ * produces (so we don't need dlopen at runtime, which musl-static PHP
+ * doesn't support), we register branchfs with spc as a "builtin" ext
+ * and stage its sources into source/php-src/ext/branchfs/ right before
+ * ./buildconf runs. buildconf's glob over ext/ * /config.m4 then picks
+ * up our PHP_ARG_ENABLE(branchfs, ...) declaration, so the subsequent
+ * ./configure run accepts --enable-branchfs, and make links branchfs
+ * into libphp (and into the cli binary).
+ *
+ * CI sets SPC_BRANCHFS_SOURCE to the directory containing
+ * branchfs.c / branchfs.h / config.m4 before invoking `spc build`.
+ *
+ * References:
+ *   - spc extension registration:
+ *     https://github.com/crazywhalecc/static-php-cli/blob/2.4.0/config/ext.json
+ *   - patchBeforeBuildconf hook contract:
+ *     src/SPC/builder/Extension.php :: patchBeforeBuildconf()
+ *   - existing "modify ext source just before buildconf" precedent:
+ *     src/SPC/builder/extension/simdjson.php
+ */
+
+namespace SPC\builder\extension;
+
+use SPC\builder\Extension;
+use SPC\exception\FileSystemException;
+use SPC\exception\WrongUsageException;
+use SPC\util\CustomExt;
+
+#[CustomExt('branchfs')]
+class branchfs extends Extension
+{
+    /**
+     * Files branchfs's config.m4 references. Missing any of these means
+     * the ext source dir wasn't staged correctly — fail fast with a
+     * clear message rather than letting buildconf emit its own confusing
+     * m4 error.
+     */
+    private const REQUIRED_FILES = ['branchfs.c', 'branchfs.h', 'config.m4'];
+
+    public function patchBeforeBuildconf(): bool
+    {
+        $src = getenv('SPC_BRANCHFS_SOURCE');
+        if ($src === false || $src === '') {
+            throw new WrongUsageException(
+                'branchfs extension is enabled but SPC_BRANCHFS_SOURCE is not set. '
+                . 'Point it at the branched-wp/ext/ directory before running spc build.'
+            );
+        }
+        if (!is_dir($src)) {
+            throw new WrongUsageException("SPC_BRANCHFS_SOURCE={$src} is not a directory");
+        }
+
+        $dst = SOURCE_PATH . '/php-src/ext/branchfs';
+        if (!is_dir($dst) && !mkdir($dst, 0755, true) && !is_dir($dst)) {
+            throw new FileSystemException("could not create {$dst}");
+        }
+
+        foreach (self::REQUIRED_FILES as $name) {
+            $from = rtrim($src, '/') . '/' . $name;
+            if (!is_file($from)) {
+                throw new WrongUsageException("SPC_BRANCHFS_SOURCE is missing {$name} (looked at {$from})");
+            }
+            if (!copy($from, $dst . '/' . $name)) {
+                throw new FileSystemException("copy {$from} -> {$dst}/{$name} failed");
+            }
+        }
+
+        return true;
+    }
+}

--- a/branched-wp/ci/spc-branchfs/integrate.sh
+++ b/branched-wp/ci/spc-branchfs/integrate.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Integrate branchfs as a first-class builtin extension into an spc checkout.
+#
+# Usage:
+#   integrate.sh <path-to-static-php-cli>
+#
+# Idempotent: safe to re-run on a cache hit.
+#
+# Rather than shipping a .patch file (ext.json is a big JSON doc; a
+# line-level diff is fragile when upstream spc bumps), we:
+#   1. jq-merge a `branchfs` entry into config/ext.json
+#   2. drop Branchfs.php into src/SPC/builder/extension/
+#      (spc auto-loads via the #[CustomExt(...)] attribute)
+#
+# The staging of branchfs.c/.h/config.m4 into source/php-src/ext/branchfs/
+# is done by Branchfs.php::patchBeforeBuildconf() at build time, driven by
+# the SPC_BRANCHFS_SOURCE env var.
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "usage: $0 <path-to-spc>" >&2
+  exit 2
+fi
+
+SPC_DIR="$1"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ ! -f "$SPC_DIR/config/ext.json" ]; then
+  echo "FATAL: $SPC_DIR does not look like an spc checkout (no config/ext.json)" >&2
+  exit 1
+fi
+
+# 1) Register branchfs in config/ext.json as a builtin extension that
+#    takes --enable-branchfs and depends on the sqlite static library.
+#    Using type=builtin tells spc's SourceManager to skip the download
+#    lookup (see SourceManager.php line 44).
+python3 - "$SPC_DIR/config/ext.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path) as f:
+    data = json.load(f)
+data['branchfs'] = {
+    "type": "builtin",
+    "arg-type": "enable",
+    "lib-depends": ["sqlite"],
+}
+with open(path, 'w') as f:
+    json.dump(data, f, indent=4)
+    f.write('\n')
+print("ext.json: registered 'branchfs'")
+PY
+
+# 2) Drop the Builder class. spc discovers it via the #[CustomExt] attr.
+install -m 0644 "$HERE/Branchfs.php" "$SPC_DIR/src/SPC/builder/extension/branchfs.php"
+echo "src/SPC/builder/extension/branchfs.php: installed"

--- a/branched-wp/e2e/dev.sh
+++ b/branched-wp/e2e/dev.sh
@@ -28,7 +28,13 @@ PHP_BIN="${PHP_BIN:-php}"
 # needs to be loaded from ext/branchfs.so (local-dev path with
 # Homebrew/apt PHP). Passing `-d extension=...` for a module that's
 # already loaded is a warning, not a fatal, but we prefer clean stderr.
-if "$PHP_BIN" -m 2>/dev/null | grep -qi '^branchfs$'; then
+#
+# Capture `php -m` output into a variable first: piping directly into
+# `grep -q` causes `grep` to close stdin on first match, which with
+# `set -o pipefail` marks the whole pipe as failed (SIGPIPE on php -m)
+# and drops us into the else branch even when branchfs is present.
+PHP_MODULES="$("$PHP_BIN" -m 2>/dev/null || true)"
+if printf '%s\n' "$PHP_MODULES" | grep -qi '^branchfs$'; then
     PHP="$PHP_BIN -d display_errors=Off -d display_startup_errors=Off"
     BRANCHFS_BUILTIN=1
 else

--- a/branched-wp/e2e/dev.sh
+++ b/branched-wp/e2e/dev.sh
@@ -23,7 +23,18 @@ BRANCHFS_SECRET="${BRANCHFS_SECRET:-dev-secret}"
 SITE_TITLE="${SITE_TITLE:-Branched WP Dev}"
 
 PHP_BIN="${PHP_BIN:-php}"
-PHP="$PHP_BIN -d extension=$BASE_DIR/ext/branchfs.so -d display_errors=Off -d display_startup_errors=Off"
+# Auto-detect whether branchfs is already statically compiled into this
+# PHP (release path: spc-built PHP has branchfs as a builtin ext) vs.
+# needs to be loaded from ext/branchfs.so (local-dev path with
+# Homebrew/apt PHP). Passing `-d extension=...` for a module that's
+# already loaded is a warning, not a fatal, but we prefer clean stderr.
+if "$PHP_BIN" -m 2>/dev/null | grep -qi '^branchfs$'; then
+    PHP="$PHP_BIN -d display_errors=Off -d display_startup_errors=Off"
+    BRANCHFS_BUILTIN=1
+else
+    PHP="$PHP_BIN -d extension=$BASE_DIR/ext/branchfs.so -d display_errors=Off -d display_startup_errors=Off"
+    BRANCHFS_BUILTIN=0
+fi
 DOLT="${DOLT:-$(command -v dolt || echo "$HOME/.local/bin/dolt")}"
 
 DB_PATH="$WORK_DIR/branchfs.db"
@@ -60,7 +71,9 @@ sleep 1
 rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR" "$WP_ROOT" "$DOLT_DATA/wordpress"
 
-[ -x "$BASE_DIR/ext/branchfs.so" ] || { echo "ext/branchfs.so not built. Run: make"; exit 1; }
+if [ "$BRANCHFS_BUILTIN" = "0" ]; then
+    [ -x "$BASE_DIR/ext/branchfs.so" ] || { echo "ext/branchfs.so not built. Run: make"; exit 1; }
+fi
 [ -d "$WP_SRC" ] || { echo "WordPress source missing at $WP_SRC. See README."; exit 1; }
 
 echo ""

--- a/branched-wp/e2e/test_sqlite_clone_minimal.sh
+++ b/branched-wp/e2e/test_sqlite_clone_minimal.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# ============================================================
+# Minimal SQLite-clone smoke test — used by release CI to
+# validate per-platform release artifacts.
+#
+# Covers only the three assertions that prove the C extension +
+# bundled PHP + bundled Dolt actually work on this platform:
+#
+#   A. git clone against the running dev stack succeeds
+#   B. the cloned .ht.sqlite opens and has wp_* tables
+#   G. `php -S` on the cloned wordpress/ directory returns HTTP
+#      200 with a <title> — i.e. WP boots against the SQLite
+#      drop-in via the bundled PHP.
+#
+# Intentionally skips push/round-trip/wp-cli/idempotency — those
+# are covered by test_sqlite_clone.sh on linux-x64, which is the
+# one platform where we run the full suite. The port validation
+# only needs to prove the binary works, not re-test userland.
+#
+# Requires the dev stack to be running (e2e/dev.sh in another
+# shell, or equivalent). Honors PHP_BIN, PHP_PORT, BOOT_PORT.
+# Exit 0 on all three PASS, non-zero otherwise.
+# ============================================================
+set -u
+set -o pipefail
+
+E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PHP_PORT="${PHP_PORT:-18080}"
+BOOT_PORT="${BOOT_PORT:-9091}"
+CLONE_DIR="/tmp/wp-sqlite-clone-minimal-$$"
+PHP_BIN="${PHP_BIN:-php}"
+PASS=0
+FAIL=0
+BOOT_PID=""
+
+# Prefer a PHP with pdo_sqlite + sqlite3 — without either the
+# SQLite integration drop-in refuses to serve the clone.
+for cand in "$PHP_BIN" "php" "/usr/bin/php" "/usr/local/bin/php"; do
+    if [ -x "$(command -v "$cand" 2>/dev/null)" ] \
+       && "$cand" -r 'exit(extension_loaded("pdo_sqlite") && extension_loaded("sqlite3") ? 0 : 1);' 2>/dev/null; then
+        PHP_BIN="$cand"; break
+    fi
+done
+
+cleanup() {
+    if [ -n "$BOOT_PID" ]; then
+        kill "$BOOT_PID" 2>/dev/null || true
+        for _ in 1 2 3 4 5; do
+            kill -0 "$BOOT_PID" 2>/dev/null || break
+            sleep 0.5
+        done
+        kill -9 "$BOOT_PID" 2>/dev/null || true
+        wait "$BOOT_PID" 2>/dev/null || true
+    fi
+    pkill -f "php -S 127.0.0.1:$BOOT_PORT" 2>/dev/null || true
+    rm -rf "$CLONE_DIR"
+}
+trap cleanup EXIT
+
+step() { echo ""; echo "=== $1: $2 ==="; }
+pass() { echo "  PASS"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $*"; FAIL=$((FAIL+1)); }
+
+# Confirm the remote is reachable before we test against it.
+echo "Waiting for dev server on 127.0.0.1:$PHP_PORT..."
+for i in $(seq 1 30); do
+    if curl -s -o /dev/null "http://127.0.0.1:$PHP_PORT/" 2>/dev/null; then break; fi
+    if [ "$i" -eq 30 ]; then echo "FATAL: dev server not responding on :$PHP_PORT"; exit 1; fi
+    sleep 1
+done
+
+# -------------------------------------------------------------
+# A. git clone
+# -------------------------------------------------------------
+step A "git clone http://127.0.0.1:$PHP_PORT/site.git $CLONE_DIR"
+rm -rf "$CLONE_DIR"
+if git clone "http://127.0.0.1:$PHP_PORT/site.git" "$CLONE_DIR" 2>&1 | tail -3; then
+    pass
+else
+    fail "git clone exited non-zero"
+fi
+
+# -------------------------------------------------------------
+# B. .ht.sqlite exists + wp_* tables have rows
+# -------------------------------------------------------------
+step B ".ht.sqlite exists and has wp_* tables"
+SQLITE_FILE="$CLONE_DIR/wordpress/wp-content/database/.ht.sqlite"
+if [ ! -f "$SQLITE_FILE" ]; then
+    fail "$SQLITE_FILE missing"
+else
+    # Assert: at least wp_options, wp_posts, wp_users exist and
+    # wp_options has the canonical blogname row.
+    TABLE_OK=$("$PHP_BIN" -r '
+        $s = new SQLite3($argv[1], SQLITE3_OPEN_READONLY);
+        $want = ["wp_options","wp_posts","wp_users"];
+        $have = [];
+        $r = $s->query("SELECT name FROM sqlite_master WHERE type=\"table\"");
+        while ($row = $r->fetchArray(SQLITE3_ASSOC)) $have[] = $row["name"];
+        foreach ($want as $t) {
+            if (!in_array($t, $have)) { echo "missing-table: $t"; exit(1); }
+        }
+        $blogname = $s->querySingle("SELECT option_value FROM wp_options WHERE option_name=\"blogname\"");
+        if (!$blogname) { echo "missing-blogname"; exit(1); }
+        echo "blogname=" . $blogname;
+    ' "$SQLITE_FILE" 2>&1)
+    if [ $? -eq 0 ]; then
+        echo "  $TABLE_OK"
+        pass
+    else
+        fail "sqlite check failed: $TABLE_OK"
+    fi
+fi
+
+# -------------------------------------------------------------
+# G. php -S on the clone serves HTTP 200 with <title>
+# -------------------------------------------------------------
+step G "php -S on $CLONE_DIR/wordpress serves HTTP 200 + <title>"
+
+# Auto-prepend WP-cron disable + external HTTP block so boot
+# doesn't loopback to the remote dev stack.
+PREPEND="/tmp/sqlite-clone-minimal-prepend-$$.php"
+cat > "$PREPEND" <<'EOF'
+<?php
+if (!defined('DISABLE_WP_CRON')) define('DISABLE_WP_CRON', true);
+if (!defined('WP_HTTP_BLOCK_EXTERNAL')) define('WP_HTTP_BLOCK_EXTERNAL', true);
+EOF
+
+"$PHP_BIN" -d "auto_prepend_file=$PREPEND" -S "127.0.0.1:$BOOT_PORT" \
+    -t "$CLONE_DIR/wordpress" \
+    > /tmp/sqlite-clone-minimal-boot.log 2>&1 &
+BOOT_PID=$!
+
+# Wait for port.
+PORT_UP=0
+for i in $(seq 1 30); do
+    if "$PHP_BIN" -r "\$s=@fsockopen('127.0.0.1',$BOOT_PORT,\$e,\$m,0.5); if(\$s){fclose(\$s);exit(0);} exit(1);" 2>/dev/null; then
+        PORT_UP=1; break
+    fi
+    if ! kill -0 "$BOOT_PID" 2>/dev/null; then
+        echo "  php -S died early:"
+        tail -10 /tmp/sqlite-clone-minimal-boot.log
+        break
+    fi
+    sleep 1
+done
+
+if [ "$PORT_UP" -ne 1 ]; then
+    fail "php -S never opened port $BOOT_PORT"
+else
+    BODY_FILE="/tmp/sqlite-clone-minimal-body-$$.out"
+    STATUS=$(curl -s --max-time 30 -o "$BODY_FILE" \
+                  -w "%{http_code}" "http://127.0.0.1:$BOOT_PORT/" \
+             || echo ERR)
+    TITLE=$(grep -oE '<title>[^<]+</title>' "$BODY_FILE" 2>/dev/null | head -1 || true)
+    if [ "$STATUS" = "200" ] && [ -n "$TITLE" ]; then
+        echo "  status=$STATUS title=$TITLE"
+        pass
+    else
+        fail "status=$STATUS title='$TITLE'"
+        echo "  --- boot log tail ---"
+        tail -15 /tmp/sqlite-clone-minimal-boot.log | sed 's/^/    /'
+        echo "  --- body head ---"
+        head -c 400 "$BODY_FILE" 2>/dev/null | sed 's/^/    /'
+    fi
+    rm -f "$BODY_FILE"
+fi
+rm -f "$PREPEND"
+
+echo ""
+echo "============================================================"
+echo "  RESULTS: $PASS passed, $FAIL failed (out of 3)"
+echo "============================================================"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "ALL MINIMAL SMOKE CHECKS PASSED"
+exit 0

--- a/branched-wp/ext/branchfs.c
+++ b/branched-wp/ext/branchfs.c
@@ -1962,17 +1962,63 @@ ZEND_NAMED_FUNCTION(branchfs_override_glob) {
  * Section 10: Module lifecycle
  * ================================================================ */
 
+/* Arg info — PHP 8.2 requires every internal function to declare its
+ * parameters. Missing arginfo triggers a "Missing arginfo for ..." startup
+ * warning on stdout, which (among other things) corrupts static-php-cli's
+ * "echo 'hello'" sanity check that runs before display_errors can be
+ * silenced. Keep these blocks in sync with the ZEND_PARSE_PARAMETERS_*
+ * macros in each PHP_FUNCTION below. */
+ZEND_BEGIN_ARG_INFO_EX(arginfo_branchfs_set_db, 0, 0, 1)
+    ZEND_ARG_INFO(0, path)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_branchfs_set_root, 0, 0, 1)
+    ZEND_ARG_INFO(0, path)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_branchfs_set_branch, 0, 0, 1)
+    ZEND_ARG_INFO(0, branch)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_branchfs_get_branch, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_branchfs_activate, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_branchfs_deactivate, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_branchfs_create_branch, 0, 0, 1)
+    ZEND_ARG_INFO(0, name)
+    ZEND_ARG_INFO(0, parent)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_branchfs_import_file, 0, 0, 3)
+    ZEND_ARG_INFO(0, real_path)
+    ZEND_ARG_INFO(0, branch)
+    ZEND_ARG_INFO(0, virtual_path)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_branchfs_import_dir, 0, 0, 2)
+    ZEND_ARG_INFO(0, branch)
+    ZEND_ARG_INFO(0, virtual_path)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_branchfs_is_active, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 static const zend_function_entry branchfs_functions[] = {
-    PHP_FE(branchfs_set_db, NULL)
-    PHP_FE(branchfs_set_root, NULL)
-    PHP_FE(branchfs_set_branch, NULL)
-    PHP_FE(branchfs_get_branch, NULL)
-    PHP_FE(branchfs_activate, NULL)
-    PHP_FE(branchfs_deactivate, NULL)
-    PHP_FE(branchfs_create_branch, NULL)
-    PHP_FE(branchfs_import_file, NULL)
-    PHP_FE(branchfs_import_dir, NULL)
-    PHP_FE(branchfs_is_active, NULL)
+    PHP_FE(branchfs_set_db, arginfo_branchfs_set_db)
+    PHP_FE(branchfs_set_root, arginfo_branchfs_set_root)
+    PHP_FE(branchfs_set_branch, arginfo_branchfs_set_branch)
+    PHP_FE(branchfs_get_branch, arginfo_branchfs_get_branch)
+    PHP_FE(branchfs_activate, arginfo_branchfs_activate)
+    PHP_FE(branchfs_deactivate, arginfo_branchfs_deactivate)
+    PHP_FE(branchfs_create_branch, arginfo_branchfs_create_branch)
+    PHP_FE(branchfs_import_file, arginfo_branchfs_import_file)
+    PHP_FE(branchfs_import_dir, arginfo_branchfs_import_dir)
+    PHP_FE(branchfs_is_active, arginfo_branchfs_is_active)
     PHP_FE_END
 };
 

--- a/branched-wp/gitpress/build.rs
+++ b/branched-wp/gitpress/build.rs
@@ -17,12 +17,27 @@ fn main() -> Result<()> {
 
     println!("cargo:rerun-if-env-changed=GITPRESS_PHP_BIN");
     println!("cargo:rerun-if-env-changed=GITPRESS_DOLT_BIN");
-
-    ensure_branchfs_binary(repo_root)?;
+    println!("cargo:rerun-if-env-changed=GITPRESS_RUNTIME_DIR");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
     let bundle_path = out_dir.join("gitpress-runtime.tar.gz");
-    build_runtime_bundle(repo_root, &bundle_path)?;
+
+    // Two modes:
+    //   1. GITPRESS_RUNTIME_DIR is set → CI/cross-compile mode. A pre-staged
+    //      directory contains bin/php, bin/dolt, lib/branchfs.so already
+    //      built for the target platform. We just tar it up alongside the
+    //      PHP/WP/vendor sources. Host tooling (make, ldd, readelf) is
+    //      never invoked — critical when building for a foreign arch.
+    //   2. Unset → local-dev fallback. Build ext/branchfs.so via `make`,
+    //      resolve host php/dolt via PATH, and capture their shared-lib
+    //      closure with ldd + readelf (Linux glibc only).
+    if let Ok(runtime_dir) = env::var("GITPRESS_RUNTIME_DIR") {
+        let runtime_dir = PathBuf::from(runtime_dir);
+        build_runtime_bundle_from_dir(repo_root, &runtime_dir, &bundle_path)?;
+    } else {
+        ensure_branchfs_binary(repo_root)?;
+        build_runtime_bundle(repo_root, &bundle_path)?;
+    }
 
     println!(
         "cargo:rustc-env=GITPRESS_RUNTIME_BUNDLE={}",
@@ -84,6 +99,91 @@ fn build_runtime_bundle(repo_root: &Path, bundle_path: &Path) -> Result<()> {
     add_file(&mut tar, repo_root, "e2e/bootstrap_wp.php")?;
     add_file(&mut tar, repo_root, "e2e/wp.zip")?;
     add_portable_runtime(&mut tar, repo_root)?;
+
+    tar.finish()?;
+    let encoder = tar.into_inner()?;
+    encoder.finish()?;
+    Ok(())
+}
+
+/// Pre-staged runtime mode: the caller has already produced
+///   $GITPRESS_RUNTIME_DIR/bin/php
+///   $GITPRESS_RUNTIME_DIR/bin/dolt
+///   $GITPRESS_RUNTIME_DIR/lib/branchfs.so
+/// for the target platform. We just tar the PHP/WP sources + those three
+/// artifacts, without invoking make/ldd/readelf on the host.
+fn build_runtime_bundle_from_dir(
+    repo_root: &Path,
+    runtime_dir: &Path,
+    bundle_path: &Path,
+) -> Result<()> {
+    let php_bin = runtime_dir.join("bin/php");
+    let dolt_bin = runtime_dir.join("bin/dolt");
+    let branchfs_so = runtime_dir.join("lib/branchfs.so");
+
+    for (label, path) in [
+        ("bin/php", &php_bin),
+        ("bin/dolt", &dolt_bin),
+        ("lib/branchfs.so", &branchfs_so),
+    ] {
+        if !path.exists() {
+            bail!(
+                "GITPRESS_RUNTIME_DIR={} is missing {}",
+                runtime_dir.display(),
+                label
+            );
+        }
+    }
+
+    println!("cargo:rerun-if-changed={}", php_bin.display());
+    println!("cargo:rerun-if-changed={}", dolt_bin.display());
+    println!("cargo:rerun-if-changed={}", branchfs_so.display());
+
+    let file = File::create(bundle_path).with_context(|| {
+        format!(
+            "failed to create runtime bundle at {}",
+            bundle_path.display()
+        )
+    })?;
+    let encoder = GzEncoder::new(file, Compression::default());
+    let mut tar = Builder::new(encoder);
+
+    add_tree(&mut tar, repo_root, "scripts")?;
+    add_tree(&mut tar, repo_root, "sql")?;
+    add_tree(&mut tar, repo_root, "vendor")?;
+    add_tree(&mut tar, repo_root, "wp-plugin")?;
+    add_file_as(&mut tar, &branchfs_so, "ext/branchfs.so")?;
+    add_file(&mut tar, repo_root, "e2e/router.php")?;
+    add_file(&mut tar, repo_root, "e2e/bootstrap_wp.php")?;
+    add_file(&mut tar, repo_root, "e2e/wp.zip")?;
+
+    // With a statically-linked PHP and a statically-linked dolt we have no
+    // shared-lib closure to capture — just drop the two binaries at the
+    // same portable-runtime/ paths the runtime extractor expects.
+    add_file_as(&mut tar, &php_bin, "portable-runtime/bin/php")?;
+    add_file_as(&mut tar, &dolt_bin, "portable-runtime/bin/dolt")?;
+
+    // If the caller staged any extra shared libraries under
+    // $GITPRESS_RUNTIME_DIR/lib/ (not branchfs.so itself), include them.
+    // Static PHP builds won't ship any; dynamic builds will.
+    let lib_dir = runtime_dir.join("lib");
+    if lib_dir.is_dir() {
+        for entry in WalkDir::new(&lib_dir).min_depth(1).max_depth(1) {
+            let entry = entry?;
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name == "branchfs.so" {
+                continue;
+            }
+            add_file_as(
+                &mut tar,
+                entry.path(),
+                &format!("portable-runtime/lib/{name}"),
+            )?;
+        }
+    }
 
     tar.finish()?;
     let encoder = tar.into_inner()?;

--- a/branched-wp/gitpress/build.rs
+++ b/branched-wp/gitpress/build.rs
@@ -24,10 +24,13 @@ fn main() -> Result<()> {
 
     // Two modes:
     //   1. GITPRESS_RUNTIME_DIR is set → CI/cross-compile mode. A pre-staged
-    //      directory contains bin/php, bin/dolt, lib/branchfs.so already
-    //      built for the target platform. We just tar it up alongside the
-    //      PHP/WP/vendor sources. Host tooling (make, ldd, readelf) is
-    //      never invoked — critical when building for a foreign arch.
+    //      directory contains bin/php, bin/dolt, and optionally
+    //      lib/branchfs.so built for the target platform. Release builds
+    //      now compile branchfs *into* the static PHP binary (spc
+    //      builtin ext) so lib/branchfs.so is absent; it is still
+    //      supported for dynamic-PHP runtime bundles. Host tooling
+    //      (make, ldd, readelf) is never invoked — critical when
+    //      building for a foreign arch.
     //   2. Unset → local-dev fallback. Build ext/branchfs.so via `make`,
     //      resolve host php/dolt via PATH, and capture their shared-lib
     //      closure with ldd + readelf (Linux glibc only).
@@ -109,9 +112,13 @@ fn build_runtime_bundle(repo_root: &Path, bundle_path: &Path) -> Result<()> {
 /// Pre-staged runtime mode: the caller has already produced
 ///   $GITPRESS_RUNTIME_DIR/bin/php
 ///   $GITPRESS_RUNTIME_DIR/bin/dolt
+/// for the target platform, plus optionally
 ///   $GITPRESS_RUNTIME_DIR/lib/branchfs.so
-/// for the target platform. We just tar the PHP/WP sources + those three
-/// artifacts, without invoking make/ldd/readelf on the host.
+/// when PHP is dynamically linked. The release pipeline builds branchfs
+/// *into* a static PHP via spc, so lib/branchfs.so is usually absent —
+/// the runtime launcher detects this and skips the extension flag.
+/// We just tar the PHP/WP sources + available artifacts, without
+/// invoking make/ldd/readelf on the host.
 fn build_runtime_bundle_from_dir(
     repo_root: &Path,
     runtime_dir: &Path,
@@ -121,11 +128,7 @@ fn build_runtime_bundle_from_dir(
     let dolt_bin = runtime_dir.join("bin/dolt");
     let branchfs_so = runtime_dir.join("lib/branchfs.so");
 
-    for (label, path) in [
-        ("bin/php", &php_bin),
-        ("bin/dolt", &dolt_bin),
-        ("lib/branchfs.so", &branchfs_so),
-    ] {
+    for (label, path) in [("bin/php", &php_bin), ("bin/dolt", &dolt_bin)] {
         if !path.exists() {
             bail!(
                 "GITPRESS_RUNTIME_DIR={} is missing {}",
@@ -152,7 +155,11 @@ fn build_runtime_bundle_from_dir(
     add_tree(&mut tar, repo_root, "sql")?;
     add_tree(&mut tar, repo_root, "vendor")?;
     add_tree(&mut tar, repo_root, "wp-plugin")?;
-    add_file_as(&mut tar, &branchfs_so, "ext/branchfs.so")?;
+    // branchfs.so is optional: when PHP has branchfs compiled in (the
+    // static-musl release path), there is no separate .so to ship.
+    if branchfs_so.exists() {
+        add_file_as(&mut tar, &branchfs_so, "ext/branchfs.so")?;
+    }
     add_file(&mut tar, repo_root, "e2e/router.php")?;
     add_file(&mut tar, repo_root, "e2e/bootstrap_wp.php")?;
     add_file(&mut tar, repo_root, "e2e/wp.zip")?;

--- a/branched-wp/gitpress/src/main.rs
+++ b/branched-wp/gitpress/src/main.rs
@@ -585,12 +585,18 @@ fn start_php_server(
 
 fn php_base_command(layout: &Layout, runtime: &PortableRuntime, shared: &SharedPaths) -> Command {
     let mut command = php_command(runtime, shared);
+    // branchfs may be either a separate .so (dynamic-PHP runtime bundle)
+    // or statically compiled into the PHP binary (release path — spc
+    // musl-static PHP has no dlopen support). Only pass -d extension=
+    // when the .so is actually present; otherwise the static module is
+    // already registered at startup.
+    let branchfs_so = layout.runtime_dir.join("ext/branchfs.so");
+    if branchfs_so.exists() {
+        command
+            .arg("-d")
+            .arg(format!("extension={}", branchfs_so.display()));
+    }
     command
-        .arg("-d")
-        .arg(format!(
-            "extension={}",
-            layout.runtime_dir.join("ext/branchfs.so").display()
-        ))
         .arg("-d")
         .arg("display_errors=Off")
         .arg("-d")

--- a/branched-wp/gitpress/src/main.rs
+++ b/branched-wp/gitpress/src/main.rs
@@ -639,13 +639,25 @@ fn php_command(runtime: &PortableRuntime, shared: &SharedPaths) -> Command {
         return Command::new(php_bin);
     }
 
-    let mut command = Command::new(&runtime.loader);
-    command
-        .arg("--library-path")
-        .arg(&runtime.lib_dir)
-        .arg(&runtime.php)
-        .env("LD_LIBRARY_PATH", &runtime.lib_dir);
-    command
+    // Two PHP binary flavors ship in the runtime bundle:
+    //   1. Dynamic PHP (local-dev, dynamic Homebrew/apt build): needs the
+    //      staged `lib/ld-linux-x86-64.so.2` + `lib/` shared libs, invoked
+    //      via the loader so we're independent of the host's glibc.
+    //   2. Static PHP (release path, spc-built musl binary with branchfs
+    //      compiled in): self-contained, no loader or lib/ dir shipped.
+    // Probe for the loader: when absent, the binary is static, invoke
+    // directly. Otherwise wrap with the loader to pin the library path.
+    if runtime.loader.exists() {
+        let mut command = Command::new(&runtime.loader);
+        command
+            .arg("--library-path")
+            .arg(&runtime.lib_dir)
+            .arg(&runtime.php)
+            .env("LD_LIBRARY_PATH", &runtime.lib_dir);
+        command
+    } else {
+        Command::new(&runtime.php)
+    }
 }
 
 fn dolt_command(runtime: &PortableRuntime, shared: &SharedPaths) -> Command {

--- a/branched-wp/tests/test_gc.php
+++ b/branched-wp/tests/test_gc.php
@@ -50,8 +50,13 @@ assert_true($blobs_after_delete === $blobs_before_delete,
     "blobs unchanged after branch delete (gc hasn't run yet)");
 
 // Dry-run first.
-$branchctl = escapeshellcmd(PHP_BINARY)
-           . ' -d extension=' . escapeshellarg(realpath(__DIR__ . '/../ext/branchfs.so'))
+// When branchfs is statically compiled into PHP (release path), there
+// is no .so on disk; PHP_BINARY already has branchfs loaded and would
+// refuse -d extension=... for an already-registered module. Pass the
+// flag only if the .so exists (local-dev path).
+$so_path = realpath(__DIR__ . '/../ext/branchfs.so');
+$ext_flag = $so_path !== false ? ' -d extension=' . escapeshellarg($so_path) : '';
+$branchctl = escapeshellcmd(PHP_BINARY) . $ext_flag
            . ' ' . escapeshellarg(__DIR__ . '/../scripts/branchctl.php');
 $out = [];
 $rc  = 0;

--- a/branched-wp/tests/test_gc.php
+++ b/branched-wp/tests/test_gc.php
@@ -21,6 +21,10 @@ $db = new SQLite3($DB);
 $db->exec(file_get_contents(__DIR__ . '/../sql/schema.sql'));
 $db->close();
 
+// macOS canonicalizes /tmp → /private/tmp via symlink; branchfs needs
+// the canonical root or relative-path lookups miss.
+@mkdir($ROOT, 0755, true);
+$ROOT = realpath($ROOT) ?: $ROOT;
 branchfs_set_db($DB);
 branchfs_set_root($ROOT);
 

--- a/branched-wp/tests/test_merge.php
+++ b/branched-wp/tests/test_merge.php
@@ -90,8 +90,11 @@ file_put_contents('branchfs://main/readme.txt',      "main edit\n");
 file_put_contents('branchfs://feature-a/readme.txt', "feature edit\n");
 
 echo "=== merge: default (abort) strategy refuses on conflict ===\n";
-$cmd = escapeshellcmd(PHP_BINARY)
-     . ' -d extension=' . escapeshellarg(realpath(__DIR__ . '/../ext/branchfs.so'))
+// Only pass -d extension when the .so exists on disk (local-dev path).
+// Static-PHP builds have branchfs baked in and reject re-registration.
+$so_path = realpath(__DIR__ . '/../ext/branchfs.so');
+$ext_flag = $so_path !== false ? ' -d extension=' . escapeshellarg($so_path) : '';
+$cmd = escapeshellcmd(PHP_BINARY) . $ext_flag
      . ' ' . escapeshellarg(__DIR__ . '/../scripts/merge.php')
      . ' feature-a main ' . escapeshellarg($DB);
 $output = [];
@@ -140,8 +143,7 @@ fork_snapshot($DB, 'feature-b', str_repeat('b', 32));
 file_put_contents('branchfs://feature-b/note.txt', "feature only edit\n");
 // Target main is still at "base note" for this path
 
-$cmd2 = escapeshellcmd(PHP_BINARY)
-      . ' -d extension=' . escapeshellarg(realpath(__DIR__ . '/../ext/branchfs.so'))
+$cmd2 = escapeshellcmd(PHP_BINARY) . $ext_flag
       . ' ' . escapeshellarg(__DIR__ . '/../scripts/merge.php')
       . ' feature-b main ' . escapeshellarg($DB);
 $output = [];

--- a/branched-wp/tests/test_merge.php
+++ b/branched-wp/tests/test_merge.php
@@ -24,6 +24,8 @@ $db = new SQLite3($DB);
 $db->exec(file_get_contents(__DIR__ . '/../sql/schema.sql'));
 $db->close();
 
+@mkdir($ROOT, 0755, true);
+$ROOT = realpath($ROOT) ?: $ROOT;
 branchfs_set_db($DB);
 branchfs_set_root($ROOT);
 

--- a/branched-wp/tests/test_opcache_keys.php
+++ b/branched-wp/tests/test_opcache_keys.php
@@ -24,6 +24,8 @@ $db = new SQLite3($DB);
 $db->exec(file_get_contents(__DIR__ . '/../sql/schema.sql'));
 $db->close();
 
+@mkdir($ROOT, 0755, true);
+$ROOT = realpath($ROOT) ?: $ROOT;
 branchfs_set_db($DB);
 branchfs_set_root($ROOT);
 branchfs_set_branch('main');

--- a/branched-wp/tests/test_plugin_compat.php
+++ b/branched-wp/tests/test_plugin_compat.php
@@ -23,6 +23,17 @@ function assert_eq($a, $b, $msg) {
 $DB = '/tmp/branchfs_test_compat_' . getmypid() . '.db';
 $WP_ROOT = '/tmp/branchfs_wproot_' . getmypid();
 
+// On macOS, /tmp is a symlink to /private/tmp, so getcwd() after chdir()
+// returns the canonical /private/tmp/... path. If branchfs_set_root()
+// stores the un-canonicalized /tmp/... prefix, the relative-path lookups
+// further down never match and every `file_get_contents('foo')` misses.
+// Resolve the WP_ROOT to its real path before setting it on the ext.
+@mkdir($WP_ROOT, 0755, true);
+$WP_ROOT_REAL = realpath($WP_ROOT);
+if ($WP_ROOT_REAL !== false) {
+    $WP_ROOT = $WP_ROOT_REAL;
+}
+
 echo "=== BranchFS Plugin Compatibility Tests ===\n";
 echo "WP Root: $WP_ROOT\n\n";
 

--- a/branched-wp/tests/test_realpath.php
+++ b/branched-wp/tests/test_realpath.php
@@ -21,6 +21,8 @@ $db = new SQLite3($DB);
 $db->exec(file_get_contents(__DIR__ . '/../sql/schema.sql'));
 $db->close();
 
+@mkdir($ROOT, 0755, true);
+$ROOT = realpath($ROOT) ?: $ROOT;
 branchfs_set_db($DB);
 branchfs_set_root($ROOT);
 branchfs_set_branch('main');

--- a/branched-wp/tests/test_syscall_overrides.php
+++ b/branched-wp/tests/test_syscall_overrides.php
@@ -28,6 +28,8 @@ $db = new SQLite3($DB);
 $db->exec(file_get_contents(__DIR__ . '/../sql/schema.sql'));
 $db->close();
 
+@mkdir($ROOT, 0755, true);
+$ROOT = realpath($ROOT) ?: $ROOT;
 branchfs_set_db($DB);
 branchfs_set_root($ROOT);
 branchfs_set_branch('main');

--- a/branched-wp/tests/test_wp_boot.php
+++ b/branched-wp/tests/test_wp_boot.php
@@ -26,6 +26,8 @@ $sqlite->exec(file_get_contents(__DIR__ . '/../sql/schema.sql'));
 $sqlite->close();
 
 // Configure branchfs
+@mkdir($WP_ROOT, 0755, true);
+$WP_ROOT = realpath($WP_ROOT) ?: $WP_ROOT;
 branchfs_set_db($DB);
 branchfs_set_root($WP_ROOT);
 branchfs_set_branch('main');


### PR DESCRIPTION
## Summary

Port `branched-wp` to build and run on four tier-1 targets — Linux x86_64 + aarch64, macOS x86_64 + aarch64 — and add a release pipeline that produces one self-contained, zero-system-dep `gitpress` tarball per target on every `v*` tag push.

The central architectural change in this branch is **branchfs is no longer a runtime-loaded `.so` in the release artifact.** musl-static PHP is built without `HAVE_LIBDL` — it physically cannot `dlopen()` anything — so the release PHP ships with branchfs compiled *directly into* the `php` binary as a first-class static-php-cli extension. The dynamic `branchfs.so` path is retained only for local development against a Homebrew / apt PHP.

### What landed

- **`ci/spc-branchfs/`** — new directory containing `Branchfs.php` (an spc `Extension` subclass with a `#[CustomExt('branchfs')]` attribute) and `integrate.sh` (jq-merges a `branchfs` entry into spc's `config/ext.json` and drops the `Extension` class into spc's `src/SPC/builder/extension/`). At build time, `Branchfs.php::patchBeforeBuildconf()` stages `branched-wp/ext/{branchfs.c,branchfs.h,config.m4}` into `source/php-src/ext/branchfs/` so spc's buildconf glob picks it up and `./configure --enable-branchfs` becomes a valid flag. The idiomatic spc extension-registration pattern — no line-level patching of spc sources.
- **`gitpress/build.rs`** — new `GITPRESS_RUNTIME_DIR` mode. When the env var is set, consumes a pre-staged `runtime/bin/php` + `runtime/bin/dolt` (+ optionally `runtime/lib/branchfs.so` when the runtime is dynamic-PHP). `lib/branchfs.so` is *absent* in the release tarballs now — the launcher + router auto-detect branchfs being statically present and skip the `-d extension=…` flag everywhere. Local-dev fallback (no env var set) still walks the host's `ldd` closure for dynamic Homebrew/apt PHP.
- **`Makefile`** — `uname -s` branch for Darwin (`-bundle -undefined dynamic_lookup`, Homebrew sqlite3 auto-discovery). `BRANCHFS_BUILTIN=1` short-circuits the `.so` build and all PHP-header detection (important: allows `make test-all` to run cleanly on a bare host that only has the spc-built PHP). Default `GITPRESS_TARGET` follows the host arch. `ext/branchfs.c` needed **no** changes — already POSIX-clean.
- **`e2e/dev.sh`**, **`e2e/test_sqlite_clone_minimal.sh`** — auto-detect whether branchfs is builtin via `php -m` and adjust the invocation accordingly. The existing e2e suite (including the minimal port-smoke) is the same for both code paths; only the PHP invocation differs.
- **`gitpress/src/main.rs::php_command()`** — probes `runtime/lib/ld-linux-x86-64.so.2` at runtime. When present (dynamic-PHP bundle), wraps the PHP binary in `ld-linux --library-path runtime/lib/` to pin the glibc closure. When absent (release path, static musl PHP), invokes the binary directly. Without this branch, the release path silently fails to spawn PHP and the launcher deadlocks on its dolt-readiness probe.
- **Release CI** (`.github/workflows/branched-wp-release.yml`): 4-way matrix (ubuntu-24.04, ubuntu-24.04-arm, macos-15-intel, macos-14), static-php-cli → static PHP with branchfs compiled in, matching Dolt binary, `make test-all` + `test_sqlite_clone_minimal.sh` + a gitpress-bundle smoke against **only** the bundled binaries, package, upload. Separate `checksums` job composes `SHA256SUMS`. Triggers: tag push (attaches to Release) + `workflow_dispatch` dry-run.
- **Docs**: `README` Downloads section with install/verify recipe; `LIMITATIONS.md` replaces "Linux+glibc only" with a tier-1 matrix and explicitly documents the spc-builtin-extension design + the Windows port blockers (grep placeholder `WP_BRANCHED_WINDOWS_ISSUE`).

### Windows

**Not yet supported.** Port blockers are enumerated in `branched-wp/LIMITATIONS.md` — no native `fnmatch(3)`, `realpath` vs `_fullpath` semantics, MSVC + `config.w32` vs our phpize-style build, and path-separator / case-insensitivity assumptions baked into `store_*` + the `branchfs://` URL parser.

## Local verification (linux-x86_64 leg)

See [the validation comment](#) for full transcripts. Short version:

- `spc build "branchfs,mbstring,mysqli,pdo_mysql,sqlite3,pdo_sqlite,phar,tokenizer,fileinfo,filter,session" --build-cli` on a NixOS 25.05 host — `php -m` includes `branchfs`, `php --ri branchfs` prints module info, `ldd php` says **"not a dynamic executable"**. 14 MB static binary.
- `make test-all` with `BRANCHFS_BUILTIN=1` against the spc-built PHP — **181 assertions across 9 files, 0 failures.**
- `e2e/test_sqlite_clone_minimal.sh` against `e2e/dev.sh` booted with the spc-built PHP — **3/3 PASS** (git clone, SQLite schema, `php -S` boot + `<title>`).
- `GITPRESS_RUNTIME_DIR=./runtime cargo build --release -p gitpress --target x86_64-unknown-linux-musl` → package as `gitpress-<v>-linux-x86_64.tar.gz` → extract to `/tmp/gp/`, `./gitpress start`, then `curl -H "Host: localhost" http://127.0.0.1:18080/` → **HTTP 200**, `<title>GitPress</title>`, `X-BranchFS-Branch: main`.

The `linux-aarch64`, `macos-x86_64`, `macos-aarch64` matrix legs are CI-only; this host can't prove them.

## Outstanding for rc1

- CI billing restoration + one dry-run of `branched-wp release` via `workflow_dispatch` to prove the three remaining matrix legs.
- Only after all four legs are green does `v0.1.0-rc1` get tagged.

## What CI will do on the first real `v*` tag push

1. For each of the 4 matrix entries in parallel:
   - Install static-php-cli, build static PHP 8.2 with the declared extension set, **including branchfs compiled in** (cached — only cold-builds on SPC_REF / extension-set / branchfs-source changes).
   - Download the matching `dolt-{linux,darwin}-{amd,arm}64.tar.gz`.
   - Run `make test-all` with `BRANCHFS_BUILTIN=1` against the spc-built PHP — asserts branchfs is actually present and functional.
   - Boot `e2e/dev.sh` using only the bundled PHP + Dolt, then run `test_sqlite_clone_minimal.sh` — asserts the release artifact actually works on the target.
   - Build `gitpress` with `GITPRESS_RUNTIME_DIR=$PWD/runtime cargo build --release -p gitpress --target <triple>`.
   - Upload `gitpress-<version>-<os>-<arch>.tar.gz` to the GitHub Release.
2. Checksums job downloads all four tarballs, composes `SHA256SUMS`, attaches it to the Release.

Dry-run any time via `gh workflow run "branched-wp release" -f dry_run=true` — artifacts land on the workflow run without touching the Releases page.

## Test plan

- [ ] Restore GitHub billing so the workflow can run.
- [ ] Dry-run the workflow via `workflow_dispatch` from the Actions tab — verify all four matrix legs pass.
- [ ] Cut a `v0.1.0-rc1` tag and confirm five assets + `SHA256SUMS` show up on the Release.
- [ ] Download + extract + run `./gitpress start` from each asset on the matching machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)