### PR TITLE
Fix Pages build: ship zfs_gitrev.h shim

### DIFF
--- a/zfs-wasm-real/src/shim/zfs_gitrev.h
+++ b/zfs-wasm-real/src/shim/zfs_gitrev.h
@@ -1,0 +1,13 @@
+/*
+ * Stand-in for the autoconf-generated zfs_gitrev.h.
+ *
+ * OpenZFS's configure writes this to upstream/zfs/include/zfs_gitrev.h
+ * with the short git revision of the source tree. We never run ./configure
+ * in CI (we drive the build from a hand-rolled Makefile), so spa_history.c's
+ * `#include "zfs_gitrev.h"` would fail. A fixed label is fine — the demo
+ * logs it once in spa_history and we don't care about the exact hash.
+ */
+#ifndef _ZFS_GITREV_H
+#define _ZFS_GITREV_H
+#define ZFS_META_GITREV "zfs-2.2.6-wasm"
+#endif


### PR DESCRIPTION
The zfs-wasm-pages workflow fails at spa_history.c because that TU `#include "zfs_gitrev.h"` is normally generated by OpenZFS's ./configure into `upstream/zfs/include/`. Our Dockerfile doesn't run configure, so clean CI fails even though local builds happened to have the file around.

Add `zfs-wasm-real/src/shim/zfs_gitrev.h` with a fixed label. src/shim is already on the -I path, so the quote-form lookup resolves it.

Closes the CI regression from #37. Demo URL stays https://adamziel.github.io/experiments/real-zfs/.