### PR TITLE
sqlite-markdown: skip rewriting unchanged post files

### DIFF
--- a/sqlite-markdown/src/sqlite_markdown.c
+++ b/sqlite-markdown/src/sqlite_markdown.c
@@ -1586,7 +1586,20 @@ static int write_post_record(const char *root, Dataset *dataset, PostRecord *pos
         rc = ensure_parent_directories(root, path);
     }
     if (rc == SQLITE_OK) {
-        rc = write_text_file_atomic(path, buffer.data, buffer.length);
+        /* Skip the write entirely when the on-disk bytes already match what we
+         * would produce. This avoids touching files (and their mtimes) when an
+         * UPDATE leaves the rendered markdown identical — e.g. a no-op write
+         * or a tool re-issuing the same row values. */
+        char *existing = NULL;
+        size_t existing_length = 0;
+        int read_rc = read_text_file(path, &existing, &existing_length);
+        bool unchanged = read_rc == SQLITE_OK
+            && existing_length == buffer.length
+            && (buffer.length == 0 || memcmp(existing, buffer.data, buffer.length) == 0);
+        free(existing);
+        if (!unchanged) {
+            rc = write_text_file_atomic(path, buffer.data, buffer.length);
+        }
     }
     if (rc == SQLITE_OK && old_path != NULL && strcmp(old_path, path) != 0) {
         unlink(old_path);

--- a/sqlite-markdown/tests/test_extension.py
+++ b/sqlite-markdown/tests/test_extension.py
@@ -826,6 +826,33 @@ About body.
         )
 
 
+    def test_noop_update_does_not_rewrite_markdown_file(self) -> None:
+        self.insert_post(title="Stable", name="stable", content="stable body\n", post_id=1)
+        post_path = self.root / "1-stable.md"
+        original_bytes = post_path.read_bytes()
+        original_mtime_ns = post_path.stat().st_mtime_ns
+
+        # Re-issue an UPDATE that sets every column to its current value. The
+        # rendered markdown is identical, so the file must not be touched.
+        self.connection.execute(
+            """
+            UPDATE wp_posts
+            SET
+                post_title = post_title,
+                post_name = post_name,
+                post_status = post_status,
+                post_type = post_type,
+                post_date_gmt = post_date_gmt,
+                post_modified_gmt = post_modified_gmt,
+                post_content = post_content
+            WHERE ID = 1
+            """
+        )
+
+        self.assertEqual(post_path.read_bytes(), original_bytes)
+        self.assertEqual(post_path.stat().st_mtime_ns, original_mtime_ns)
+
+
 def expected_post_name(title: str, name: str | None) -> str:
     if name is not None and name != "":
         return name


### PR DESCRIPTION
After #35 landed, any UPDATE on `wp_posts` rewrites the post's markdown file unconditionally. That means tools that re-issue current values across rows end up regenerating every post on disk, churning mtimes and git diffs even when nothing actually changed.

This pulls a small read-and-compare in front of the atomic write: if the rendered bytes match what's already on disk, the write is skipped. Path renames (slug/parent moves) still work — only the no-op write disappears.

A targeted test re-applies an UPDATE that sets every column to its current value and asserts both the bytes and the mtime are unchanged. Full suite (1090 tests) still passes.

Note: this only short-circuits writes that would be byte-identical. The first UPDATE on a hand-authored, non-canonical markdown file (e.g. one using `title:` / `slug:` / unknown frontmatter keys) will still normalize it. Preserving arbitrary author-supplied frontmatter is a separate, larger change.