### PR TITLE
real-zfs: always-visible ⋯ menu instead of hover-reveal

### DIFF
--- a/real-zfs/app.js
+++ b/real-zfs/app.js
@@ -287,23 +287,24 @@ function poolRow() {
       <span class="tag pool">POOL</span>
     </div>
     <div></div>
-    <div class="actions">
-      <button class="icon-btn primary" title="New dataset">+ Dataset</button>
-    </div>
+    <div class="actions"></div>
   `;
-  row.querySelector("button").onclick = (e) => {
-    e.stopPropagation();
-    inlineEdit(row, {
-      placeholder: "data",
-      hint: `${state.pool}/`,
-      onCommit: withBusy(async (name) => {
-        const full = `${state.pool}/${name}`;
-        await mkDataset(full);
-        setActive({ kind: "ds", ds: full });
-        setStatus(`created ${full}`, "ok");
+  attachRowMenu(row, [
+    {
+      label: "+ New dataset",
+      kind: "primary",
+      run: () => inlineEdit(row, {
+        placeholder: "data",
+        hint: `${state.pool}/`,
+        onCommit: withBusy(async (name) => {
+          const full = `${state.pool}/${name}`;
+          await mkDataset(full);
+          setActive({ kind: "ds", ds: full });
+          setStatus(`created ${full}`, "ok");
+        }),
       }),
-    });
-  };
+    },
+  ]);
   return row;
 }
 
@@ -325,11 +326,7 @@ function renderDsRow(parentEl, ds, childrenOfSnap) {
       <span class="tag ${tagText}">${tagText.toUpperCase()}</span>
     </div>
     <div>${pinHTML}</div>
-    <div class="actions">
-      <button class="icon-btn" title="Snapshot only">📷 Snap</button>
-      <button class="icon-btn primary" title="Snapshot then clone (git-style)">🌿 Branch</button>
-      <button class="icon-btn danger" title="Destroy dataset">✕</button>
-    </div>
+    <div class="actions"></div>
   `;
 
   row.addEventListener("click", () => {
@@ -337,42 +334,43 @@ function renderDsRow(parentEl, ds, childrenOfSnap) {
     refresh();
   });
 
-  const [snapBtn, branchBtn, destroyBtn] = row.querySelectorAll(".actions button");
-
-  snapBtn.onclick = (e) => {
-    e.stopPropagation();
-    inlineEdit(row, {
-      placeholder: nextSnapName(meta),
-      hint: `${ds}@`,
-      onCommit: withBusy(async (name) => {
-        await mkSnap(ds, name);
-        setStatus(`snapshot ${snapFull(ds, name)}`, "ok");
+  attachRowMenu(row, [
+    {
+      label: "🌿 Branch (snap + clone)",
+      kind: "primary",
+      run: () => inlineEdit(row, {
+        placeholder: nextBranchName(),
+        hint: `${state.pool}/`,
+        onCommit: withBusy(async (name) => {
+          const full = `${state.pool}/${name}`;
+          await branchFrom(ds, name);
+          setActive({ kind: "ds", ds: full });
+          setStatus(`branched ${ds} → ${full}`, "ok");
+        }),
       }),
-    });
-  };
-
-  branchBtn.onclick = (e) => {
-    e.stopPropagation();
-    inlineEdit(row, {
-      placeholder: nextBranchName(),
-      hint: `${state.pool}/`,
-      onCommit: withBusy(async (name) => {
-        const full = `${state.pool}/${name}`;
-        await branchFrom(ds, name);
-        setActive({ kind: "ds", ds: full });
-        setStatus(`branched ${ds} → ${full}`, "ok");
+    },
+    {
+      label: "📷 Snapshot only",
+      run: () => inlineEdit(row, {
+        placeholder: nextSnapName(meta),
+        hint: `${ds}@`,
+        onCommit: withBusy(async (name) => {
+          await mkSnap(ds, name);
+          setStatus(`snapshot ${snapFull(ds, name)}`, "ok");
+        }),
       }),
-    });
-  };
-
-  destroyBtn.onclick = (e) => {
-    e.stopPropagation();
-    confirmInline(row, "Destroy?", withBusy(async () => {
-      await destroyTarget(ds);
-      if (state.active?.ds === ds) setActive(null);
-      setStatus(`destroyed ${ds}`, "ok");
-    }));
-  };
+    },
+    { divider: true },
+    {
+      label: "✕ Destroy dataset",
+      kind: "danger",
+      run: () => confirmInline(row, "Destroy?", withBusy(async () => {
+        await destroyTarget(ds);
+        if (state.active?.ds === ds) setActive(null);
+        setStatus(`destroyed ${ds}`, "ok");
+      })),
+    },
+  ]);
 
   parentEl.appendChild(row);
 
@@ -408,10 +406,7 @@ function renderSnapRow(parentEl, ds, snap, full) {
       <span class="tag ro">RO</span>
     </div>
     <div></div>
-    <div class="actions">
-      <button class="icon-btn primary" title="Clone snapshot into a new dataset">🌿 Branch</button>
-      <button class="icon-btn danger" title="Destroy snapshot">✕</button>
-    </div>
+    <div class="actions"></div>
   `;
 
   row.addEventListener("click", () => {
@@ -419,34 +414,101 @@ function renderSnapRow(parentEl, ds, snap, full) {
     refresh();
   });
 
-  const [branchBtn, destroyBtn] = row.querySelectorAll(".actions button");
-  branchBtn.onclick = (e) => {
-    e.stopPropagation();
-    inlineEdit(row, {
-      placeholder: nextBranchName(),
-      hint: `${state.pool}/`,
-      onCommit: withBusy(async (name) => {
-        const dst = `${state.pool}/${name}`;
-        await mkClone(full, dst);
-        setActive({ kind: "ds", ds: dst });
-        setStatus(`cloned ${full} → ${dst}`, "ok");
+  attachRowMenu(row, [
+    {
+      label: "🌿 Branch from snapshot",
+      kind: "primary",
+      run: () => inlineEdit(row, {
+        placeholder: nextBranchName(),
+        hint: `${state.pool}/`,
+        onCommit: withBusy(async (name) => {
+          const dst = `${state.pool}/${name}`;
+          await mkClone(full, dst);
+          setActive({ kind: "ds", ds: dst });
+          setStatus(`cloned ${full} → ${dst}`, "ok");
+        }),
       }),
-    });
-  };
-  destroyBtn.onclick = (e) => {
-    e.stopPropagation();
-    confirmInline(row, "Destroy?", withBusy(async () => {
-      await destroyTarget(full);
-      if (state.active?.kind === "snap"
-          && state.active.ds === ds && state.active.snap === snap) {
-        setActive(null);
-      }
-      setStatus(`destroyed ${full}`, "ok");
-    }));
-  };
+    },
+    { divider: true },
+    {
+      label: "✕ Destroy snapshot",
+      kind: "danger",
+      run: () => confirmInline(row, "Destroy?", withBusy(async () => {
+        await destroyTarget(full);
+        if (state.active?.kind === "snap"
+            && state.active.ds === ds && state.active.snap === snap) {
+          setActive(null);
+        }
+        setStatus(`destroyed ${full}`, "ok");
+      })),
+    },
+  ]);
 
   parentEl.appendChild(row);
 }
+
+// ---------- Per-row dropdown menu ----------
+//
+// Each tree row carries a single ⋯ button on the right. Clicking it
+// opens a dropdown anchored beneath the button with the row's actions.
+// One menu is open at a time; clicking outside or selecting an item
+// closes it. Keyboard: Escape closes.
+
+let openMenu = null;
+
+function attachRowMenu(row, items) {
+  const actionsEl = row.querySelector(".actions");
+  const trigger = document.createElement("button");
+  trigger.type = "button";
+  trigger.className = "menu-trigger";
+  trigger.title = "Actions";
+  trigger.setAttribute("aria-label", "Actions");
+  trigger.textContent = "⋯";
+  actionsEl.appendChild(trigger);
+
+  trigger.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (openMenu?.row === row) { closeMenu(); return; }
+    closeMenu();
+    showMenu(row, trigger, items);
+  });
+}
+
+function showMenu(row, trigger, items) {
+  const menu = document.createElement("div");
+  menu.className = "row-menu";
+  for (const item of items) {
+    if (item.divider) {
+      menu.appendChild(document.createElement("hr"));
+      continue;
+    }
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.textContent = item.label;
+    if (item.kind) btn.classList.add(item.kind);
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      closeMenu();
+      item.run();
+    });
+    menu.appendChild(btn);
+  }
+  trigger.classList.add("open");
+  row.querySelector(".actions").appendChild(menu);
+  openMenu = { row, menu, trigger };
+}
+
+function closeMenu() {
+  if (!openMenu) return;
+  openMenu.menu.remove();
+  openMenu.trigger.classList.remove("open");
+  openMenu = null;
+}
+
+document.addEventListener("click", () => closeMenu());
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape") closeMenu();
+});
 
 function nextSnapName(meta) {
   return `v${meta.snaps.length + 1}`;

--- a/real-zfs/index.html
+++ b/real-zfs/index.html
@@ -66,8 +66,8 @@
             <p class="eyebrow">Versioning</p>
             <h2>Datasets &amp; snapshots</h2>
             <p class="panel-subtitle">
-              Hover any row to act on it. <strong>Branch</strong>
-              snapshots and clones in one step.
+              Click the <code>⋯</code> on any row to act on it.
+              <strong>Branch</strong> snapshots and clones in one step.
             </p>
           </div>
           <div id="dataset-tree" class="tree" role="tree"

--- a/real-zfs/styles.css
+++ b/real-zfs/styles.css
@@ -271,14 +271,73 @@ button.primary {
 .row .actions {
   display: flex;
   gap: 2px;
-  opacity: 0;
-  transition: opacity 90ms ease;
+  position: relative;
 }
 
-.row:hover .actions,
-.row:focus-within .actions,
-.row.editing .actions {
-  opacity: 1;
+.menu-trigger {
+  background: transparent;
+  color: var(--ink-dim);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 1px 6px 3px;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.menu-trigger:hover,
+.menu-trigger.open {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--ink);
+  border-color: var(--line-strong);
+}
+
+.row-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 20;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.45);
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  min-width: 170px;
+}
+
+.row-menu button {
+  background: transparent;
+  border: 0;
+  color: var(--ink);
+  text-align: left;
+  padding: 7px 10px;
+  border-radius: 4px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.row-menu button:hover {
+  background: rgba(96, 165, 250, 0.16);
+}
+
+.row-menu button.danger {
+  color: var(--err);
+}
+
+.row-menu button.danger:hover {
+  background: rgba(248, 113, 113, 0.18);
+}
+
+.row-menu hr {
+  border: 0;
+  border-top: 1px solid var(--line);
+  margin: 4px 2px;
 }
 
 .icon-btn {


### PR DESCRIPTION
Hover-reveal was invisible to anyone who didn't hover (touch, screen readers, anyone). Each row now shows a persistent `⋯` button on the right; click it for a small dropdown of that row's actions. One menu open at a time; outside-click or Escape closes.

| Row | Menu |
|---|---|
| pool | + New dataset |
| dataset | 🌿 Branch (snap+clone) · 📷 Snapshot only · ✕ Destroy |
| snapshot | 🌿 Branch from snapshot · ✕ Destroy |

Inline naming + inline confirm flows kept as-is.