### PR TITLE
Make zfswasm.js an ES module so the browser demo loads

### DIFF
--- a/zfs-wasm-real/Makefile
+++ b/zfs-wasm-real/Makefile
@@ -196,7 +196,7 @@ ZFSWASM_LDFLAGS_COMMON := \
     -sALLOW_MEMORY_GROWTH=1 \
     -sINITIAL_MEMORY=67108864 \
     -sMODULARIZE=1 \
-    -sEXPORT_ES6=0 \
+    -sEXPORT_ES6=1 \
     -sEXPORT_NAME=ZfsWasm \
     -sENVIRONMENT=node,web,worker \
     -sFORCE_FILESYSTEM=1 \
@@ -231,6 +231,11 @@ $(BUILD)/zfswasm.o: src/zfswasm.c
 
 $(BUILD)/zfswasm.js: $(BUILD)/zfswasm.o $(BUILD)/libzfs.a $(BUILD)/libzpool.a $(BUILD)/libzcommon.a $(BUILD)/libnvpair.a $(BUILD)/libspl.a $(BUILD)/libshim.a
 	$(CC) $(CFLAGS) $(ZFSWASM_LDFLAGS) $^ -o $@
+	@# emscripten emits .js even with EXPORT_ES6=1; drop a package.json
+	@# next to it so Node treats files in build/ as ESM (without it,
+	@# Node 18 chokes on `import.meta.url` in the loader). The browser
+	@# loads the file by URL and does not care about package.json.
+	@printf '{"type":"module"}\n' > $(BUILD)/package.json
 
 $(BUILD)/libnvpair.a: $(NVPAIR_OBJS)
 	$(AR) rcs $@ $^

--- a/zfs-wasm-real/scripts/smoke-node.mjs
+++ b/zfs-wasm-real/scripts/smoke-node.mjs
@@ -12,16 +12,17 @@
 // pthread condvars — a direct blocking call into ZFS code unwinds.
 
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const BACKING = '/tmp/zfswasm-smoke.img';
 const SIZE = 128 * 1024 * 1024;
 
-const { createRequire } = await import('node:module');
-const require = createRequire(import.meta.url);
-
 const log = (line) => console.log(line);
 
-const ZfsWasm = require(path.join(process.cwd(), 'build', 'zfswasm.js'));
+// The wasm module is built with -sEXPORT_ES6=1 so the browser demo
+// can `import` it. Use the matching dynamic-ESM form here.
+const modUrl = pathToFileURL(path.join(process.cwd(), 'build', 'zfswasm.js'));
+const { default: ZfsWasm } = await import(modUrl.href);
 const mod = await ZfsWasm({
     print: (s) => console.log('[mod] ' + s),
     printErr: (s) => console.log('[mod-err] ' + s),

--- a/zfs-wasm-real/src/shim/zfs_gitrev.h
+++ b/zfs-wasm-real/src/shim/zfs_gitrev.h
@@ -1,0 +1,13 @@
+/*
+ * Stand-in for the autoconf-generated zfs_gitrev.h.
+ *
+ * OpenZFS's configure writes this to upstream/zfs/include/zfs_gitrev.h
+ * with the short git revision of the source tree. We never run ./configure
+ * in CI (we drive the build from a hand-rolled Makefile), so spa_history.c's
+ * `#include "zfs_gitrev.h"` would fail. A fixed label is fine — the demo
+ * logs it once in spa_history and we don't care about the exact hash.
+ */
+#ifndef _ZFS_GITREV_H
+#define _ZFS_GITREV_H
+#define ZFS_META_GITREV "zfs-2.2.6-wasm"
+#endif


### PR DESCRIPTION
Live demo at https://adamziel.github.io/experiments/real-zfs/ errors with:

    Uncaught SyntaxError: The requested module './build/zfswasm.js'
    does not provide an export named 'default' (at app.js:9:8)

The browser uses ESM (`import ZfsWasmFactory from "./build/zfswasm.js"`) but the wasm module was linked with `-sEXPORT_ES6=0`, which emits CJS. Flip the flag, and drop a tiny `build/package.json` so Node still treats the same file as ESM (without it Node 18 chokes on `import.meta.url`).

Node smoke unchanged behaviorally — full pool_create → snap → clone → read roundtrip still rc=0 across all three reads, including the snapshot serving pre-modification content.