### PR TITLE
real-zfs demo: tree-view UX surfacing every ZFS op

### DIFF
--- a/real-zfs/app.js
+++ b/real-zfs/app.js
@@ -1,37 +1,75 @@
-// Browser demo for the OpenZFS wasm bundle.
+// Browser demo for the OpenZFS-in-wasm bundle.
 //
-// The wasm module is built with -sPROXY_TO_PTHREAD, so all ZFS work
-// runs on a dedicated pthread worker. Exported zfswasm_*_begin
-// functions are non-blocking enqueues; we poll zfswasm_poll() until
-// the worker signals completion, then read the int rc from
-// zfswasm_result().
+// Wires every operation the wasm exposes (pool create/export, dataset
+// create/destroy, snapshot, snapshot destroy, clone, file read/write)
+// into a tree-view UI: dataset/snapshot tree on the left, file tree
+// in the middle, content editor on the right.
+//
+// The wasm runs on a dedicated pthread (-sPROXY_TO_PTHREAD), so each
+// op is a non-blocking enqueue followed by polling. We track the
+// dataset / snapshot / file tree on the JS side because the C bundle
+// does not yet expose `list` APIs — every state change here either
+// originated in this UI or in the demo seed scenario, so the mirror
+// stays accurate.
 
 import ZfsWasmFactory from "./build/zfswasm.js";
 
 const POOL = "tankw";
-const DS = `${POOL}/site`;
-const BRANCH = `${POOL}/branch`;
-const SNAP_NAME = "v1";
-const SNAP_FULL = `${DS}@${SNAP_NAME}`;
 const BACKING = "/tmp/zfswasm-demo.img";
 const BACKING_SIZE = 128 * 1024 * 1024;
 
+// ---------- DOM helpers ----------
+
 const $ = (id) => document.getElementById(id);
-const logEl = $("log");
-const log = (line) => {
-  logEl.textContent += line + "\n";
-  logEl.scrollTop = logEl.scrollHeight;
+const els = {
+  boot: $("boot"), reset: $("reset"),
+  mPool: $("m-pool"), mDs: $("m-datasets"),
+  mSnaps: $("m-snapshots"), mActive: $("m-active"),
+  dsTree: $("dataset-tree"), fileTree: $("file-tree"),
+  filesTitle: $("files-title"), filesSubtitle: $("files-subtitle"),
+  editor: $("editor"), editorTitle: $("editor-title"),
+  editorSubtitle: $("editor-subtitle"), editorStatus: $("editor-status"),
+  opSnap: $("op-snap"), opClone: $("op-clone"), opNewds: $("op-newds"),
+  opDestroy: $("op-destroy"), opNewfile: $("op-newfile"),
+  opSave: $("op-save"),
+  log: $("log"), clearLog: $("clear-log"),
+  promptDialog: $("prompt-dialog"), promptTitle: $("prompt-title"),
+  promptHelp: $("prompt-help"), promptInput: $("prompt-input"),
+  promptTextarea: $("prompt-textarea"),
 };
 
-let zfs;
+const log = (line) => {
+  const ts = new Date().toLocaleTimeString();
+  els.log.textContent += `[${ts}] ${line}\n`;
+  els.log.scrollTop = els.log.scrollHeight;
+};
+const setStatus = (msg, kind = "") => {
+  els.editorStatus.textContent = msg;
+  els.editorStatus.className = "status " + kind;
+};
 
-async function boot() {
-  const bootBtn = $("op-boot");
-  const status = $("boot-status");
-  bootBtn.disabled = true;
-  status.textContent = "loading wasm…";
-  status.className = "status";
+// ---------- State ----------
 
+const state = {
+  zfs: null,
+  pool: null,
+  // Map<datasetFullName, { kind: 'ds' | 'clone',
+  //                       parentSnap?: 'pool/ds@snap',
+  //                       files: Map<path, { size }>,
+  //                       snaps: string[] }>
+  datasets: new Map(),
+  active: null,            // selected node: { kind, ds, snap?, file? }
+  busy: false,
+};
+
+const isSnapshot = (id) => id.includes("@");
+const dsOfSnap   = (snap) => snap.split("@")[0];
+
+// ---------- WASM bindings ----------
+
+async function bootZfs() {
+  els.boot.disabled = true;
+  log("loading wasm…");
   const mod = await ZfsWasmFactory({
     print: (s) => log("[mod] " + s),
     printErr: (s) => log("[mod-err] " + s),
@@ -41,47 +79,23 @@ async function boot() {
   mod.FS.mkdirTree("/tmp");
   mod.FS.writeFile(BACKING, new Uint8Array(BACKING_SIZE));
 
-  const bindings = bindApi(mod);
-
-  status.textContent = "creating pool…";
-  let rc = await bindings.runOp(bindings.init);
-  if (rc !== 0) throw new Error(`init rc=${rc}`);
-
-  rc = await bindings.runOp(bindings.poolCreate, POOL, BACKING);
-  if (rc !== 0) throw new Error(`pool_create rc=${rc}`);
-
-  rc = await bindings.runOp(bindings.dsCreate, DS);
-  if (rc !== 0) throw new Error(`ds_create rc=${rc}`);
-
-  zfs = bindings;
-  status.textContent = `pool ${POOL} ready, dataset ${DS} created.`;
-  status.classList.add("ok");
-  $("ops-card").hidden = false;
-  $("results-card").hidden = false;
-  log("[boot] OK");
-}
-
-function bindApi(mod) {
-  const _poll = mod.cwrap("zfswasm_poll", "number", []);
+  const _poll   = mod.cwrap("zfswasm_poll", "number", []);
   const _result = mod.cwrap("zfswasm_result", "number", []);
-  const init = mod.cwrap("zfswasm_init_begin", "number", []);
-  const poolCreate = mod.cwrap("zfswasm_pool_create_begin", "number",
-    ["string", "string"]);
-  const dsCreate = mod.cwrap("zfswasm_ds_create_begin", "number",
-    ["string"]);
-  const snap = mod.cwrap("zfswasm_snap_begin", "number",
-    ["string", "string"]);
-  const clone = mod.cwrap("zfswasm_clone_begin", "number",
-    ["string", "string"]);
-  const _fw = mod.cwrap("zfswasm_file_write_begin", "number",
-    ["string", "string", "number", "number"]);
-  const _fr = mod.cwrap("zfswasm_file_read_begin", "number",
-    ["string", "string", "number", "number", "number"]);
+  const init    = mod.cwrap("zfswasm_init_begin", "number", []);
+  const pcreate = mod.cwrap("zfswasm_pool_create_begin", "number", ["string","string"]);
+  const dscreate= mod.cwrap("zfswasm_ds_create_begin", "number", ["string"]);
+  const dsdestr = mod.cwrap("zfswasm_ds_destroy_begin", "number", ["string"]);
+  const snap    = mod.cwrap("zfswasm_snap_begin", "number", ["string","string"]);
+  const sndest  = mod.cwrap("zfswasm_snap_destroy_begin", "number", ["string"]);
+  const clone   = mod.cwrap("zfswasm_clone_begin", "number", ["string","string"]);
+  const fw      = mod.cwrap("zfswasm_file_write_begin", "number",
+                            ["string","string","number","number"]);
+  const fr      = mod.cwrap("zfswasm_file_read_begin", "number",
+                            ["string","string","number","number","number"]);
 
   const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-
-  async function runOp(beginFn, ...args) {
-    const rc = beginFn(...args);
+  async function call(begin, ...args) {
+    const rc = begin(...args);
     if (rc !== 0) throw new Error(`enqueue rc=${rc}`);
     let delay = 1;
     while (_poll() === 0) {
@@ -91,99 +105,430 @@ function bindApi(mod) {
     return _result();
   }
 
-  async function fileWrite(ds, path, text) {
-    const bytes = new TextEncoder().encode(text);
-    const buf = mod._malloc(bytes.length || 1);
-    try {
-      if (bytes.length) mod.HEAPU8.set(bytes, buf);
-      return await runOp(_fw, ds, path, buf, bytes.length);
-    } finally {
-      mod._free(buf);
-    }
-  }
-
-  async function fileRead(ds, path, cap = 4096) {
-    const buf = mod._malloc(cap);
-    const outLen = mod._malloc(4);
-    try {
-      const rc = await runOp(_fr, ds, path, buf, cap, outLen);
-      if (rc !== 0) return { rc, data: null };
-      const len = mod.HEAPU32[outLen >> 2];
-      const data = new TextDecoder().decode(
-        mod.HEAPU8.subarray(buf, buf + len));
-      return { rc: 0, data };
-    } finally {
-      mod._free(buf);
-      mod._free(outLen);
-    }
-  }
-
   return {
-    init, poolCreate, dsCreate, snap, clone,
-    runOp, fileWrite, fileRead,
+    mod,
+    init:      ()         => call(init),
+    poolCreate:(name, bk) => call(pcreate, name, bk),
+    dsCreate:  (full)     => call(dscreate, full),
+    dsDestroy: (full)     => call(dsdestr,  full),
+    snap:      (ds, name) => call(snap, ds, name),
+    snapDestroy:(full)    => call(sndest, full),
+    clone:     (snap, dst)=> call(clone, snap, dst),
+    async fileWrite(ds, path, text) {
+      const bytes = new TextEncoder().encode(text);
+      const buf = mod._malloc(bytes.length || 1);
+      try {
+        if (bytes.length) mod.HEAPU8.set(bytes, buf);
+        return await call(fw, ds, path, buf, bytes.length);
+      } finally { mod._free(buf); }
+    },
+    async fileRead(ds, path, cap = 16384) {
+      const buf = mod._malloc(cap);
+      const out = mod._malloc(4);
+      try {
+        const rc = await call(fr, ds, path, buf, cap, out);
+        if (rc !== 0) return { rc, data: null };
+        const len = mod.HEAPU32[out >> 2];
+        return {
+          rc: 0,
+          data: new TextDecoder().decode(mod.HEAPU8.subarray(buf, buf + len)),
+          len,
+        };
+      } finally { mod._free(buf); mod._free(out); }
+    },
   };
 }
 
-async function writeMain() {
-  const text = $("main-text").value;
-  log(`[write main] ${JSON.stringify(text)}`);
-  const rc = await zfs.fileWrite(DS, "/file.txt", text);
-  log(`[write main] rc=${rc}`);
+// ---------- Boot + demo seed ----------
+
+async function boot() {
+  try {
+    state.zfs = await bootZfs();
+    log("init…");
+    if ((await state.zfs.init()) !== 0) throw new Error("init failed");
+    log(`pool_create ${POOL} on ${BACKING}`);
+    if ((await state.zfs.poolCreate(POOL, BACKING)) !== 0)
+      throw new Error("pool_create failed");
+    state.pool = POOL;
+
+    // Seed: site dataset with two files, snapshot, clone, branch edits.
+    await mkDataset(`${POOL}/site`);
+    await writeFile(`${POOL}/site`, "/index.html",
+      "<h1>Hello from OpenZFS</h1>\n<p>Edit me, snapshot, branch.</p>\n");
+    await writeFile(`${POOL}/site`, "/notes.txt",
+      "Welcome — try the Snapshot button on tankw/site, then Clone.\n");
+    await mkSnap(`${POOL}/site`, "v1");
+    await mkClone(`${POOL}/site@v1`, `${POOL}/branch`);
+    await writeFile(`${POOL}/branch`, "/index.html",
+      "<h1>Hello from a branch</h1>\n<p>This is the cloned dataset.</p>\n");
+
+    setActive({ kind: "ds", ds: `${POOL}/site` });
+    refresh();
+    [els.opSnap, els.opClone, els.opNewds, els.opDestroy,
+     els.opNewfile, els.opSave, els.reset].forEach((b) => (b.disabled = false));
+    setStatus("ready", "ok");
+  } catch (e) {
+    log("[err] " + e.message);
+    setStatus(e.message, "err");
+    els.boot.disabled = false;
+  }
 }
 
-async function snap() {
-  log(`[snap] ${SNAP_FULL}`);
-  const rc = await zfs.runOp(zfs.snap, DS, SNAP_NAME);
-  log(`[snap] rc=${rc}`);
+// ---------- State mutators ----------
+
+async function mkDataset(full) {
+  log(`ds_create ${full}`);
+  const rc = await state.zfs.dsCreate(full);
+  if (rc !== 0) throw new Error(`ds_create rc=${rc}`);
+  state.datasets.set(full, { kind: "ds", files: new Map(), snaps: [] });
 }
 
-async function clone() {
-  log(`[clone] ${SNAP_FULL} -> ${BRANCH}`);
-  const rc = await zfs.runOp(zfs.clone, SNAP_FULL, BRANCH);
-  log(`[clone] rc=${rc}`);
+async function mkSnap(ds, name) {
+  log(`snap ${ds}@${name}`);
+  const rc = await state.zfs.snap(ds, name);
+  if (rc !== 0) throw new Error(`snap rc=${rc}`);
+  state.datasets.get(ds).snaps.push(name);
 }
 
-async function writeBranch() {
-  const text = $("branch-text").value;
-  log(`[write branch] ${JSON.stringify(text)}`);
-  const rc = await zfs.fileWrite(BRANCH, "/file.txt", text);
-  log(`[write branch] rc=${rc}`);
+async function mkClone(snap, dst) {
+  log(`clone ${snap} -> ${dst}`);
+  const rc = await state.zfs.clone(snap, dst);
+  if (rc !== 0) throw new Error(`clone rc=${rc}`);
+  // Inherit files from the parent at snap time (best-effort mirror).
+  const parentFiles = state.datasets.get(dsOfSnap(snap))?.files
+                       ?? new Map();
+  state.datasets.set(dst, {
+    kind: "clone",
+    parentSnap: snap,
+    files: new Map([...parentFiles]),
+    snaps: [],
+  });
 }
 
-async function readAll() {
-  log("[read] site / branch / snapshot");
-  const a = await zfs.fileRead(DS, "/file.txt");
-  const b = await zfs.fileRead(BRANCH, "/file.txt");
-  const c = await zfs.fileRead(SNAP_FULL, "/file.txt");
-  $("out-site").textContent = render(a);
-  $("out-branch").textContent = render(b);
-  $("out-snap").textContent = render(c);
+async function writeFile(ds, path, text) {
+  log(`file_write ${ds}:${path} (${text.length}B)`);
+  const rc = await state.zfs.fileWrite(ds, path, text);
+  if (rc !== 0) throw new Error(`file_write rc=${rc}`);
+  const meta = state.datasets.get(ds);
+  if (meta) meta.files.set(path, { size: text.length });
 }
 
-function render({ rc, data }) {
-  if (rc !== 0) return `rc=${rc}`;
-  return data || "(empty)";
+async function destroyDataset(full) {
+  log(`destroy ${full}`);
+  const rc = isSnapshot(full)
+    ? await state.zfs.snapDestroy(full)
+    : await state.zfs.dsDestroy(full);
+  if (rc !== 0) throw new Error(`destroy rc=${rc}`);
+  if (isSnapshot(full)) {
+    const ds = state.datasets.get(dsOfSnap(full));
+    if (ds) ds.snaps = ds.snaps.filter((n) => `${dsOfSnap(full)}@${n}` !== full);
+  } else {
+    state.datasets.delete(full);
+  }
 }
 
-function wire(id, fn) {
-  $(id).addEventListener("click", async () => {
-    try {
-      await fn();
-    } catch (e) {
-      log("[err] " + e.message);
+// ---------- UI: tree rendering ----------
+
+function refresh() {
+  // Active label
+  els.mPool.textContent = state.pool ?? "—";
+  els.mDs.textContent = [...state.datasets.values()].length;
+  els.mSnaps.textContent = [...state.datasets.values()]
+    .reduce((n, d) => n + d.snaps.length, 0);
+  els.mActive.textContent = activeLabel();
+
+  renderDatasetTree();
+  renderFileTree();
+  renderEditor();
+}
+
+function activeLabel() {
+  if (!state.active) return "—";
+  const a = state.active;
+  if (a.kind === "snap") return `${a.ds}@${a.snap}`;
+  return a.ds;
+}
+
+function renderDatasetTree() {
+  els.dsTree.innerHTML = "";
+  if (!state.pool) return;
+  // Pool root.
+  const root = node({
+    label: state.pool, tag: "POOL", className: "tree-node muted",
+  });
+  els.dsTree.appendChild(root);
+
+  // Build parent-snap -> [clone names] map.
+  const childrenOfSnap = new Map();
+  for (const [name, meta] of state.datasets) {
+    if (meta.kind === "clone")
+      childrenOfSnap.set(meta.parentSnap,
+        [...(childrenOfSnap.get(meta.parentSnap) ?? []), name]);
+  }
+
+  // Top-level datasets: directly under pool, not clones of any snap.
+  const topLevel = [...state.datasets.entries()]
+    .filter(([, m]) => m.kind === "ds")
+    .map(([n]) => n)
+    .sort();
+
+  const wrap = document.createElement("div");
+  wrap.className = "tree-children";
+  root.after(wrap);
+
+  for (const ds of topLevel) renderDatasetSubtree(wrap, ds, childrenOfSnap);
+}
+
+function renderDatasetSubtree(parentEl, ds, childrenOfSnap) {
+  const meta = state.datasets.get(ds);
+  const tagText = meta.kind === "clone" ? "clone" : "ds";
+  const dsEl = node({
+    label: ds, tag: tagText, className: "tree-node",
+    selected: state.active?.kind !== "snap" && state.active?.ds === ds,
+    onClick: () => { setActive({ kind: "ds", ds }); refresh(); },
+  });
+  parentEl.appendChild(dsEl);
+
+  const children = document.createElement("div");
+  children.className = "tree-children";
+  parentEl.appendChild(children);
+
+  for (const snap of meta.snaps) {
+    const full = `${ds}@${snap}`;
+    const snapEl = node({
+      label: `@${snap}`, tag: "snap ro", className: "tree-node snap",
+      selected: state.active?.kind === "snap" && state.active.ds === ds
+        && state.active.snap === snap,
+      onClick: () => { setActive({ kind: "snap", ds, snap }); refresh(); },
+    });
+    children.appendChild(snapEl);
+
+    const cloneNames = childrenOfSnap.get(full) ?? [];
+    for (const c of cloneNames) {
+      const sub = document.createElement("div");
+      sub.className = "tree-children";
+      children.appendChild(sub);
+      renderDatasetSubtree(sub, c, childrenOfSnap);
     }
+  }
+}
+
+function renderFileTree() {
+  els.fileTree.innerHTML = "";
+  if (!state.active) return;
+  const ds = state.active.ds;
+  const meta = state.datasets.get(ds);
+  if (!meta) return;
+
+  const isSnap = state.active.kind === "snap";
+  els.filesTitle.textContent = isSnap
+    ? `Files in ${ds}@${state.active.snap}` : `Files in ${ds}`;
+  els.filesSubtitle.textContent = isSnap
+    ? "Read-only view of the snapshot."
+    : "Click a file to open.";
+
+  const sorted = [...meta.files.keys()].sort();
+  if (!sorted.length) {
+    const empty = document.createElement("div");
+    empty.className = "tree-node muted";
+    empty.textContent = "(empty)";
+    els.fileTree.appendChild(empty);
+    return;
+  }
+
+  for (const path of sorted) {
+    const file = meta.files.get(path);
+    const el = node({
+      label: path, tag: `${file.size}B`, className: "tree-node",
+      selected: state.active?.file === path,
+      onClick: () => {
+        state.active = { ...state.active, file: path };
+        refresh();
+        loadFileIntoEditor(path);
+      },
+    });
+    els.fileTree.appendChild(el);
+  }
+}
+
+async function loadFileIntoEditor(path) {
+  const target = state.active.kind === "snap"
+    ? `${state.active.ds}@${state.active.snap}`
+    : state.active.ds;
+  log(`file_read ${target}:${path}`);
+  const r = await state.zfs.fileRead(target, path);
+  if (r.rc !== 0) {
+    setStatus(`file_read rc=${r.rc}`, "err");
+    return;
+  }
+  els.editor.value = r.data ?? "";
+  els.editor.disabled = state.active.kind === "snap";
+  els.editorTitle.textContent = `${target}:${path}`;
+  els.editorSubtitle.textContent = state.active.kind === "snap"
+    ? "Snapshot — read only" : "Edit and Save to write back to ZFS.";
+  els.opSave.disabled = state.active.kind === "snap";
+  setStatus(`${r.len} bytes`, "ok");
+}
+
+function renderEditor() {
+  if (!state.active?.file) {
+    els.editor.value = "";
+    els.editor.disabled = true;
+    els.editorTitle.textContent = "No file selected";
+    els.editorSubtitle.textContent = "Pick a file from the file tree.";
+    els.opSave.disabled = true;
+    setStatus("");
+  }
+}
+
+function setActive(active) {
+  state.active = active;
+}
+
+function node({ label, tag, className, selected, onClick }) {
+  const el = document.createElement("div");
+  el.className = className + (selected ? " selected" : "");
+  el.role = "treeitem";
+
+  const lbl = document.createElement("span");
+  lbl.textContent = label;
+  el.appendChild(lbl);
+
+  if (tag) {
+    for (const t of String(tag).split(" ")) {
+      const badge = document.createElement("span");
+      badge.className = `tag ${t}`;
+      badge.textContent = t.toUpperCase();
+      el.appendChild(badge);
+    }
+  }
+  if (onClick) el.addEventListener("click", onClick);
+  return el;
+}
+
+// ---------- Prompt dialog ----------
+
+function promptText({ title, help, value = "", multiline = false }) {
+  return new Promise((resolve) => {
+    els.promptTitle.textContent = title;
+    els.promptHelp.textContent = help ?? "";
+    els.promptInput.value = value;
+    els.promptInput.hidden = !!multiline;
+    els.promptTextarea.hidden = !multiline;
+    if (multiline) els.promptTextarea.value = value;
+    const onClose = () => {
+      els.promptDialog.removeEventListener("close", onClose);
+      const v = els.promptDialog.returnValue === "ok"
+        ? (multiline ? els.promptTextarea.value : els.promptInput.value)
+        : null;
+      resolve(v);
+    };
+    els.promptDialog.addEventListener("close", onClose);
+    els.promptDialog.showModal();
+    setTimeout(() => {
+      (multiline ? els.promptTextarea : els.promptInput).focus();
+    }, 0);
   });
 }
 
-$("op-boot").addEventListener("click", () => {
-  boot().catch((e) => {
-    $("boot-status").textContent = "boot failed: " + e.message;
-    $("boot-status").className = "status err";
-    log("[boot err] " + e.message);
+// ---------- Toolbar wiring ----------
+
+function withBusy(fn) {
+  return async (...args) => {
+    if (state.busy) return;
+    state.busy = true;
+    try { await fn(...args); }
+    catch (e) { log("[err] " + e.message); setStatus(e.message, "err"); }
+    finally { state.busy = false; refresh(); }
+  };
+}
+
+els.boot.addEventListener("click", boot);
+
+els.opSnap.addEventListener("click", withBusy(async () => {
+  if (!state.active || state.active.kind !== "ds") {
+    setStatus("select a dataset first", "err"); return;
+  }
+  const name = await promptText({
+    title: `Snapshot ${state.active.ds}`,
+    help: "Snap name. Will be saved as " + state.active.ds + "@<name>.",
+    value: `v${(state.datasets.get(state.active.ds).snaps.length || 0) + 1}`,
   });
-});
-wire("op-write-main", writeMain);
-wire("op-snap", snap);
-wire("op-clone", clone);
-wire("op-write-branch", writeBranch);
-wire("op-read", readAll);
+  if (!name) return;
+  await mkSnap(state.active.ds, name);
+  setStatus(`snapshot ${state.active.ds}@${name}`, "ok");
+}));
+
+els.opClone.addEventListener("click", withBusy(async () => {
+  if (!state.active || state.active.kind !== "snap") {
+    setStatus("select a snapshot first", "err"); return;
+  }
+  const dst = await promptText({
+    title: `Clone ${state.active.ds}@${state.active.snap}`,
+    help: "New dataset name. Must be unique under the pool.",
+    value: `${POOL}/clone${state.datasets.size}`,
+  });
+  if (!dst) return;
+  await mkClone(`${state.active.ds}@${state.active.snap}`, dst);
+  setActive({ kind: "ds", ds: dst });
+  setStatus(`cloned to ${dst}`, "ok");
+}));
+
+els.opNewds.addEventListener("click", withBusy(async () => {
+  const name = await promptText({
+    title: "New dataset",
+    help: `Will be created as ${POOL}/<name>.`,
+    value: "data",
+  });
+  if (!name) return;
+  const full = `${POOL}/${name}`;
+  await mkDataset(full);
+  setActive({ kind: "ds", ds: full });
+  setStatus(`created ${full}`, "ok");
+}));
+
+els.opDestroy.addEventListener("click", withBusy(async () => {
+  if (!state.active) return;
+  const target = state.active.kind === "snap"
+    ? `${state.active.ds}@${state.active.snap}`
+    : state.active.ds;
+  const ok = confirm(`Destroy ${target}?`);
+  if (!ok) return;
+  await destroyDataset(target);
+  setActive(null);
+  setStatus(`destroyed ${target}`, "ok");
+}));
+
+els.opNewfile.addEventListener("click", withBusy(async () => {
+  if (!state.active || state.active.kind !== "ds") {
+    setStatus("select a dataset first", "err"); return;
+  }
+  const path = await promptText({
+    title: `New file in ${state.active.ds}`,
+    help: "File path inside the dataset (e.g. /readme.md).",
+    value: "/readme.md",
+  });
+  if (!path) return;
+  const text = await promptText({
+    title: `Initial content for ${path}`,
+    help: "UTF-8. Stored as a DMU plain-file object.",
+    value: "Hello from the wasm ZFS demo.\n",
+    multiline: true,
+  });
+  if (text === null) return;
+  await writeFile(state.active.ds, path, text);
+  state.active.file = path;
+  setStatus(`wrote ${path}`, "ok");
+  refresh();
+  loadFileIntoEditor(path);
+}));
+
+els.opSave.addEventListener("click", withBusy(async () => {
+  if (!state.active?.file || state.active.kind === "snap") return;
+  const text = els.editor.value;
+  await writeFile(state.active.ds, state.active.file, text);
+  setStatus(`saved ${text.length} bytes`, "ok");
+}));
+
+els.reset.addEventListener("click", () => window.location.reload());
+els.clearLog.addEventListener("click", () => { els.log.textContent = ""; });

--- a/real-zfs/index.html
+++ b/real-zfs/index.html
@@ -3,16 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>OpenZFS in WebAssembly — live demo</title>
+    <title>OpenZFS in WebAssembly — interactive demo</title>
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
     <!--
-      Pthread support in emscripten needs SharedArrayBuffer, which the
-      browser only allows when the page is cross-origin isolated. GitHub
-      Pages does not let us set response headers, so the service worker
-      at sw.js reinjects COOP: same-origin / COEP: require-corp on every
-      fetch before handing the request to the page.
+      SharedArrayBuffer + Emscripten pthreads need cross-origin
+      isolation. GitHub Pages cannot set headers, so the service
+      worker re-injects COOP/COEP on every fetch.
     -->
     <script>
       if ("serviceWorker" in navigator && !window.crossOriginIsolated) {
@@ -26,79 +24,125 @@
       }
     </script>
 
-    <main>
-      <header>
-        <h1>OpenZFS in WebAssembly</h1>
-        <p class="sub">
-          Real OpenZFS 2.2.6 userland, compiled to wasm with Emscripten.
-          A pool on a 128 MiB file in the module's virtual FS. Real
-          snapshots, real copy-on-write clones.
-        </p>
-        <p class="sub small">
-          Source + Dockerized build pipeline:
-          <a href="https://github.com/adamziel/experiments/tree/main/zfs-wasm-real">zfs-wasm-real/</a>.
-        </p>
+    <div class="page-shell">
+      <header class="hero">
+        <div class="hero-copy">
+          <p class="eyebrow">OpenZFS in WebAssembly</p>
+          <h1>Real ZFS pool, snapshots, and clones — in your browser tab.</h1>
+          <p class="hero-text">
+            OpenZFS 2.2.6 userland compiled with Emscripten. A 128 MiB pool
+            on a file in MEMFS. Every dataset is a real DMU object set;
+            every snapshot is a real DSL snapshot; every clone is true
+            copy-on-write. Drive it from the panels below.
+          </p>
+          <div class="hero-actions">
+            <button id="boot" class="primary">Boot pool + load demo</button>
+            <button id="reset" class="ghost" disabled>Reset</button>
+          </div>
+        </div>
+        <div class="hero-card">
+          <div class="metric">
+            <span class="metric-label">Pool</span>
+            <strong id="m-pool">—</strong>
+          </div>
+          <div class="metric">
+            <span class="metric-label">Datasets</span>
+            <strong id="m-datasets">0</strong>
+          </div>
+          <div class="metric">
+            <span class="metric-label">Snapshots</span>
+            <strong id="m-snapshots">0</strong>
+          </div>
+          <div class="metric">
+            <span class="metric-label">Active</span>
+            <strong id="m-active">—</strong>
+          </div>
+        </div>
       </header>
 
-      <section class="card">
-        <h2>1. Boot the module</h2>
-        <p class="help">
-          Starts the wasm module on a dedicated pthread worker, creates a
-          128 MiB backing file in MEMFS, then runs <code>spa_create</code>
-          to produce pool <code>tankw</code> and dataset
-          <code>tankw/site</code>.
-        </p>
-        <button id="op-boot">Boot pool</button>
-        <div id="boot-status" class="status"></div>
-      </section>
+      <main class="studio-grid">
+        <section class="panel">
+          <div class="panel-heading">
+            <p class="eyebrow">Versioning</p>
+            <h2>Datasets &amp; snapshots</h2>
+            <p class="panel-subtitle">
+              Click a dataset to make it active. Click a snapshot to read
+              from it. Clones nest under the snapshot they were made from.
+            </p>
+          </div>
+          <div class="toolbar">
+            <button id="op-snap" class="small" disabled>Snapshot…</button>
+            <button id="op-clone" class="small" disabled>Clone snap…</button>
+            <button id="op-newds" class="small" disabled>New dataset…</button>
+            <button id="op-destroy" class="small ghost" disabled>Destroy…</button>
+          </div>
+          <div id="dataset-tree" class="tree"></div>
+        </section>
 
-      <section class="card" id="ops-card" hidden>
-        <h2>2. Write → snapshot → clone → read</h2>
-        <div class="grid">
-          <label>
-            <span>Write to <code>tankw/site:/file.txt</code></span>
-            <input id="main-text" value="hello world on main" />
-          </label>
-          <button id="op-write-main">Write main</button>
-          <button id="op-snap">Snapshot <code>@v1</code></button>
-          <button id="op-clone">Clone into <code>tankw/branch</code></button>
-          <label>
-            <span>Overwrite on <code>tankw/branch:/file.txt</code></span>
-            <input id="branch-text" value="on branch" />
-          </label>
-          <button id="op-write-branch">Write branch</button>
-          <button id="op-read">Read all three</button>
+        <section class="panel">
+          <div class="panel-heading">
+            <p class="eyebrow">Data</p>
+            <h2 id="files-title">Files</h2>
+            <p class="panel-subtitle" id="files-subtitle">
+              Each dataset has its own root ZAP. Files are real DMU
+              objects.
+            </p>
+          </div>
+          <div class="toolbar">
+            <button id="op-newfile" class="small" disabled>New file…</button>
+          </div>
+          <div id="file-tree" class="tree"></div>
+        </section>
+
+        <section class="panel preview">
+          <div class="panel-heading">
+            <p class="eyebrow">Preview</p>
+            <h2 id="editor-title">No file selected</h2>
+            <p class="panel-subtitle" id="editor-subtitle">
+              Pick a file from the file tree.
+            </p>
+          </div>
+          <textarea id="editor" placeholder="" disabled></textarea>
+          <div class="toolbar">
+            <button id="op-save" class="primary" disabled>Save</button>
+            <span id="editor-status" class="status"></span>
+          </div>
+        </section>
+
+        <section class="panel log-panel">
+          <div class="panel-heading">
+            <p class="eyebrow">Audit</p>
+            <h2>Journal</h2>
+            <p class="panel-subtitle">
+              Every wasm call, in order. Useful when you want to convince
+              yourself this is really hitting OpenZFS code.
+            </p>
+          </div>
+          <div class="toolbar">
+            <button id="clear-log" class="small ghost">Clear</button>
+          </div>
+          <pre id="log"></pre>
+        </section>
+      </main>
+    </div>
+
+    <!-- Modal for short text prompts (snap name, clone name, etc.) -->
+    <dialog id="prompt-dialog">
+      <form method="dialog">
+        <h3 id="prompt-title">Name</h3>
+        <p id="prompt-help" class="prompt-help"></p>
+        <input id="prompt-input" autocomplete="off" />
+        <textarea
+          id="prompt-textarea"
+          placeholder=""
+          rows="4"
+          hidden></textarea>
+        <div class="prompt-actions">
+          <button value="cancel" class="ghost">Cancel</button>
+          <button value="ok" class="primary">OK</button>
         </div>
-      </section>
-
-      <section class="card" id="results-card" hidden>
-        <h2>3. Results</h2>
-        <div class="results">
-          <div>
-            <strong>tankw/site</strong>
-            <pre id="out-site">—</pre>
-          </div>
-          <div>
-            <strong>tankw/branch</strong>
-            <pre id="out-branch">—</pre>
-          </div>
-          <div>
-            <strong>tankw/site@v1</strong>
-            <pre id="out-snap">—</pre>
-          </div>
-        </div>
-        <p class="hint">
-          The snapshot returns the pre-modification content even after the
-          live dataset is overwritten — that is COW working on the real
-          OpenZFS DMU.
-        </p>
-      </section>
-
-      <section class="card">
-        <h2>Log</h2>
-        <pre id="log"></pre>
-      </section>
-    </main>
+      </form>
+    </dialog>
 
     <script type="module" src="./app.js"></script>
   </body>

--- a/real-zfs/styles.css
+++ b/real-zfs/styles.css
@@ -1,14 +1,18 @@
 :root {
   --bg: #0b0f18;
-  --panel: #121827;
-  --panel-line: #1f2a40;
-  --ink: #e2e8f0;
-  --ink-dim: #94a3b8;
+  --bg-elev: #121827;
+  --bg-elev-2: #1a2233;
+  --line: #1f2a40;
+  --line-strong: #2c3a55;
+  --ink: #e6edf6;
+  --ink-dim: #93a1b9;
+  --ink-muted: #6a7790;
   --accent: #60a5fa;
+  --accent-2: #818cf8;
   --ok: #34d399;
   --warn: #fbbf24;
   --err: #f87171;
-  --radius: 10px;
+  --radius: 12px;
 }
 
 * {
@@ -17,35 +21,22 @@
 
 html, body {
   margin: 0;
-  padding: 0;
-  background: var(--bg);
+  background: radial-gradient(
+      1100px 600px at 80% -10%, rgba(96, 165, 250, 0.10), transparent 60%),
+    radial-gradient(
+      900px 500px at -10% 110%, rgba(129, 140, 248, 0.10), transparent 55%),
+    var(--bg);
   color: var(--ink);
-  font: 15px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font: 14px/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  min-height: 100%;
 }
 
-code, pre, input {
-  font-family: ui-monospace, SFMono-Regular, "Menlo", monospace;
-  font-size: 13px;
+body {
+  padding: 28px;
 }
 
-main {
-  max-width: 920px;
-  margin: 0 auto;
-  padding: 32px 20px 80px;
-}
-
-header h1 {
-  font-size: 30px;
-  margin: 0 0 4px;
-  letter-spacing: -0.01em;
-}
-
-.sub {
-  color: var(--ink-dim);
-  margin: 0 0 6px;
-}
-
-.sub.small {
+code, pre, textarea, input {
+  font-family: ui-monospace, SFMono-Regular, "Menlo", "Consolas", monospace;
   font-size: 13px;
 }
 
@@ -53,60 +44,134 @@ a {
   color: var(--accent);
 }
 
-.card {
-  background: var(--panel);
-  border: 1px solid var(--panel-line);
-  border-radius: var(--radius);
-  padding: 18px 20px;
-  margin: 18px 0;
+.page-shell {
+  max-width: 1500px;
+  margin: 0 auto;
 }
 
-.card h2 {
-  font-size: 16px;
-  margin: 0 0 10px;
-  color: var(--ink);
+/* ----- Hero ----- */
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(280px, 0.7fr);
+  gap: 20px;
+  margin-bottom: 22px;
 }
 
-.help {
+.hero h1 {
+  font-size: 24px;
+  margin: 4px 0 8px;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+}
+
+.eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0;
+}
+
+.hero-text {
   color: var(--ink-dim);
   margin: 0 0 14px;
 }
 
-.grid {
+.hero-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.hero-card {
+  background: var(--bg-elev);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 16px;
   display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 10px 12px;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.metric {
+  background: var(--bg-elev-2);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.metric-label {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  margin-bottom: 2px;
+}
+
+.metric strong {
+  font-size: 16px;
+  color: var(--ink);
+  word-break: break-all;
+}
+
+/* ----- Studio grid ----- */
+
+.studio-grid {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(220px, 1fr) minmax(360px, 1.6fr);
+  grid-template-rows: minmax(280px, 1fr) minmax(180px, 0.6fr);
+  gap: 16px;
+}
+
+.panel {
+  background: var(--bg-elev);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.panel.preview {
+  grid-row: span 1;
+}
+
+.panel.log-panel {
+  grid-column: 1 / -1;
+}
+
+.panel-heading h2 {
+  font-size: 15px;
+  margin: 2px 0 4px;
+}
+
+.panel-subtitle {
+  color: var(--ink-dim);
+  font-size: 12px;
+  margin: 0 0 10px;
+}
+
+.toolbar {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
   align-items: center;
 }
 
-label {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-label span {
-  color: var(--ink-dim);
-  font-size: 13px;
-}
-
-input {
-  background: #0d1422;
-  color: var(--ink);
-  border: 1px solid var(--panel-line);
-  border-radius: 6px;
-  padding: 8px 10px;
-  width: 100%;
-}
+/* ----- Buttons ----- */
 
 button {
-  background: var(--accent);
-  color: #0b0f18;
+  cursor: pointer;
   border: 0;
   border-radius: 6px;
   padding: 8px 14px;
   font-weight: 600;
-  cursor: pointer;
+  font-size: 13px;
+  background: var(--accent);
+  color: #0b0f18;
+  transition: transform 90ms ease, opacity 90ms ease, background 90ms ease;
 }
 
 button:disabled {
@@ -114,60 +179,191 @@ button:disabled {
   cursor: not-allowed;
 }
 
-.status {
-  margin-top: 10px;
-  color: var(--ink-dim);
-  font-size: 13px;
+button:not(:disabled):hover {
+  transform: translateY(-1px);
 }
 
-.status.ok {
-  color: var(--ok);
-}
-
-.status.err {
-  color: var(--err);
-}
-
-.results {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  gap: 12px;
-}
-
-.results pre {
-  background: #0d1422;
-  border: 1px solid var(--panel-line);
-  border-radius: 6px;
-  padding: 10px;
-  margin: 6px 0 0;
-  overflow: auto;
-  white-space: pre-wrap;
-  color: var(--ink);
-}
-
-.hint {
-  color: var(--ink-dim);
-  margin: 14px 0 0;
-  font-size: 13px;
-}
-
-#log {
-  background: #0d1422;
-  border: 1px solid var(--panel-line);
-  border-radius: 6px;
-  padding: 10px;
-  margin: 0;
-  max-height: 240px;
-  overflow: auto;
-  color: var(--ink-dim);
+button.small {
+  padding: 5px 10px;
   font-size: 12px;
 }
 
+button.ghost {
+  background: var(--bg-elev-2);
+  color: var(--ink);
+  border: 1px solid var(--line-strong);
+}
+
+button.primary {
+  background: var(--accent);
+  color: #0b0f18;
+}
+
+/* ----- Trees ----- */
+
+.tree {
+  flex: 1;
+  min-height: 120px;
+  overflow: auto;
+  background: #0d1422;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 6px 4px;
+}
+
+.tree-node {
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--ink);
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 12.5px;
+  user-select: none;
+}
+
+.tree-node:hover {
+  background: rgba(96, 165, 250, 0.08);
+}
+
+.tree-node.selected {
+  background: rgba(96, 165, 250, 0.18);
+  color: var(--ink);
+}
+
+.tree-node.snap {
+  color: var(--accent-2);
+}
+
+.tree-node.muted {
+  color: var(--ink-muted);
+}
+
+.tree-children {
+  margin-left: 14px;
+  border-left: 1px dashed var(--line);
+  padding-left: 6px;
+}
+
+.tag {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgba(129, 140, 248, 0.18);
+  color: var(--accent-2);
+  letter-spacing: 0.04em;
+}
+
+.tag.ds   { background: rgba(96, 165, 250, 0.18); color: var(--accent); }
+.tag.snap { background: rgba(129, 140, 248, 0.18); color: var(--accent-2); }
+.tag.clone{ background: rgba(52, 211, 153, 0.18); color: var(--ok); }
+.tag.ro   { background: rgba(251, 191, 36, 0.20); color: var(--warn); }
+
+/* ----- Editor ----- */
+
+.preview textarea {
+  flex: 1;
+  min-height: 200px;
+  background: #0d1422;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 10px 12px;
+  color: var(--ink);
+  resize: vertical;
+}
+
+.preview textarea:disabled {
+  background: #10182a;
+  color: var(--ink-dim);
+}
+
+.status {
+  font-size: 12px;
+  color: var(--ink-dim);
+}
+
+.status.ok  { color: var(--ok); }
+.status.err { color: var(--err); }
+
+/* ----- Log ----- */
+
+.log-panel pre {
+  flex: 1;
+  background: #0a1020;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 10px 12px;
+  color: var(--ink-dim);
+  font-size: 12px;
+  margin: 0;
+  max-height: 220px;
+  overflow: auto;
+  white-space: pre-wrap;
+}
+
+/* ----- Dialog ----- */
+
+dialog {
+  background: var(--bg-elev);
+  color: var(--ink);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  padding: 18px;
+  min-width: 320px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+}
+
+dialog::backdrop {
+  background: rgba(8, 12, 22, 0.7);
+  backdrop-filter: blur(2px);
+}
+
+dialog h3 {
+  margin: 0 0 6px;
+  font-size: 16px;
+}
+
+.prompt-help {
+  color: var(--ink-dim);
+  font-size: 12px;
+  margin: 0 0 10px;
+}
+
+dialog input,
+dialog textarea {
+  width: 100%;
+  margin: 6px 0;
+  background: #0d1422;
+  color: var(--ink);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 8px 10px;
+}
+
+.prompt-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+@media (max-width: 1024px) {
+  .studio-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .panel.preview {
+    grid-column: 1 / -1;
+  }
+}
+
 @media (max-width: 720px) {
-  .results {
+  .hero {
     grid-template-columns: 1fr;
   }
-  .grid {
+  .studio-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/zfs-wasm-real/Makefile
+++ b/zfs-wasm-real/Makefile
@@ -196,7 +196,7 @@ ZFSWASM_LDFLAGS_COMMON := \
     -sALLOW_MEMORY_GROWTH=1 \
     -sINITIAL_MEMORY=67108864 \
     -sMODULARIZE=1 \
-    -sEXPORT_ES6=0 \
+    -sEXPORT_ES6=1 \
     -sEXPORT_NAME=ZfsWasm \
     -sENVIRONMENT=node,web,worker \
     -sFORCE_FILESYSTEM=1 \
@@ -231,6 +231,11 @@ $(BUILD)/zfswasm.o: src/zfswasm.c
 
 $(BUILD)/zfswasm.js: $(BUILD)/zfswasm.o $(BUILD)/libzfs.a $(BUILD)/libzpool.a $(BUILD)/libzcommon.a $(BUILD)/libnvpair.a $(BUILD)/libspl.a $(BUILD)/libshim.a
 	$(CC) $(CFLAGS) $(ZFSWASM_LDFLAGS) $^ -o $@
+	@# emscripten emits .js even with EXPORT_ES6=1; drop a package.json
+	@# next to it so Node treats files in build/ as ESM (without it,
+	@# Node 18 chokes on `import.meta.url` in the loader). The browser
+	@# loads the file by URL and does not care about package.json.
+	@printf '{"type":"module"}\n' > $(BUILD)/package.json
 
 $(BUILD)/libnvpair.a: $(NVPAIR_OBJS)
 	$(AR) rcs $@ $^

--- a/zfs-wasm-real/scripts/smoke-node.mjs
+++ b/zfs-wasm-real/scripts/smoke-node.mjs
@@ -12,16 +12,17 @@
 // pthread condvars — a direct blocking call into ZFS code unwinds.
 
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const BACKING = '/tmp/zfswasm-smoke.img';
 const SIZE = 128 * 1024 * 1024;
 
-const { createRequire } = await import('node:module');
-const require = createRequire(import.meta.url);
-
 const log = (line) => console.log(line);
 
-const ZfsWasm = require(path.join(process.cwd(), 'build', 'zfswasm.js'));
+// The wasm module is built with -sEXPORT_ES6=1 so the browser demo
+// can `import` it. Use the matching dynamic-ESM form here.
+const modUrl = pathToFileURL(path.join(process.cwd(), 'build', 'zfswasm.js'));
+const { default: ZfsWasm } = await import(modUrl.href);
 const mod = await ZfsWasm({
     print: (s) => console.log('[mod] ' + s),
     printErr: (s) => console.log('[mod-err] ' + s),

--- a/zfs-wasm-real/src/shim/zfs_gitrev.h
+++ b/zfs-wasm-real/src/shim/zfs_gitrev.h
@@ -1,0 +1,13 @@
+/*
+ * Stand-in for the autoconf-generated zfs_gitrev.h.
+ *
+ * OpenZFS's configure writes this to upstream/zfs/include/zfs_gitrev.h
+ * with the short git revision of the source tree. We never run ./configure
+ * in CI (we drive the build from a hand-rolled Makefile), so spa_history.c's
+ * `#include "zfs_gitrev.h"` would fail. A fixed label is fine — the demo
+ * logs it once in spa_history and we don't care about the exact hash.
+ */
+#ifndef _ZFS_GITREV_H
+#define _ZFS_GITREV_H
+#define ZFS_META_GITREV "zfs-2.2.6-wasm"
+#endif


### PR DESCRIPTION
Replaces the three-button toy with a layout that mirrors the Rust zfs-wasm/ demo: hero card with live counts, dataset/snapshot tree on the left, file tree in the middle, content editor on the right, journal underneath.

Every wasm-exposed op is reachable:

| Op | UI |
|---|---|
| pool_create + init | Boot pool + load demo |
| ds_create / ds_destroy | New dataset… / Destroy |
| snap / snap_destroy | Snapshot… / Destroy |
| clone | Clone snap… (under the selected snapshot) |
| file_write | New file… / editor → Save |
| file_read | Click any file in the tree |

Boot also seeds a demo scenario (`tankw/site` with two files, snapshot `@v1`, clone `tankw/branch` with branch edits) so the tree shows something interesting on first paint. Snapshots render as read-only — pick one to see content as of that moment.

Mirror state lives in JS because the C bundle does not expose list APIs yet; adding `zfswasm_ds_list` / `zfswasm_file_list` is a clean follow-up.